### PR TITLE
[ft]: add custom Trix rich text editor for article content

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^19.2.0",
         "react-oidc-context": "^3.3.1",
         "react-router-dom": "^7.13.1",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "trix": "^2.1.19"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -86,6 +87,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2657,6 +2659,7 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2667,6 +2670,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2677,9 +2681,17 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.0",
@@ -2726,6 +2738,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -3003,6 +3016,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3217,6 +3231,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3474,6 +3489,15 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.352",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
@@ -3560,6 +3584,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4105,6 +4130,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4396,6 +4422,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
       "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+      "peer": true,
       "dependencies": {
         "jwt-decode": "^4.0.0"
       },
@@ -4505,6 +4532,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4549,6 +4577,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4731,6 +4760,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4740,6 +4770,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5226,6 +5257,18 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trix": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/trix/-/trix-2.1.19.tgz",
+      "integrity": "sha512-E7RA3EOeUiUwNJlrF5onIOkqCA06xUU6GmHOVxXyMnGMValrDK3Ce7uaMVgiVUOvVt4mzUERAHAzD10mxoLpOg==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.2.5"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -5270,6 +5313,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5412,6 +5456,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5533,6 +5578,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
     "react-dom": "^19.2.0",
     "react-oidc-context": "^3.3.1",
     "react-router-dom": "^7.13.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "trix": "^2.1.19"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/components/TrixEditor.css
