### PR TITLE
[fx]: Trix editor — article typography + preserve image captions

### DIFF
--- a/frontend/src/components/TrixEditor.css
+++ b/frontend/src/components/TrixEditor.css
@@ -118,31 +118,103 @@ trix-editor.trix-content {
   border: none !important;
   outline: none !important;
   box-shadow: none !important;
-  padding: 1rem !important;
+  padding: 1.5rem 1.75rem !important;
   min-height: 280px;
-  line-height: 1.6;
+  /* Reads as article body, not form chrome: a notch larger than the 13-14px
+     admin UI and looser leading for sustained reading. */
+  line-height: 1.75;
   color: hsl(var(--foreground, 224 71% 4%));
   background: hsl(var(--card, 0 0% 100%));
   font-family: inherit;
-  font-size: 14px;
+  font-size: 16px;
   display: block;
 }
 
+/* ── Editorial typography ──────────────────────────────────────────────────
+   Tailwind's preflight resets heading sizes/weights to inherit and strips all
+   block margins, which collapses article content into one flat wall of text.
+   We restore a deliberate hierarchy and reading rhythm here. Headings use a
+   serif display stack to read as a newspaper masthead against the sans admin
+   chrome (system serifs only — no webfont fetch inside the CMS). */
+
+trix-editor.trix-content > * {
+  margin: 0 0 1.1em;
+}
+
+trix-editor.trix-content > *:last-child {
+  margin-bottom: 0;
+}
+
+trix-editor.trix-content h1,
+trix-editor.trix-content h2,
+trix-editor.trix-content h3,
+trix-editor.trix-content h4,
+trix-editor.trix-content h5,
+trix-editor.trix-content h6 {
+  font-family: ui-serif, Georgia, "Iowan Old Style", "Times New Roman", serif;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: hsl(var(--foreground, 224 71% 4%));
+  margin: 1.6em 0 0.5em;
+}
+
+trix-editor.trix-content > *:first-child {
+  margin-top: 0;
+}
+
+trix-editor.trix-content h1 { font-size: 1.85em; }
+trix-editor.trix-content h2 { font-size: 1.5em; }
+trix-editor.trix-content h3 { font-size: 1.25em; }
+trix-editor.trix-content h4 { font-size: 1.05em; }
+trix-editor.trix-content h5,
+trix-editor.trix-content h6 {
+  font-size: 0.9em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: hsl(var(--muted-foreground, 215 16% 47%));
+}
+
+trix-editor.trix-content strong { font-weight: 700; }
+trix-editor.trix-content em { font-style: italic; }
+
 /* ── Restore styles stripped by global CSS resets (Tailwind base / kumo) ── */
 
