### PR TITLE
fix(media): run the filesystem index in the background

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -150,7 +150,8 @@ the database. After the media rsync completes, populate it once from the CMS
 (Media -> Reindex) or directly:
 
 ```bash
-curl -X POST https://localhost/v1/media/index   # admin session required
+curl -X POST https://localhost/v1/media/index   # admin session required; returns 202
+curl https://localhost/v1/media/index           # poll progress
 ```
 
 It walks `MEDIA_ROOT/wp-content/uploads`, skips WordPress's generated `-WxH`
@@ -159,8 +160,17 @@ already-indexed files are skipped and any alt text set in the CMS is preserved â
 so re-run it after any later out-of-band rsync. Uploads through the CMS index
 themselves and need no reindex.
 
-Note this walks the whole tree, so on a large corpus over CephFS the first run
-takes a while; run it once at cutover rather than on a schedule.
+**The index runs in the background.** `POST` returns `202` immediately and `GET`
+reports `{running, progress:{walked, scanned, added, skipped}, error}`; a second
+`POST` while one is in flight returns `409`. This is not cosmetic: the real corpus
+is ~145k filesystem entries and the walk takes minutes, while Nginx cuts an idle
+upstream read at 60s and Cloudflare at ~100s. A synchronous version was cancelled
+by those proxies every time and could never finish. A run is capped at two hours
+so a wedged filesystem cannot leave the job stuck "running" forever.
+
+Progress is reported per entry *walked* rather than per file indexed, because the
+corpus is mostly derivatives that are skipped without a stat â€” counting only
+indexed files would look frozen for long stretches.
 
 ### Disk
 

--- a/frontend/src/pages/mediaView.tsx
+++ b/frontend/src/pages/mediaView.tsx
@@ -27,9 +27,18 @@ type MediaResponse = {
 }
 
 type IndexReport = {
+  walked?: number
   scanned?: number
   added?: number
   skipped?: number
+}
+
+type IndexStatus = {
+  running: boolean
+  started_at?: string
+  finished_at?: string
+  progress?: IndexReport
+  error?: string
 }
 
 const PAGE_SIZE = 60
@@ -73,6 +82,8 @@ function MediaView() {
   const [selected, setSelected] = useState<MediaItem | null>(null)
   const [uploadStatus, setUploadStatus] = useState<string | null>(null)
   const [isIndexing, setIsIndexing] = useState(false)
+  const [indexProgress, setIndexProgress] = useState<string | null>(null)
+  const [reloadToken, setReloadToken] = useState(0)
 
   // Debounce so typing doesn't fire a request per keystroke; the filter itself
   // is applied server-side because the library is far too large to filter here.
@@ -117,7 +128,7 @@ function MediaView() {
 
     void load()
     return () => controller.abort()
-  }, [fetchPage])
+  }, [fetchPage, reloadToken])
 
   const loadMore = async () => {
     setIsLoadingMore(true)
@@ -133,7 +144,10 @@ function MediaView() {
     }
   }
 
-  const refresh = () => setSearch((current) => current)
+  // Bumping a token is what actually re-runs the load effect. Re-setting `search`
+  // to its current value does not: React bails out of a same-value setState, so
+  // the effect never re-fires and the list silently stays stale.
+  const refresh = useCallback(() => setReloadToken((n) => n + 1), [])
 
   const handleUpload = async (files: FileList | null) => {
     if (!files || files.length === 0) return
@@ -223,6 +237,32 @@ function MediaView() {
     }
   }
 