+++ b/frontend/src/components/TrixEditor.css
@@ -1,0 +1,331 @@
+/* Variables use shadcn/ui HSL format: hsl(var(--name)).
+   Fallback values match the refactoring/frontend design system so this
+   renders correctly even before shadcn variables are in scope. */
+
+.trix-editor-wrapper {
+  position: relative;
+  border: 1px solid hsl(var(--border, 220 13% 91%));
+  border-radius: var(--radius, 0.5rem);
+  background: hsl(var(--card, 0 0% 100%));
+  /* No overflow:hidden; it would clip the resize handle overlay when an image
+     is selected near the editor edge. */
+}
+
+/* ── Toolbar ── */
+
+trix-toolbar .trix-button-row {
+  display: flex;
+  gap: 2px;
+  padding: 6px 8px;
+  background: hsl(var(--card, 0 0% 100%));
+  border-bottom: 1px solid hsl(var(--border, 220 13% 91%));
+}
+
+trix-toolbar .trix-button-group {
+  border: none;
+  margin: 0;
+  display: inline-flex;
+  gap: 2px;
+}
+
+trix-toolbar .trix-button-group:not(:first-child) {
+  border-left: none;
+}
+
+trix-toolbar .trix-button {
+  border: none;
+  background: transparent;
+  padding: 5px;
+  border-radius: calc(var(--radius, 0.5rem) - 2px);
+  cursor: pointer;
+  color: hsl(var(--foreground, 224 71% 4%));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  min-height: 28px;
+}
+
+trix-toolbar .trix-button:not(:first-child) {
+  border-left: none;
+}
+
+trix-toolbar .trix-button:hover {
+  background: hsl(var(--muted, 220 14% 96%));
+}
+
+trix-toolbar .trix-button.trix-active {
+  background: hsl(var(--muted, 220 14% 96%));
+  font-weight: 600;
+}
+
+trix-toolbar .trix-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.trix-icon {
+  width: 20px;
+  height: 20px;
+  display: block;
+  flex-shrink: 0;
+}
+
+/* ── Link dialog ── */
+
+trix-toolbar .trix-dialog {
+  background: hsl(var(--card, 0 0% 100%));
+  border-top: 1px solid hsl(var(--border, 220 13% 91%));
+  padding: 8px 10px;
+  box-shadow: none;
+}
+
+trix-toolbar .trix-dialog__link-fields {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+trix-toolbar .trix-input--dialog {
+  background: hsl(var(--background, 0 0% 98%));
+  border: 1px solid hsl(var(--border, 220 13% 91%));
+  border-radius: calc(var(--radius, 0.5rem) - 2px);
+  color: hsl(var(--foreground, 224 71% 4%));
+  font-size: 13px;
+  min-height: 32px;
+  padding: 4px 10px;
+  flex: 1;
+}
+
+trix-toolbar .trix-button--dialog {
+  background: hsl(var(--background, 0 0% 98%));
+  border: 1px solid hsl(var(--border, 220 13% 91%));
+  border-radius: calc(var(--radius, 0.5rem) - 2px);
+  color: hsl(var(--foreground, 224 71% 4%));
+  cursor: pointer;
+  font-size: 13px;
+  min-height: 32px;
+  padding: 4px 12px;
+}
+
+trix-toolbar .trix-button--dialog:hover {
+  background: hsl(var(--muted, 220 14% 96%));
+}
+
+/* ── Editor area ── */
+
+trix-editor.trix-content {
+  border: none !important;
+  outline: none !important;
+  box-shadow: none !important;
+  padding: 1rem !important;
+  min-height: 280px;
+  line-height: 1.6;
+  color: hsl(var(--foreground, 224 71% 4%));
+  background: hsl(var(--card, 0 0% 100%));
+  font-family: inherit;
+  font-size: 14px;
+  display: block;
+}
+
+/* ── Restore styles stripped by global CSS resets (Tailwind base / kumo) ── */
+
+trix-editor.trix-content ul {
+  list-style: disc;
+  padding-left: 1.5em;
+}
+
+trix-editor.trix-content ol {
+  list-style: decimal;
+  padding-left: 1.5em;
+}
+
+trix-editor.trix-content a {
+  color: hsl(var(--primary, 243 75% 59%));
+  text-decoration: underline;
+  position: relative;
+  cursor: pointer;
+}
+
+/* ── Attachments (images, files, captions) ── */
+
+/* .attachment--preview is the wrapper Trix puts around each image. We need it
+   block-level + text-align: center so the inline <img> inside sits over the
+   centered <figcaption>. Don't make the inner <img> display:block, otherwise
+   the parent's text-align won't apply and it falls to the left edge. */
+trix-editor.trix-content .attachment {
+  position: relative;
+  max-width: 100%;
+}
+
+trix-editor.trix-content .attachment--preview {
+  display: block;
+  text-align: center;
+  margin: 1em auto;
+}
+
+trix-editor.trix-content .attachment img {
+  display: inline-block;
+  max-width: 100%;
+  height: auto;
+  border-radius: calc(var(--radius, 0.5rem) - 2px);
+  cursor: move;
+}
+
+/* Caption. Trix renders <figcaption class="attachment__caption">; when the
+   attachment is selected it becomes an editable <input class="attachment__caption-editor">. */
+trix-editor.trix-content .attachment__caption {
+  display: block;
+  margin-top: 0.5em;
+  text-align: center;
+  font-size: 12px;
+  color: hsl(var(--muted-foreground, 215 16% 47%));
+  font-style: italic;
+  line-height: 1.4;
+}
+
+trix-editor.trix-content .attachment__caption .attachment__name,
+trix-editor.trix-content .attachment__caption .attachment__size {
+  display: inline;
+}
+
+trix-editor.trix-content .attachment__caption-editor {
+  display: block;
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  text-align: center;
+  font: inherit;
+  color: inherit;
+  resize: none;
+  padding: 0;
+}
+
+trix-editor.trix-content .attachment__caption-editor::placeholder {
+  color: hsl(var(--muted-foreground, 215 16% 47%));
+  opacity: 0.7;
+}
+
+/* No outline on the figure: it's a full-width centered block and an outline
+   encloses the whole row. Instead, ring the IMG itself when its enclosing
+   figure is selected. */
+trix-editor.trix-content .attachment.attachment--preview.attachment--selected img {
+  outline: 2px solid hsl(var(--primary, 243 75% 59%));
+  outline-offset: 2px;
+}
+
+/* Drag-in-progress state on the source figure. */
+trix-editor.trix-content .attachment.attachment--preview.attachment--dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+/* Per-image alignment, set during a drop. Overrides the default centering
+   from .attachment--preview above. Both the inline style and the class are
+   applied at commit time for redundancy through Trix's HTML serialization. */
+trix-editor.trix-content .attachment--preview.attachment--align-left {
+  text-align: left;
+}
+trix-editor.trix-content .attachment--preview.attachment--align-center {
+  text-align: center;
+}
+trix-editor.trix-content .attachment--preview.attachment--align-right {
+  text-align: right;
+}
+
+/* Resize overlay rendered by JS into .trix-editor-wrapper, positioned over
+   the currently selected image. The overlay itself is click-through so Trix's
+   own drag-to-reorder still works; only the corner squares grab pointer events. */
+.trix-resize-overlay {
+  position: absolute;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.trix-resize-handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: hsl(var(--primary, 243 75% 59%));
+  border: 2px solid hsl(var(--background, 0 0% 100%));
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  pointer-events: auto;
+}
+
+.trix-resize-handle--nw { top: -6px; left: -6px; cursor: nwse-resize; }
+.trix-resize-handle--ne { top: -6px; right: -6px; cursor: nesw-resize; }
+.trix-resize-handle--sw { bottom: -6px; left: -6px; cursor: nesw-resize; }
+.trix-resize-handle--se { bottom: -6px; right: -6px; cursor: nwse-resize; }
+
+/* Drop indicator shown only during an active drag-to-rearrange. The width and
+   horizontal position shift to hint at the alignment that will be applied on
+   drop: short bar on the left = left-align, centered short bar = center,
+   short bar on the right = right-align. */
+.trix-drop-indicator {
+  position: absolute;
+  height: 3px;
+  background: hsl(var(--primary, 243 75% 59%));
+  border-radius: 999px;
+  z-index: 6;
+  pointer-events: none;
+  transition: left 80ms ease-out, width 80ms ease-out;
+  box-shadow: 0 0 0 1px hsl(var(--background, 0 0% 100%)),
+              0 2px 6px hsl(var(--primary, 243 75% 59%) / 0.4);
+}
+
+.trix-drop-indicator::before,
+.trix-drop-indicator::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: hsl(var(--primary, 243 75% 59%));
+  transform: translateY(-50%);
+}
+.trix-drop-indicator::before { left: -4px; }
+.trix-drop-indicator::after  { right: -4px; }
+
+trix-editor.trix-content .attachment__progress {
+  position: absolute;
+  top: 50%;
+  left: 5%;
+  right: 5%;
+  height: 4px;
+  border-radius: 2px;
+  background: hsl(var(--muted, 220 14% 96%));
+  overflow: hidden;
+}
+
+trix-editor.trix-content .attachment__progress[value]::-webkit-progress-bar {
+  background: hsl(var(--muted, 220 14% 96%));
+}
+
+trix-editor.trix-content .attachment__progress[value]::-webkit-progress-value {
+  background: hsl(var(--primary, 243 75% 59%));
+}
+
+/* Hover tooltip showing the link target above the text. */
+trix-editor.trix-content a:hover::after {
+  content: attr(href);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  background: hsl(var(--foreground, 224 71% 4%));
+  color: hsl(var(--background, 0 0% 100%));
+  padding: 4px 8px;
+  border-radius: calc(var(--radius, 0.5rem) - 2px);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: nowrap;
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+  z-index: 10;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}