-trix-editor.trix-content ul {
-  list-style: disc;
+trix-editor.trix-content ul,
+trix-editor.trix-content ol {
   padding-left: 1.5em;
 }
 
-trix-editor.trix-content ol {
-  list-style: decimal;
-  padding-left: 1.5em;
+trix-editor.trix-content ul { list-style: disc; }
+trix-editor.trix-content ol { list-style: decimal; }
+
+trix-editor.trix-content li { margin: 0.3em 0; }
+
+trix-editor.trix-content blockquote {
+  margin: 1.4em 0;
+  padding: 0.2em 0 0.2em 1.1em;
+  border-left: 3px solid hsl(var(--primary, 243 75% 59%));
+  color: hsl(var(--muted-foreground, 215 16% 47%));
+  font-style: italic;
+}
+
+trix-editor.trix-content pre {
+  margin: 1.2em 0;
+  padding: 0.9em 1.1em;
+  background: hsl(var(--muted, 220 14% 96%));
+  border: 1px solid hsl(var(--border, 220 13% 91%));
+  border-radius: calc(var(--radius, 0.5rem) - 2px);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.875em;
+  line-height: 1.6;
+  overflow-x: auto;
+  white-space: pre-wrap;
 }
 
 trix-editor.trix-content a {
   color: hsl(var(--primary, 243 75% 59%));
   text-decoration: underline;
+  text-underline-offset: 2px;
   position: relative;
   cursor: pointer;
 }

--- a/frontend/src/components/TrixEditor.tsx
+++ b/frontend/src/components/TrixEditor.tsx
@@ -11,6 +11,72 @@ if (typeof window !== "undefined" && window.Trix) {
   window.Trix.config.attachments.preview.caption.size = false
 }
 
+const IMAGE_CONTENT_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+}
+
+const contentTypeForUrl = (url: string): string => {
+  const ext = url.split(/[?#]/)[0].split(".").pop()?.toLowerCase() ?? ""
+  return IMAGE_CONTENT_TYPES[ext] ?? "image/jpeg"
+}
+
+// Trix only restores an image's caption when it's carried in the attachment's
+// data attributes. Article HTML imported from WordPress instead puts the
+// caption in a plain caption element (block editor: <figure><figcaption>;
+// classic editor: <div class="wp-caption">…<* class="wp-caption-text">), which
+// Trix's parser drops onto the next line as body text — the caption "isn't
+// picked up by the editor". Rewrite those into Trix's native attachment format
+// so loadHTML keeps the caption bound to the image. Containers already
+// round-tripped through Trix (they carry data-trix-attachment) are skipped, so
+// this is idempotent.
+const restoreFigureCaptions = (html: string): string => {
+  if (typeof window === "undefined" || !window.DOMParser) return html
+  if (!html.includes("<figure") && !html.includes("wp-caption")) return html
+
+  const doc = new DOMParser().parseFromString(html, "text/html")
+  let changed = false
+
+  for (const container of Array.from(doc.querySelectorAll("figure, .wp-caption"))) {
+    if (container.hasAttribute("data-trix-attachment")) continue
+    // Only the simple single-image case is safe to rebuild. Galleries and
+    // nested captioned figures hold more than one image (or another caption
+    // container); reconstructing them from a single <img> would silently drop
+    // the rest, so leave those untouched.
+    if (container.querySelectorAll("img").length !== 1) continue
+    if (container.querySelector("figure, .wp-caption")) continue
+
+    const img = container.querySelector("img")
+    const src = img?.getAttribute("src")?.trim()
+    const caption = container.querySelector("figcaption, .wp-caption-text")?.textContent?.trim()
+    if (!img || !src || !caption) continue
+
+    const basename = src.split("/").pop()?.split(/[?#]/)[0]
+    const replacement = doc.createElement("figure")
+    replacement.setAttribute("data-trix-attachment", JSON.stringify({
+      contentType: contentTypeForUrl(src),
+      url: src,
+      filename: img.getAttribute("alt")?.trim() || basename || "image",
+      // Force inline preview: Trix's previewablePattern excludes svg/avif and
+      // any extension-less CDN URL, which would otherwise render as a file stub.
+      previewable: true,
+    }))
+    replacement.setAttribute("data-trix-attributes", JSON.stringify({ presentation: "gallery", caption }))
+    const newImg = doc.createElement("img")
+    newImg.setAttribute("src", src)
+    replacement.appendChild(newImg)
+    container.replaceWith(replacement)
+    changed = true
+  }
+
+  return changed ? doc.body.innerHTML : html
+}
+
 type TrixEditorProps = {
   value: string
   onChange: (html: string) => void
@@ -28,7 +94,7 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
     const editor = editorRef.current
     if (!editor) return
     if (value !== lastEmittedRef.current) {
-      editor.editor.loadHTML(value)
+      editor.editor.loadHTML(restoreFigureCaptions(value))
       lastEmittedRef.current = value
     }
   }, [value])


### PR DESCRIPTION
Follow-up to the Trix editor (#97) addressing two pieces of review feedback: article text display and dropped image captions.

## 1. Article typography

Tailwind's preflight reset had flattened the editor body — headings, paragraphs, blockquotes, and code all rendered as one undifferentiated block of 14px text. Restored an editorial hierarchy using the existing `hsl(var(--token))` design system (no webfont fetch):

- Serif display headings (h1–h6) with a real size/weight scale
- Comfortable reading size (16px) and paragraph/list rhythm
- Accented blockquotes, styled code blocks, refined link underlines

## 2. Image captions weren't picked up

WordPress-imported article HTML stores image captions in a `<figcaption>` (block editor) or `<div class="wp-caption">…<* class="wp-caption-text">` (classic editor). On load, Trix turned the image into an attachment but dropped the caption text onto the next body line — so the caption "wasn't picked up by the editor."

`restoreFigureCaptions()` now rewrites captioned images into Trix's native attachment format (`data-trix-attachment` + `data-trix-attributes` with the caption) **before** `loadHTML`, so the caption stays bound to the image and round-trips on save.

Safeguards:
- Handles both block-editor `<figure>` and classic-editor `<div class="wp-caption">`
- **Single-image containers only** — galleries and nested figures are left intact rather than rebuilt, to avoid silently dropping images
- Forces inline preview so `svg`/`avif`/extension-less CDN URLs still render (not as file stubs)
- Idempotent: images already in Trix format are skipped, so re-saved content is untouched

## Verification

- `tsc -b` and `vite build` pass clean
- Transform logic validated against a real DOM across 18 cases: Gutenberg + classic captions, gallery/nested skip, svg/avif preview, query-string filenames, idempotency