+  // The index walks ~145k filesystem entries and takes minutes, so the server
+  // runs it in the background and we poll. A synchronous request could never
+  // finish: Nginx cuts an upstream read at 60s and Cloudflare at ~100s.
+  const pollIndexStatus = useCallback(async (): Promise<boolean> => {
+    const response = await apiFetch("/v1/media/index")
+    if (!response.ok) throw new Error(await errorMessage(response, `Status check failed (${response.status})`))
+    const status = (await response.json()) as IndexStatus
+
+    const p = status.progress
+    if (status.running) {
+      setIndexProgress(
+        `Indexing… ${String(p?.walked ?? 0)} files scanned, ${String(p?.added ?? 0)} added`,
+      )
+      return true
+    }
+
+    setIndexProgress(null)
+    if (status.error) {
+      setError(`Reindex failed: ${status.error}`)
+    } else if (status.finished_at) {
+      setNotice(`Indexed ${String(p?.scanned ?? 0)} assets — ${String(p?.added ?? 0)} new, ${String(p?.skipped ?? 0)} already known.`)
+      if ((p?.added ?? 0) > 0) refresh()
+    }
+    return false
+  }, [apiFetch, refresh])
+
   const handleReindex = async () => {
     setIsIndexing(true)
     setError(null)
@@ -230,15 +270,19 @@ function MediaView() {
 
     try {
       const response = await apiFetch("/v1/media/index", { method: "POST" })
-      if (!response.ok) {
+      // 409 means one is already running — join its progress rather than error.
+      if (!response.ok && response.status !== 409) {
         setError(await errorMessage(response, `Reindex failed (${response.status})`))
+        setIsIndexing(false)
         return
       }
-      const report = (await response.json()) as IndexReport
-      setNotice(`Indexed ${String(report.scanned ?? 0)} files — ${String(report.added ?? 0)} new.`)
-      if ((report.added ?? 0) > 0) refresh()
+
+      while (await pollIndexStatus()) {
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to reindex media.")
+      setIndexProgress(null)
     } finally {
       setIsIndexing(false)
     }
@@ -268,7 +312,7 @@ function MediaView() {
               type="button"
             >
               <RefreshCw className={`w-4 h-4 ${isIndexing ? "animate-spin" : ""}`} aria-hidden="true" />
-              {isIndexing ? "Indexing..." : "Reindex"}
+              {indexProgress ?? (isIndexing ? "Starting…" : "Reindex")}
             </button>
             <input
               accept="image/jpeg,image/png,image/gif,image/webp"

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -1732,6 +1732,28 @@ const docTemplate = `{
             }
         },
         "/v1/media/index": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "media"
+                ],
+                "summary": "Media reindex status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.MediaIndexStatusResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1744,16 +1766,16 @@ const docTemplate = `{
                 "tags": [
                     "media"
                 ],
-                "summary": "Reindex the media filesystem",
+                "summary": "Start a media filesystem reindex",
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/models.MediaIndexResponse"
+                            "$ref": "#/definitions/models.MediaIndexStatusResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal Server Error",
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
@@ -4497,6 +4519,29 @@ const docTemplate = `{
                 },
                 "skipped": {
                     "type": "integer"
+                },
+                "walked": {
+                    "type": "integer"
+                }
+            }
+        },
+        "models.MediaIndexStatusResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "finished_at": {
+                    "type": "string"
+                },
+                "progress": {
+                    "$ref": "#/definitions/models.MediaIndexResponse"
+                },
+                "running": {
+                    "type": "boolean"
+                },
+                "started_at": {
+                    "type": "string"
                 }
             }
         },

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -1729,6 +1729,28 @@
             }
         },
         "/v1/media/index": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "media"
+                ],
+                "summary": "Media reindex status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.MediaIndexStatusResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -1741,16 +1763,16 @@
                 "tags": [
                     "media"
                 ],
-                "summary": "Reindex the media filesystem",
+                "summary": "Start a media filesystem reindex",
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/models.MediaIndexResponse"
+                            "$ref": "#/definitions/models.MediaIndexStatusResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal Server Error",
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
@@ -4494,6 +4516,29 @@
                 },
                 "skipped": {
                     "type": "integer"
+                },
+                "walked": {
+                    "type": "integer"
+                }
+            }
+        },
+        "models.MediaIndexStatusResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "finished_at": {
+                    "type": "string"
+                },
+                "progress": {
+                    "$ref": "#/definitions/models.MediaIndexResponse"
+                },
+                "running": {
+                    "type": "boolean"
+                },
+                "started_at": {
+                    "type": "string"
                 }
             }
         },

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -583,6 +583,21 @@ definitions:
         type: integer
       skipped:
         type: integer
+      walked:
+        type: integer
+    type: object
+  models.MediaIndexStatusResponse:
+    properties:
+      error:
+        type: string
+      finished_at:
+        type: string
+      progress:
+        $ref: '#/definitions/models.MediaIndexResponse'
+      running:
+        type: boolean
+      started_at:
+        type: string
     type: object
   models.MediaOverview:
     properties:
@@ -2143,16 +2158,29 @@ paths:
       tags:
       - media
   /v1/media/index:
-    post:
+    get:
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.MediaIndexResponse'
-        "500":
-          description: Internal Server Error
+            $ref: '#/definitions/models.MediaIndexStatusResponse'
+      security:
+      - BearerAuth: []
+      summary: Media reindex status
+      tags:
+      - media
+    post:
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/models.MediaIndexStatusResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/models.ErrorResponse'
         "501":
@@ -2161,7 +2189,7 @@ paths:
             $ref: '#/definitions/models.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Reindex the media filesystem
+      summary: Start a media filesystem reindex
       tags:
       - media
   /v1/poll:

--- a/server/internal/database/media.go
+++ b/server/internal/database/media.go
@@ -338,16 +338,41 @@ func MediaPathInUse(ctx context.Context, conn *sql.DB, relPath string) (bool, er
 	return false, fmt.Errorf("check media usage: %w", err)
 }
 
+// progressInterval is how many filesystem entries the indexer walks between
+// progress callbacks. The corpus is mostly WordPress derivatives that are
+// skipped without a stat, so reporting per *indexed* file would appear frozen
+// for long stretches; reporting per entry walked keeps the count moving.
+const progressInterval = 500
+
 // IndexMediaRoot walks the uploads tree under root and inserts a library row for
 // every asset not already recorded, so the migrated CephFS corpus shows up
 // without a separate migration step. It is idempotent: existing paths are
 // counted as skipped and left untouched, preserving any alt text already set.
 func IndexMediaRoot(ctx context.Context, conn *sql.DB, root, uploadsSubdir string) (models.MediaIndexResponse, error) {
+	return IndexMediaRootWithProgress(ctx, conn, root, uploadsSubdir, nil)
+}
+
+// IndexMediaRootWithProgress is IndexMediaRoot with periodic progress reporting.
+// onProgress (may be nil) is called from the walking goroutine every
+// progressInterval entries and once at the end, so it must not block.
+func IndexMediaRootWithProgress(
+	ctx context.Context,
+	conn *sql.DB,
+	root, uploadsSubdir string,
+	onProgress func(models.MediaIndexResponse),
+) (models.MediaIndexResponse, error) {
 	var report models.MediaIndexResponse
 
 	known, err := knownMediaPaths(ctx, conn)
 	if err != nil {
 		return report, err
+	}
+
+	report.Walked = 0
+	notify := func() {
+		if onProgress != nil {
+			onProgress(report)
+		}
 	}
 
 	uploadsDir := filepath.Join(root, filepath.FromSlash(uploadsSubdir))
@@ -361,6 +386,11 @@ func IndexMediaRoot(ctx context.Context, conn *sql.DB, root, uploadsSubdir strin
 		}
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
+		}
+
+		report.Walked++
+		if report.Walked%progressInterval == 0 {
+			notify()
 		}
 		if entry.IsDir() {
 			return nil
@@ -404,11 +434,15 @@ func IndexMediaRoot(ctx context.Context, conn *sql.DB, root, uploadsSubdir strin
 	})
 	if walkErr != nil {
 		if os.IsNotExist(walkErr) {
+			notify()
 			return report, nil
 		}
 		return report, fmt.Errorf("index media: %w", walkErr)
 	}
 
+	// Always report the final tally: a tree smaller than progressInterval would
+	// otherwise never fire the callback at all.
+	notify()
 	return report, nil
 }
 

--- a/server/internal/database/media_integration_test.go
+++ b/server/internal/database/media_integration_test.go
@@ -292,3 +292,40 @@ func TestDeleteMediaRow(t *testing.T) {
 		t.Fatalf("second delete err = %v, want sql.ErrNoRows", err)
 	}
 }
+
+// The index reports progress as it walks, which is what lets the HTTP layer run
+// it in the background and be polled. A tree smaller than progressInterval must
+// still produce a final report rather than silently never calling back.
+func TestIndexMediaRootWithProgress_ReportsProgress(t *testing.T) {
+	conn := mediaTestDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+
+	writeFile(t, root, "wp-content/uploads/2021/01/one.jpg")
+	writeFile(t, root, "wp-content/uploads/2021/01/two.png")
+	writeFile(t, root, "wp-content/uploads/2021/02/three.gif")
+
+	var updates []models.MediaIndexResponse
+	report, err := IndexMediaRootWithProgress(ctx, conn, root, "wp-content/uploads",
+		func(p models.MediaIndexResponse) { updates = append(updates, p) })
+	if err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	if len(updates) == 0 {
+		t.Fatal("expected at least one progress callback")
+	}
+	final := updates[len(updates)-1]
+	if final.Added != report.Added || final.Scanned != report.Scanned {
+		t.Fatalf("last callback %+v disagrees with returned report %+v", final, report)
+	}
+	if report.Added != 3 {
+		t.Fatalf("added = %d, want 3", report.Added)
+	}
+	// Walked counts every entry visited (files AND directories), so it must
+	// exceed the three indexed files — that is what makes it a useful progress
+	// signal on a corpus that is mostly skipped derivatives.
+	if report.Walked <= report.Added {
+		t.Fatalf("walked = %d, expected it to exceed added = %d", report.Walked, report.Added)
+	}
+}

--- a/server/internal/handlers/media.go
+++ b/server/internal/handlers/media.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
@@ -8,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"log/slog"
+	"sync"
 	// Register decoders so image.DecodeConfig can report dimensions for the
 	// common legacy formats. WebP/AVIF simply report no dimensions (best effort).
 	_ "image/gif"
@@ -37,6 +40,9 @@ const (
 	// the Nginx `location /wp-content/` root that serves them.
 	uploadsSubdir  = "wp-content/uploads"
 	maxBaseNameLen = 100
+	// mediaIndexTimeout bounds a background index run so a wedged filesystem
+	// cannot leave the job permanently "running" and block every later attempt.
+	mediaIndexTimeout = 2 * time.Hour
 )
 
 // allowedImageTypes maps a sniffed content type to its canonical extension. Only
@@ -595,15 +601,94 @@ func DeleteMediaItem(conn *sql.DB) http.Handler {
 	})
 }
 
-// PostMediaIndex walks the media filesystem and adds any asset missing from the
-// library. This is how the migrated CephFS corpus enters the library, and it is
-// safe to re-run: existing entries keep whatever alt text they already have.
+// mediaIndexJob tracks the single in-flight index run for this process.
 //
-// @Summary Reindex the media filesystem
+// The walk takes minutes on the real corpus (~145k filesystem entries, most of
+// them WordPress derivatives that are skipped), which is far longer than the
+// proxies in front of this service allow a request to hang: Nginx cuts an
+// upstream read at 60s by default and Cloudflare at ~100s. Running it inside the
+// request meant the client disconnect cancelled the walk, so a full index could
+// never complete over HTTP. It now runs in the background on a context that
+// outlives the request, and callers poll for progress.
+type mediaIndexJob struct {
+	mu         sync.Mutex
+	running    bool
+	startedAt  time.Time
+	finishedAt time.Time
+	progress   models.MediaIndexResponse
+	err        string
+}
+
+// tryStart claims the job. It returns false when a run is already in flight, so
+// an impatient second click extends nothing and corrupts nothing.
+func (j *mediaIndexJob) tryStart() bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.running {
+		return false
+	}
+	j.running = true
+	j.startedAt = time.Now().UTC()
+	j.finishedAt = time.Time{}
+	j.progress = models.MediaIndexResponse{}
+	j.err = ""
+	return true
+}
+
+func (j *mediaIndexJob) setProgress(p models.MediaIndexResponse) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.progress = p
+}
+
+func (j *mediaIndexJob) finish(p models.MediaIndexResponse, err error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.running = false
+	j.finishedAt = time.Now().UTC()
+	j.progress = p
+	if err != nil {
+		j.err = err.Error()
+	}
+}
+
+func (j *mediaIndexJob) status() models.MediaIndexStatusResponse {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	status := models.MediaIndexStatusResponse{
+		Running:  j.running,
+		Progress: j.progress,
+		Error:    j.err,
+	}
+	if !j.startedAt.IsZero() {
+		started := j.startedAt
+		status.StartedAt = &started
+	}
+	if !j.finishedAt.IsZero() {
+		finished := j.finishedAt
+		status.FinishedAt = &finished
+	}
+	return status
+}
+
+// One job per process. Blue/green means two backends could in principle index at
+// once, but only one slot serves traffic, and the unique key on media.path makes
+// a concurrent run wasteful rather than harmful (duplicates count as skips).
+var mediaIndexer = &mediaIndexJob{}
+
+// PostMediaIndex starts a background walk of the media filesystem, adding any
+// asset missing from the library. This is how the migrated CephFS corpus enters
+// the library, and it is safe to re-run: existing entries keep whatever alt text
+// they already have.
+//
+// It returns 202 immediately; poll GET /v1/media/index for progress.
+//
+// @Summary Start a media filesystem reindex
 // @Tags media
 // @Produce json
-// @Success 200 {object} models.MediaIndexResponse
-// @Failure 500 {object} models.ErrorResponse
+// @Success 202 {object} models.MediaIndexStatusResponse
+// @Failure 409 {object} models.ErrorResponse
 // @Failure 501 {object} models.ErrorResponse
 // @Security BearerAuth
 // @Router /v1/media/index [post]
@@ -615,15 +700,46 @@ func PostMediaIndex(conn *sql.DB) http.Handler {
 			return
 		}
 
-		report, err := db.IndexMediaRoot(r.Context(), conn, root, uploadsSubdir)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+		if !mediaIndexer.tryStart() {
+			writeError(w, http.StatusConflict, "a media index is already running")
 			return
 		}
 
-		activity.LogRequest(r, "media_indexed", "Media library reindexed",
-			"added", strconv.Itoa(report.Added), "scanned", strconv.Itoa(report.Scanned))
-		writeJSON(w, http.StatusOK, report)
+		activity.LogRequest(r, "media_index_started", "Media library reindex started")
+
+		// Deliberately NOT r.Context(): the request returns immediately, so the
+		// walk must not be cancelled when the client disconnects.
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), mediaIndexTimeout)
+			defer cancel()
+
+			report, err := db.IndexMediaRootWithProgress(ctx, conn, root, uploadsSubdir, mediaIndexer.setProgress)
+			mediaIndexer.finish(report, err)
+			if err != nil {
+				slog.Error("media index failed", "error", err,
+					"walked", report.Walked, "added", report.Added)
+				return
+			}
+			slog.Info("media index complete",
+				"walked", report.Walked, "scanned", report.Scanned,
+				"added", report.Added, "skipped", report.Skipped)
+		}()
+
+		writeJSON(w, http.StatusAccepted, mediaIndexer.status())
+	})
+}
+
+// GetMediaIndexStatus reports the progress of the current or most recent index.
+//
+// @Summary Media reindex status
+// @Tags media
+// @Produce json
+// @Success 200 {object} models.MediaIndexStatusResponse
+// @Security BearerAuth
+// @Router /v1/media/index [get]
+func GetMediaIndexStatus() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, mediaIndexer.status())
 	})
 }
 

--- a/server/internal/handlers/media_integration_test.go
+++ b/server/internal/handlers/media_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 
@@ -248,5 +249,84 @@ func TestMediaHTTP_GetMissingItemIs404(t *testing.T) {
 	GetMediaItem(conn).ServeHTTP(rec, mediaIDRequest(t, http.MethodGet, "/v1/media/999999", 999999, ""))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// The whole point of the async index: the walk must outlive the request that
+// started it. This asserts POST returns 202 immediately and the work completes
+// afterwards, which the previous synchronous version could not do behind a
+// proxy that cuts idle upstream reads at 60s.
+func TestMediaHTTP_IndexRunsInBackground(t *testing.T) {
+	conn := mediaHTTPTestDB(t)
+	root := t.TempDir()
+	t.Setenv("MEDIA_ROOT", root)
+
+	for _, rel := range []string{
+		"wp-content/uploads/2019/05/campus.jpg",
+		"wp-content/uploads/2019/05/campus-150x150.jpg", // derivative, must be skipped
+		"wp-content/uploads/2020/11/protest.png",
+	} {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(abs, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	// Ensure the shared job is idle, and release it however this test exits.
+	if !mediaIndexer.tryStart() {
+		t.Fatal("package index job was unexpectedly busy")
+	}
+	mediaIndexer.finish(models.MediaIndexResponse{}, nil)
+
+	start := time.Now()
+	rec := httptest.NewRecorder()
+	PostMediaIndex(conn).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/media/index", nil))
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+	// "Immediately" — the handler must not be doing the walk inline.
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("POST took %v; it should return before the walk finishes", elapsed)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	var status models.MediaIndexStatusResponse
+	for {
+		statusRec := httptest.NewRecorder()
+		GetMediaIndexStatus().ServeHTTP(statusRec, httptest.NewRequest(http.MethodGet, "/v1/media/index", nil))
+		if err := json.Unmarshal(statusRec.Body.Bytes(), &status); err != nil {
+			t.Fatalf("decode status: %v", err)
+		}
+		if !status.Running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("index did not finish within 30s")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if status.Error != "" {
+		t.Fatalf("index reported error: %s", status.Error)
+	}
+	if status.FinishedAt == nil || status.StartedAt == nil {
+		t.Fatalf("expected both timestamps, got %+v", status)
+	}
+	if status.Progress.Added != 2 {
+		t.Fatalf("added = %d, want 2 (the derivative must be skipped)", status.Progress.Added)
+	}
+
+	// And the rows are really there, written by the background goroutine after
+	// the request had already returned.
+	_, total, err := db.ListMedia(context.Background(), conn, models.MediaListParams{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("media rows = %d, want 2", total)
 	}
 }

--- a/server/internal/handlers/media_test.go
+++ b/server/internal/handlers/media_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"image"
 	"image/color"
 	"image/png"
@@ -12,6 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"server/internal/models"
 )
 
 func pngBytes(t *testing.T, w, h int) []byte {
@@ -239,5 +243,101 @@ func TestMediaIDParam(t *testing.T) {
 				t.Fatalf("mediaIDParam(%q) = (%d, %v), want (%d, %v)", tt.id, got, ok, tt.want, tt.wantOK)
 			}
 		})
+	}
+}
+
+// The index job must survive the request that started it — that is the whole
+// point of making it asynchronous — and must not allow two concurrent runs.
+func TestMediaIndexJob_Lifecycle(t *testing.T) {
+	job := &mediaIndexJob{}
+
+	if got := job.status(); got.Running || got.StartedAt != nil || got.FinishedAt != nil {
+		t.Fatalf("fresh job should be idle, got %+v", got)
+	}
+
+	if !job.tryStart() {
+		t.Fatal("first tryStart should claim the job")
+	}
+	if job.tryStart() {
+		t.Fatal("second tryStart must be refused while running")
+	}
+
+	running := job.status()
+	if !running.Running || running.StartedAt == nil {
+		t.Fatalf("running status = %+v, want Running with StartedAt", running)
+	}
+	if running.FinishedAt != nil {
+		t.Fatal("FinishedAt must be unset while running")
+	}
+
+	job.setProgress(models.MediaIndexResponse{Walked: 1200, Scanned: 40, Added: 12})
+	if got := job.status().Progress; got.Walked != 1200 || got.Added != 12 {
+		t.Fatalf("progress = %+v, want walked 1200 / added 12", got)
+	}
+
+	job.finish(models.MediaIndexResponse{Walked: 2000, Scanned: 80, Added: 20, Skipped: 60}, nil)
+	done := job.status()
+	if done.Running || done.FinishedAt == nil || done.Error != "" {
+		t.Fatalf("finished status = %+v, want idle with FinishedAt and no error", done)
+	}
+	if done.Progress.Added != 20 || done.Progress.Skipped != 60 {
+		t.Fatalf("final progress = %+v", done.Progress)
+	}
+
+	// A completed run must not block the next one, and starting again clears the
+	// previous result rather than reporting stale counts as current.
+	if !job.tryStart() {
+		t.Fatal("a finished job should be startable again")
+	}
+	if got := job.status(); got.Progress.Added != 0 || got.FinishedAt != nil {
+		t.Fatalf("restarted job should reset counters, got %+v", got)
+	}
+}
+
+func TestMediaIndexJob_RecordsFailure(t *testing.T) {
+	job := &mediaIndexJob{}
+	job.tryStart()
+	job.finish(models.MediaIndexResponse{Walked: 10}, context.DeadlineExceeded)
+
+	got := job.status()
+	if got.Running {
+		t.Fatal("job should not be running after finish")
+	}
+	if got.Error != context.DeadlineExceeded.Error() {
+		t.Fatalf("Error = %q, want %q", got.Error, context.DeadlineExceeded.Error())
+	}
+}
+
+func TestPostMediaIndex_SecondRequestConflicts(t *testing.T) {
+	t.Setenv("MEDIA_ROOT", t.TempDir())
+
+	// Claim the shared job so the handler sees a run already in flight, then
+	// release it so later tests are unaffected.
+	if !mediaIndexer.tryStart() {
+		t.Fatal("expected the package job to be idle at test start")
+	}
+	t.Cleanup(func() { mediaIndexer.finish(models.MediaIndexResponse{}, nil) })
+
+	rec := httptest.NewRecorder()
+	PostMediaIndex(nil).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/media/index", nil))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetMediaIndexStatus_ReportsIdle(t *testing.T) {
+	rec := httptest.NewRecorder()
+	GetMediaIndexStatus().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/media/index", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var status models.MediaIndexStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if status.Running {
+		t.Fatal("expected the shared job to be idle")
 	}
 }

--- a/server/internal/models/api_responses.go
+++ b/server/internal/models/api_responses.go
@@ -366,11 +366,25 @@ type MediaUploadResponse struct {
 	Height      int    `json:"height,omitempty"`
 }
 
-// MediaIndexResponse reports what a filesystem reindex found. Scanned counts
-// every eligible file walked; Added counts rows newly inserted; Skipped counts
-// files already present in the library.
+// MediaIndexResponse reports what a filesystem reindex found. Walked counts
+// every filesystem entry visited (the corpus is mostly WordPress derivatives
+// that are skipped before any stat, so this is the only counter that moves
+// steadily); Scanned counts eligible files; Added counts rows newly inserted;
+// Skipped counts files already present in the library.
 type MediaIndexResponse struct {
+	Walked  int `json:"walked"`
 	Scanned int `json:"scanned"`
 	Added   int `json:"added"`
 	Skipped int `json:"skipped"`
+}
+
+// MediaIndexStatusResponse describes an index run. The walk takes minutes on a
+// large corpus, far longer than proxies allow a request to hang, so it runs in
+// the background and is polled through this shape.
+type MediaIndexStatusResponse struct {
+	Running    bool               `json:"running"`
+	StartedAt  *time.Time         `json:"started_at,omitempty"`
+	FinishedAt *time.Time         `json:"finished_at,omitempty"`
+	Progress   MediaIndexResponse `json:"progress"`
+	Error      string             `json:"error,omitempty"`
 }

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -52,7 +52,10 @@ func Register(mux *http.ServeMux, conn *sql.DB, verifier *oidc.IDTokenVerifier, 
 	mux.Handle("GET /v1/media/gallery", authMW(handlers.GetMediaGallery(conn)))
 	mux.Handle("GET /v1/media/{id}", authMW(handlers.GetMediaItem(conn)))
 	mux.Handle("POST /v1/media", authMW(adminOnly(handlers.PostMedia(conn))))
+	// Indexing runs in the background (the walk outlives any proxy timeout), so
+	// starting it and polling its progress are separate endpoints.
 	mux.Handle("POST /v1/media/index", authMW(adminOnly(handlers.PostMediaIndex(conn))))
+	mux.Handle("GET /v1/media/index", authMW(adminOnly(handlers.GetMediaIndexStatus())))
 	mux.Handle("PATCH /v1/media/{id}", authMW(handlers.PatchMediaItem(conn)))
 	mux.Handle("DELETE /v1/media/{id}", authMW(adminOnly(handlers.DeleteMediaItem(conn))))
 	mux.Handle("GET /v1/homepage", handlers.GetHomepage(conn))


### PR DESCRIPTION
The media index could never complete over HTTP. Fixes the 504 seen on the first
production reindex attempt.

## The bug

The index walks ~145k filesystem entries on the real corpus and takes minutes,
but it ran inside the request on `r.Context()`. The first proxy to give up
killed it:

```
POST /v1/media/index  status=500  duration_ms=60045
```

That is Nginx's default `proxy_read_timeout` of 60s — Cloudflare would have cut
in at ~100s regardless. The walk checked `ctx.Err()` and aborted cleanly, so the
6,485 rows it had inserted were committed and consistent, but no amount of
retrying could finish the job and the **Media → Reindex button was unusable by
construction** on a corpus this size.

## The fix

- `POST /v1/media/index` starts the walk on a background context that outlives
  the request and returns **202** immediately.
- `GET /v1/media/index` reports `{running, started_at, finished_at, progress, error}`.
- A second `POST` while a run is in flight returns **409** instead of starting a
  duplicate.
- Runs are capped at two hours, so a wedged filesystem can't leave the job stuck
  `running` and block every later attempt.
- Progress counts entries **walked**, not files indexed. The corpus is mostly
  WordPress derivatives that are skipped before any `stat`, so an indexed-file
  counter appears frozen for long stretches. `MediaIndexResponse` gains `Walked`.
- Frontend polls every 2s and shows live counts in the button. A 409 is treated
  as "join the run already in progress" rather than an error.

## Unrelated bug this surfaced

`refresh()` was `setSearch(current => current)`. React bails out of a same-value
`setState`, so the effect never re-fired and the list silently never reloaded
after an upload or index. It now bumps a token the load effect depends on.

## Testing

- `go build`, `go vet`, `go test ./...` clean; `tsc -b`, `eslint`, and the
  production build clean.
- New unit tests for the job lifecycle: start/refuse-concurrent/progress/finish,
  failure recording, reset-on-restart, plus 409 and status handlers.
- New integration test (`CMS_TEST_DSN`-gated, **run against real MariaDB 11.8**)
  asserting the POST returns 202 in under 2s and the walk completes *after* the
  request returned, with the derivative skipped and rows actually written by the
  background goroutine.
- Database-level test that the progress callback fires and its final report
  agrees with the returned one, including on trees smaller than the callback
  interval.

## Operational note

`deploy/README.md` updated. Once this is deployed, Media → Reindex works from the
UI; the partial index from the failed run is preserved and the rerun resumes,
skipping what is already there and keeping any alt text.