--- a/frontend/src/components/TrixEditor.tsx
+++ b/frontend/src/components/TrixEditor.tsx
@@ -1,0 +1,585 @@
+import { useEffect, useId, useRef } from "react"
+import "trix"
+import "trix/dist/trix.css"
+import "./TrixEditor.css"
+
+// Show the filename in the auto-generated caption under attachments, but hide
+// the file size this matches the upstream Trix demo's defaults and gives users an
+// editable caption field below each image.
+if (typeof window !== "undefined" && window.Trix) {
+  window.Trix.config.attachments.preview.caption.name = true
+  window.Trix.config.attachments.preview.caption.size = false
+}
+
+type TrixEditorProps = {
+  value: string
+  onChange: (html: string) => void
+}
+
+function TrixEditor({ value, onChange }: TrixEditorProps) {
+  const toolbarId = useId()
+  const editorRef = useRef<TrixEditorElement>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  // Tracks the last HTML we emitted so we don't call loadHTML on our own onChange updates,
+  // which would reset the cursor mid-edit.
+  const lastEmittedRef = useRef<string>("")
+
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    if (value !== lastEmittedRef.current) {
+      editor.editor.loadHTML(value)
+      lastEmittedRef.current = value
+    }
+  }, [value])
+
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor) return
+
+    const handleChange = () => {
+      const html = editor.value
+      lastEmittedRef.current = html
+      onChange(html)
+    }
+
+    editor.addEventListener("trix-change", handleChange)
+    return () => { editor.removeEventListener("trix-change", handleChange) }
+  }, [onChange])
+
+  // Uses XHR instead of fetch since fetch doesn't expose upload progress events,
+  // which Trix needs to render its built-in progress bar.
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor) return
+
+    const handleAttachmentAdd = (event: Event) => {
+      const { attachment } = event as TrixAttachmentAddEvent
+      // trix-attachment-add also fires for programmatic URL embeds (no .file)
+      if (!attachment.file) return
+
+      const xhr = new XMLHttpRequest()
+      xhr.open("POST", "/v1/media", true)
+
+      xhr.upload.onprogress = (progressEvent: ProgressEvent) => {
+        if (progressEvent.lengthComputable) {
+          attachment.setUploadProgress((progressEvent.loaded / progressEvent.total) * 100)
+        }
+      }
+
+      // On failure we deliberately keep the attachment in the editor: Trix
+      // shows a local blob-URL preview as soon as the file is added, so the
+      // user gets an image they can move, caption, and rearrange even when
+      // /v1/media is missing. The blob URL won't survive a page reload (the
+      // saved HTML needs the real server URL) but the in-editor UX works.
+      xhr.onload = () => {
+        if (xhr.status === 201) {
+          try {
+            const { url } = JSON.parse(xhr.responseText) as { url: string }
+            attachment.setAttributes({ url, href: url })
+            attachment.setUploadProgress(100)
+          } catch {
+            if (import.meta.env.DEV) {
+              console.warn("TrixEditor: POST /v1/media returned 201 but body was not { url: string } JSON. Keeping local preview.")
+            }
+            attachment.setUploadProgress(100)
+          }
+        } else {
+          if (import.meta.env.DEV) {
+            console.warn(`TrixEditor: POST /v1/media returned ${xhr.status.toString()}. Keeping local preview; image will not persist after reload until backend is wired up.`)
+          }
+          attachment.setUploadProgress(100)
+        }
+      }
+
+      xhr.onerror = () => {
+        if (import.meta.env.DEV) {
+          console.warn("TrixEditor: POST /v1/media network error. Keeping local preview; image will not persist after reload until backend is wired up.")
+        }
+        attachment.setUploadProgress(100)
+      }
+
+      const formData = new FormData()
+      formData.append("file", attachment.file)
+      xhr.send(formData)
+    }
+
+    editor.addEventListener("trix-attachment-add", handleAttachmentAdd)
+    return () => { editor.removeEventListener("trix-attachment-add", handleAttachmentAdd) }
+  }, [])
+
+  // Image manipulation overlay: selection, four-corner resize, and
+   // drag-to-rearrange (vertical drop + left/center/right alignment snap).
+   // All overlay DOM lives in the wrapper *outside* Trix's contenteditable so
+   // Trix doesn't overwrite our handles via its MutationObserver.
+  useEffect(() => {
+    const editor = editorRef.current
+    const wrapper = wrapperRef.current
+    if (!editor || !wrapper) return
+
+    const overlay = document.createElement("div")
+    overlay.className = "trix-resize-overlay"
+    overlay.style.display = "none"
+
+    const corners = ["nw", "ne", "sw", "se"] as const
+    type Corner = (typeof corners)[number]
+    const handles: Record<Corner, HTMLDivElement> = {} as Record<Corner, HTMLDivElement>
+    for (const corner of corners) {
+      const handle = document.createElement("div")
+      handle.className = `trix-resize-handle trix-resize-handle--${corner}`
+      handle.dataset.corner = corner
+      overlay.appendChild(handle)
+      handles[corner] = handle
+    }
+    wrapper.appendChild(overlay)
+
+    // Drop indicator (a thin horizontal bar shown only during an active drag).
+    const dropIndicator = document.createElement("div")
+    dropIndicator.className = "trix-drop-indicator"
+    dropIndicator.style.display = "none"
+    wrapper.appendChild(dropIndicator)
+
+    let activeFigure: HTMLElement | null = null
+    // Per-gesture cleanup set when a drag or resize is in progress so the
+    // outer effect's teardown can abort it on unmount (prevents leaked
+    // document listeners and a stuck `grabbing` cursor).
+    let activeGestureCleanup: (() => void) | null = null
+
+    const positionOverlay = () => {
+      if (!activeFigure) {
+        overlay.style.display = "none"
+        return
+      }
+      const img = activeFigure.querySelector("img")
+      const target = img ?? activeFigure
+      const wrapperRect = wrapper.getBoundingClientRect()
+      const rect = target.getBoundingClientRect()
+      overlay.style.display = "block"
+      overlay.style.top = `${(rect.top - wrapperRect.top).toString()}px`
+      overlay.style.left = `${(rect.left - wrapperRect.left).toString()}px`
+      overlay.style.width = `${rect.width.toString()}px`
+      overlay.style.height = `${rect.height.toString()}px`
+    }
+
+    const selectFigure = (figure: HTMLElement | null) => {
+      if (activeFigure && activeFigure !== figure) {
+        activeFigure.classList.remove("attachment--selected")
+      }
+      activeFigure = figure
+      if (figure) figure.classList.add("attachment--selected")
+      positionOverlay()
+    }
+
+    // ── Resize (4 corners, aspect-ratio locked) ────────────────────────────
+    const beginResize = (corner: Corner) => (downEvent: MouseEvent) => {
+      if (!activeFigure) return
+      const img = activeFigure.querySelector("img")
+      if (!img) return
+      downEvent.preventDefault()
+      downEvent.stopPropagation()
+
+      const startRect = img.getBoundingClientRect()
+      const startWidth = startRect.width
+      const startHeight = startRect.height
+      const aspect = startHeight / startWidth
+      const startX = downEvent.clientX
+      const xDirection = corner === "ne" || corner === "se" ? 1 : -1
+
+      const onMove = (moveEvent: MouseEvent) => {
+        const dx = (moveEvent.clientX - startX) * xDirection
+        const newWidth = Math.max(80, Math.round(startWidth + dx))
+        const newHeight = Math.max(40, Math.round(newWidth * aspect))
+        img.setAttribute("width", String(newWidth))
+        img.setAttribute("height", String(newHeight))
+        img.style.width = `${newWidth.toString()}px`
+        img.style.height = `${newHeight.toString()}px`
+        positionOverlay()
+      }
+      const cleanup = () => {
+        document.removeEventListener("mousemove", onMove)
+        document.removeEventListener("mouseup", onUp)
+      }
+      const onUp = () => {
+        activeGestureCleanup = null
+        cleanup()
+        editor.dispatchEvent(new Event("input", { bubbles: true }))
+      }
+      document.addEventListener("mousemove", onMove)
+      document.addEventListener("mouseup", onUp)
+      activeGestureCleanup = cleanup
+    }
+
+    for (const corner of corners) {
+      handles[corner].addEventListener("mousedown", beginResize(corner))
+    }
+
+    // ── Drag-to-rearrange ──────────────────────────────────────────────────
+    type Alignment = "left" | "center" | "right"
+    type DropTarget = { block: HTMLElement; insertBefore: boolean; alignment: Alignment }
+
+    const DRAG_THRESHOLD_PX = 5
+
+    // Find which top-level block the cursor is over (or nearest by Y). We
+    // intentionally include the dragged figure's own block as a candidate so
+    // the drop indicator still appears when an editor contains only one
+    // block. The actual no-op check (drop ≈ no move) happens at commit time.
+    const findBlockAt = (clientY: number): HTMLElement | null => {
+      const blocks = Array.from(editor.children) as HTMLElement[]
+      let nearest: HTMLElement | null = null
+      let nearestDist = Infinity
+      for (const block of blocks) {
+        const rect = block.getBoundingClientRect()
+        if (clientY >= rect.top && clientY <= rect.bottom) return block
+        const dist = clientY < rect.top ? rect.top - clientY : clientY - rect.bottom
+        if (dist < nearestDist) {
+          nearestDist = dist
+          nearest = block
+        }
+      }
+      return nearest
+    }
+
+    const alignmentFromX = (clientX: number): Alignment => {
+      const rect = editor.getBoundingClientRect()
+      const ratio = (clientX - rect.left) / rect.width
+      if (ratio < 0.3) return "left"
+      if (ratio > 0.7) return "right"
+      return "center"
+    }
+
+    const positionDropIndicator = (target: DropTarget) => {
+      const wrapperRect = wrapper.getBoundingClientRect()
+      const editorRect = editor.getBoundingClientRect()
+      const blockRect = target.block.getBoundingClientRect()
+      const y = target.insertBefore ? blockRect.top : blockRect.bottom
+
+      const editorLeft = editorRect.left - wrapperRect.left
+      const editorWidth = editorRect.width
+      const indicatorWidth = Math.min(editorWidth * 0.4, 240)
+      let left = editorLeft + (editorWidth - indicatorWidth) / 2
+      if (target.alignment === "left") left = editorLeft + 24
+      if (target.alignment === "right") left = editorLeft + editorWidth - indicatorWidth - 24
+
+      dropIndicator.style.display = "block"
+      dropIndicator.style.top = `${(y - wrapperRect.top).toString()}px`
+      dropIndicator.style.left = `${left.toString()}px`
+      dropIndicator.style.width = `${indicatorWidth.toString()}px`
+      dropIndicator.dataset.alignment = target.alignment
+    }
+
+    // Move the attachment via Trix's editor API. Strategy:
+    //   1. Build the clone HTML with alignment baked in. Strip the stale
+    //      data-trix-id (and matching content-type's sgid hint) so Trix mints
+    //      a fresh attachment on insert rather than colliding with the live
+    //      attachment we're about to remove.
+    //   2. Capture a DOM Range anchored on the target block BEFORE removing
+    //      the source. Trix's remove() can collapse or detach adjacent empty
+    //      blocks, which would invalidate setStartBefore/After afterwards.
+    //   3. Focus the editor BEFORE applying the selection. Focusing a
+    //      contenteditable that isn't currently focused resets the caret to
+    //      its last internal position, which would blow away our range.
+    //   4. Then remove the attachment, apply the captured range, and insert.
+    const commitMove = (figure: HTMLElement, target: DropTarget) => {
+      const trixId = figure.getAttribute("data-trix-id")
+      if (!trixId) return
+      const attachment = editor.editor.getDocument().getAttachments().find((a) => String(a.id) === trixId)
+      if (!attachment) return
+      if (!target.block.isConnected) return
+      // No-op if the user dropped right back onto the source's own block.
+      // findBlockAt no longer skips it so the drop indicator works for
+      // single-block editors; this is where we treat the same-block drop as
+      // "nothing to do" and still apply only the alignment change.
+      const droppedOnSelf = target.block.contains(figure)
+      if (droppedOnSelf) {
+        figure.classList.remove("attachment--align-left", "attachment--align-center", "attachment--align-right")
+        figure.classList.add(`attachment--align-${target.alignment}`)
+        figure.style.textAlign = target.alignment
+        editor.dispatchEvent(new Event("input", { bubbles: true }))
+        return
+      }
+
+      const clone = figure.cloneNode(true) as HTMLElement
+      clone.classList.remove("attachment--align-left", "attachment--align-center", "attachment--align-right")
+      clone.classList.add(`attachment--align-${target.alignment}`)
+      clone.style.textAlign = target.alignment
+      clone.removeAttribute("data-trix-id")
+      const html = clone.outerHTML
+
+      const range = document.createRange()
+      if (target.insertBefore) range.setStartBefore(target.block)
+      else range.setStartAfter(target.block)
+      range.collapse(true)
+
+      editor.focus()
+      attachment.remove()
+
+      if (target.block.isConnected) {
+        const selection = window.getSelection()
+        selection?.removeAllRanges()
+        selection?.addRange(range)
+      }
+
+      editor.editor.insertHTML(html)
+      editor.dispatchEvent(new Event("input", { bubbles: true }))
+    }
+
+    const beginDrag = (figure: HTMLElement, downEvent: MouseEvent) => {
+      downEvent.preventDefault()
+      const startX = downEvent.clientX
+      const startY = downEvent.clientY
+      let dragging = false
+      let dropTarget: DropTarget | null = null
+
+      const enterDragMode = () => {
+        dragging = true
+        figure.classList.add("attachment--dragging")
+        document.body.style.cursor = "grabbing"
+        overlay.style.display = "none"
+      }
+
+      const onMove = (moveEvent: MouseEvent) => {
+        if (!dragging) {
+          const dx = Math.abs(moveEvent.clientX - startX)
+          const dy = Math.abs(moveEvent.clientY - startY)
+          if (dx < DRAG_THRESHOLD_PX && dy < DRAG_THRESHOLD_PX) return
+          enterDragMode()
+        }
+
+        const block = findBlockAt(moveEvent.clientY)
+        if (!block) {
+          dropIndicator.style.display = "none"
+          dropTarget = null
+          return
+        }
+        const blockRect = block.getBoundingClientRect()
+        const insertBefore = moveEvent.clientY < blockRect.top + blockRect.height / 2
+        dropTarget = {
+          block,
+          insertBefore,
+          alignment: alignmentFromX(moveEvent.clientX),
+        }
+        positionDropIndicator(dropTarget)
+      }
+
+      // Idempotent state-restorer, invoked from onUp on normal release AND
+      // from the outer effect's cleanup if the component unmounts mid-drag.
+      const cleanup = () => {
+        document.removeEventListener("mousemove", onMove)
+        document.removeEventListener("mouseup", onUp)
+        document.body.style.cursor = ""
+        if (figure.isConnected) figure.classList.remove("attachment--dragging")
+        dropIndicator.style.display = "none"
+      }
+
+      const onUp = () => {
+        activeGestureCleanup = null
+        cleanup()
+        if (dragging && dropTarget) {
+          commitMove(figure, dropTarget)
+        } else if (!dragging) {
+          // Treat as a plain click: select the figure and restore focus so
+          // subsequent keyboard input still lands in the editor (our
+          // preventDefault on mousedown blocked the native focus path).
+          selectFigure(figure)
+          editor.focus()
+        }
+      }
+
+      document.addEventListener("mousemove", onMove)
+      document.addEventListener("mouseup", onUp)
+      activeGestureCleanup = cleanup
+    }
+
+    // ── Selection / drag entry point (capture phase so Trix can't preempt) ──
+    const onEditorMouseDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement
+      if (target.closest(".trix-resize-handle")) return
+      const figure = target.closest(".attachment--preview") as HTMLElement | null
+      if (!figure) return
+      beginDrag(figure, event)
+    }
+    const onDocumentMouseDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement
+      // Don't deselect when the user is clicking a resize handle or another
+      // figure; those have their own selection semantics.
+      if (target.closest(".trix-resize-handle")) return
+      if (target.closest(".attachment--preview")) return
+      selectFigure(null)
+    }
+
+    const onReflow = () => positionOverlay()
+    editor.addEventListener("mousedown", onEditorMouseDown, true)
+    document.addEventListener("mousedown", onDocumentMouseDown)
+    editor.addEventListener("trix-change", onReflow)
+    window.addEventListener("resize", onReflow)
+    window.addEventListener("scroll", onReflow, true)
+
+    return () => {
+      // Abort any in-progress drag/resize so we don't leave document-level
+      // listeners or a stuck `grabbing` cursor behind on unmount.
+      if (activeGestureCleanup) activeGestureCleanup()
+      editor.removeEventListener("mousedown", onEditorMouseDown, true)
+      document.removeEventListener("mousedown", onDocumentMouseDown)
+      editor.removeEventListener("trix-change", onReflow)
+      window.removeEventListener("resize", onReflow)
+      window.removeEventListener("scroll", onReflow, true)
+      overlay.remove()
+      dropIndicator.remove()
+    }
+  }, [])
+
+  // Open links in a new tab when clicked inside the editor. Trix leaves clicks
+  // to the browser's contenteditable, which only moves the caret. Readers
+  // expect a click to navigate.
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor) return
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null
+      const link = target?.closest("a")
+      if (!link || !editor.contains(link)) return
+      const href = link.getAttribute("href")
+      if (!href) return
+      event.preventDefault()
+      // Allowlist schemes before navigating. An author can type any href into
+      // the link dialog, so reject javascript:/data:/vbscript: etc. to avoid
+      // executing attacker-controlled script on click.
+      let url: URL
+      try {
+        url = new URL(href, window.location.href)
+      } catch {
+        return
+      }
+      if (!["http:", "https:", "mailto:"].includes(url.protocol)) return
+      window.open(url.toString(), "_blank", "noopener,noreferrer")
+    }
+
+    editor.addEventListener("click", handleClick)
+    return () => { editor.removeEventListener("click", handleClick) }
+  }, [])
+
+  return (
+    <div ref={wrapperRef} className="trix-editor-wrapper">
+      <svg style={{ display: "none" }} aria-hidden="true">
+        <symbol id={`${toolbarId}-undo`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M7 13L3 9M3 9L7 5M3 9H16C18.7614 9 21 11.2386 21 14C21 16.7614 18.7614 19 16 19H11" />
+        </symbol>
+        <symbol id={`${toolbarId}-redo`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M17 13L21 9M21 9L17 5M21 9H8C5.23858 9 3 11.2386 3 14C3 16.7614 5.23858 19 8 19H13" />
+        </symbol>
+        <symbol id={`${toolbarId}-bold`} viewBox="0 0 24 24">
+          <path d="M8 12H12.5M8 12V5H12.5C14.433 5 16 6.567 16 8.5C16 10.433 14.433 12 12.5 12M8 12V19H13.5C15.433 19 17 17.433 17 15.5C17 13.567 15.433 12 13.5 12H12.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </symbol>
+        <symbol id={`${toolbarId}-italic`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="19" y1="4" x2="10" y2="4" /><line x1="14" y1="20" x2="5" y2="20" /><line x1="15" y1="4" x2="9" y2="20" />
+        </symbol>
+        <symbol id={`${toolbarId}-strike`} viewBox="0 0 24 24">
+          <path d="M12.0005 12.0001C12.8959 12.0001 13.7749 12.1925 14.5457 12.5571C14.8939 12.7218 15.2146 12.9192 15.5009 13.1437C15.8484 13.4162 16.1457 13.729 16.3822 14.0732C16.8136 14.7009 17.0263 15.4096 16.9982 16.1256C16.97 16.8416 16.702 17.5385 16.2222 18.1433C15.7424 18.7481 15.0684 19.2386 14.2705 19.5638C13.4727 19.889 12.5802 20.0373 11.6865 19.9923C10.7928 19.9473 9.93104 19.7108 9.19043 19.3082C8.44982 18.9055 7.85782 18.3514 7.47656 17.7032M12.0005 12.0001H4M12.0005 12.0001H20M16.5243 6.29718C16.143 5.649 15.5512 5.09462 14.8105 4.69197C14.0699 4.28932 13.2076 4.05287 12.314 4.00789C11.4203 3.96291 10.5278 4.11091 9.72998 4.43613C8.93213 4.76135 8.25812 5.25205 7.77832 5.85689C7.29852 6.46173 7.03057 7.15885 7.00244 7.87485C6.9942 8.08463 7.00669 8.29345 7.03924 8.50014" stroke="currentColor" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </symbol>
+        <symbol id={`${toolbarId}-link`} viewBox="0 0 24 24">
+          <path fillRule="evenodd" clipRule="evenodd" d="M10.975 14.51a1.05 1.05 0 0 0 0-1.485 2.95 2.95 0 0 1 0-4.172l3.536-3.535a2.95 2.95 0 1 1 4.172 4.172l-1.093 1.092a1.05 1.05 0 0 0 1.485 1.485l1.093-1.092a5.05 5.05 0 0 0-7.142-7.142L9.49 7.368a5.05 5.05 0 0 0 0 7.142c.41.41 1.075.41 1.485 0zm2.05-5.02a1.05 1.05 0 0 0 0 1.485 2.95 2.95 0 0 1 0 4.172l-3.5 3.5a2.95 2.95 0 1 1-4.171-4.172l1.025-1.025a1.05 1.05 0 0 0-1.485-1.485L3.87 12.99a5.05 5.05 0 0 0 7.142 7.142l3.5-3.5a5.05 5.05 0 0 0 0-7.142 1.05 1.05 0 0 0-1.485 0z" fill="currentColor" />
+        </symbol>
+        <symbol id={`${toolbarId}-heading`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M7 5V12M7 12V19M7 12H17M17 5V12M17 12V19" />
+        </symbol>
+        <symbol id={`${toolbarId}-bullet`} viewBox="0 0 24 24">
+          <path fill="currentColor" d="M4 6c0-.55.45-1 1-1s1 .45 1 1-.45 1-1 1-1-.45-1-1zm5-1c-.55 0-1 .45-1 1s.45 1 1 1h10c.55 0 1-.45 1-1s-.45-1-1-1H9zm0 7c-.55 0-1 .45-1 1s.45 1 1 1h10c.55 0 1-.45 1-1s-.45-1-1-1H9zm0 7c-.55 0-1 .45-1 1s.45 1 1 1h10c.55 0 1-.45 1-1s-.45-1-1-1H9zm-5-7c0-.55.45-1 1-1s1 .45 1 1-.45 1-1 1-1-.45-1-1zm0 7c0-.55.45-1 1-1s1 .45 1 1-.45 1-1 1-1-.45-1-1z" />
+        </symbol>
+        <symbol id={`${toolbarId}-number`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M10 17H20M4 15.6853V15.5C4 14.6716 4.67157 14 5.5 14H5.54054C6.34658 14 7.00021 14.6534 7.00021 15.4595C7.00021 15.8103 6.8862 16.1519 6.67568 16.4326L4 20.0002L7 20M10 12H20M10 7H20M4 5L6 4V10" />
+        </symbol>
+        <symbol id={`${toolbarId}-quote`} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M7.17 6C4.87 6 3 7.87 3 10.17v3.41C3 14.92 4.08 16 5.42 16h3.16c1.34 0 2.42-1.08 2.42-2.42v-3.16C11 8.87 10.13 8 9.07 8H8c.13-.97.93-1.72 1.92-1.72H10V6H7.17zm9 0C13.87 6 12 7.87 12 10.17v3.41c0 1.34 1.08 2.42 2.42 2.42h3.16c1.34 0 2.42-1.08 2.42-2.42v-3.16c0-1.55-.87-2.42-1.93-2.42H17c.13-.97.93-1.72 1.92-1.72H19V6h-2.83z" />
+        </symbol>
+        <symbol id={`${toolbarId}-code`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M16 18l6-6-6-6M8 6l-6 6 6 6" />
+        </symbol>
+        <symbol id={`${toolbarId}-decrease`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 6H11M21 12H13M21 18H11M7 8l-4 4 4 4" />
+        </symbol>
+        <symbol id={`${toolbarId}-increase`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 6H11M21 12H13M21 18H11M3 8l4 4-4 4" />
+        </symbol>
+        <symbol id={`${toolbarId}-attach`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+        </symbol>
+      </svg>
+
+      <trix-toolbar id={toolbarId}>
+        <div className="trix-button-row">
+          <span className="trix-button-group trix-button-group--text-tools">
+            <button type="button" className="trix-button trix-button--icon-bold" data-trix-attribute="bold" data-trix-key="b" title="Bold" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-bold`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-italic" data-trix-attribute="italic" data-trix-key="i" title="Italic" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-italic`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-strike" data-trix-attribute="strike" title="Strikethrough" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-strike`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-link" data-trix-action="link" data-trix-key="k" title="Link" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-link`} /></svg>
+            </button>
+          </span>
+          <span className="trix-button-group trix-button-group--block-tools">
+            <button type="button" className="trix-button trix-button--icon-heading-1" data-trix-attribute="heading1" title="Heading" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-heading`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-quote" data-trix-attribute="quote" title="Quote" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-quote`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-code" data-trix-attribute="code" title="Code" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-code`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-bullet-list" data-trix-attribute="bullet" title="Bullets" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-bullet`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-number-list" data-trix-attribute="number" title="Numbers" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-number`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-decrease-nesting-level" data-trix-action="decreaseNestingLevel" title="Decrease indent" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-decrease`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-increase-nesting-level" data-trix-action="increaseNestingLevel" title="Increase indent" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-increase`} /></svg>
+            </button>
+          </span>
+          <span className="trix-button-group trix-button-group--file-tools">
+            <button type="button" className="trix-button trix-button--icon-attach" data-trix-action="attachFiles" title="Attach files" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-attach`} /></svg>
+            </button>
+          </span>
+          <span className="trix-button-group trix-button-group--history-tools">
+            <button type="button" className="trix-button trix-button--icon-undo" data-trix-action="undo" data-trix-key="z" title="Undo" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-undo`} /></svg>
+            </button>
+            <button type="button" className="trix-button trix-button--icon-redo" data-trix-action="redo" data-trix-key="shift+z" title="Redo" tabIndex={-1}>
+              <svg className="trix-icon" aria-hidden="true"><use href={`#${toolbarId}-redo`} /></svg>
+            </button>
+          </span>
+        </div>
+
+        <div className="trix-dialogs" data-trix-dialogs>
+          <div className="trix-dialog trix-dialog--link" data-trix-dialog="link" data-trix-dialog-attribute="href">
+            <div className="trix-dialog__link-fields">
+              <input type="url" name="href" className="trix-input trix-input--dialog" placeholder="Enter a URL…" aria-label="URL" required data-trix-input />
+              <div className="trix-button-group">
+                <input type="button" className="trix-button trix-button--dialog" value="Link" data-trix-method="setAttribute" />
+                <input type="button" className="trix-button trix-button--dialog" value="Unlink" data-trix-method="removeAttribute" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </trix-toolbar>
+
+      <trix-editor
+        ref={editorRef as React.RefObject<TrixEditorElement>}
+        toolbar={toolbarId}
+        className="trix-content"
+      />
+    </div>
+  )
+}
+
+export default TrixEditor

--- a/frontend/src/pages/editArticleView.tsx
+++ b/frontend/src/pages/editArticleView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { ArrowLeft, Save, Image, Search, X } from "lucide-react"
 import { useNavigate, useParams } from "react-router-dom"
 import { useApiFetch } from "../hooks/useApiFetch"
+import TrixEditor from "../components/TrixEditor"
 
 type EditableStatus = "draft" | "published"
 
@@ -298,14 +299,10 @@ function EditArticleView() {
               />
             </label>
 
-            <label className={labelClass}>
+            <div className={labelClass}>
               <span className={labelTextClass}>Content</span>
-              <textarea
-                className={`${inputClass} resize-y min-h-[320px] font-mono text-xs leading-relaxed`}
-                onChange={(e) => setContent(e.target.value)}
-                value={content}
-              />
-            </label>
+              <TrixEditor onChange={setContent} value={content} />
+            </div>
           </div>
 
           {/* Sidebar */}

--- a/frontend/src/trix.d.ts
+++ b/frontend/src/trix.d.ts
@@ -1,0 +1,67 @@
+import "trix"
+
+declare global {
+  interface Window {
+    Trix?: {
+      config: {
+        attachments: {
+          preview: {
+            caption: {
+              name: boolean
+              size: boolean
+            }
+          }
+        }
+      }
+    }
+  }
+
+  interface TrixDocument {
+    getAttachments(): TrixAttachment[]
+  }
+
+  interface TrixEditorInternal {
+    loadHTML(html: string): void
+    getDocument(): TrixDocument
+    getSelectedRange(): [number, number]
+    setSelectedRange(range: [number, number] | number): void
+    deleteInDirection(direction: "forward" | "backward"): void
+    insertHTML(html: string): void
+    activateAttachment(attachment: TrixAttachment): void
+  }
+
+  interface TrixEditorElement extends HTMLElement {
+    editor: TrixEditorInternal
+    value: string
+  }
+
+  interface TrixAttachment {
+    id: number
+    file: File | null
+    setUploadProgress(value: number): void
+    setAttributes(attrs: Partial<{ url: string; href: string }>): void
+    remove(): void
+  }
+
+  interface TrixAttachmentAddEvent extends Event {
+    attachment: TrixAttachment
+  }
+}
+
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "trix-editor": {
+        toolbar?: string
+        className?: string
+        autofocus?: boolean
+        [key: string]: unknown
+      }
+      "trix-toolbar": {
+        id?: string
+        children?: import("react").ReactNode
+        [key: string]: unknown
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the plain `<textarea>` in the edit-article view with a custom **Trix** rich text editor for article content. Adds a formatting toolbar, image upload via `POST /v1/media`, and in-editor image resize, drag-to-rearrange, and alignment.

## Changes

- `frontend/src/components/TrixEditor.tsx` / `TrixEditor.css` — the editor component + styling
- `frontend/src/trix.d.ts` — type declarations for the `trix` package
- `frontend/src/pages/editArticleView.tsx` — Content field now renders `<TrixEditor>`
- `frontend/package.json` / `package-lock.json` — adds `trix@^2.1.19`

## ⚠️ Backend not yet implemented

Image uploads will **not persist** until the server provides:

1. **`POST /v1/media`** — currently routed to the `handlers.Users` stub (`routes.go:35`). Needs a real handler that reads the multipart `file` field, stores the bytes, and returns `201` with `{"url": "<public image url>"}`.
2. **Storage** — no media table, object storage, or static-file serving exists yet. Pick a disk volume (+ static route) or S3/MinIO.
3. **GET route / static serving** — so the returned URL is publicly fetchable and saved article HTML can load the image after reload.

Until then the editor shows a local blob preview that is lost on reload.

## Verification

- `tsc -b` passes clean (exit 0)
- Scoped to 6 frontend files; no server changes
