### PR TITLE
fix(articles): stop serving unpublished drafts by slug to anonymous callers

### DIFF
--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -227,6 +227,7 @@ const docTemplate = `{
         },
         "/v1/articles/{slug}": {
             "get": {
+                "description": "Public. Unauthenticated callers only see published, non-archived articles; anything else answers 404, the same as an unknown slug. An authenticated editor sees drafts and archived articles too.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -224,6 +224,7 @@
         },
         "/v1/articles/{slug}": {
             "get": {
+                "description": "Public. Unauthenticated callers only see published, non-archived articles; anything else answers 404, the same as an unknown slug. An authenticated editor sees drafts and archived articles too.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -1113,6 +1113,9 @@ paths:
       tags:
       - articles
     get:
+      description: Public. Unauthenticated callers only see published, non-archived
+        articles; anything else answers 404, the same as an unknown slug. An authenticated
+        editor sees drafts and archived articles too.
       parameters:
       - description: Article slug
         in: path

--- a/server/internal/database/http_models.go
+++ b/server/internal/database/http_models.go
@@ -322,7 +322,11 @@ func GetRelatedArticlesBySlug(ctx context.Context, conn *sql.DB, slug string, k 
 		"JOIN article_embeddings AS src_vec ON src_vec.article_id = src.id " +
 		"JOIN article_embeddings AS cand_vec ON cand_vec.article_id <> src.id " +
 		"JOIN articles AS a ON a.id = cand_vec.article_id " +
-		"WHERE src.slug = ? " +
+		// "Related reading" is surfaced on the public article page, so a
+		// candidate must be live content regardless of who is asking -- an
+		// unpublished or soft-deleted article is not something to link to from
+		// anywhere, including the CMS preview.
+		"WHERE src.slug = ? AND a.pub_date IS NOT NULL AND a.archived_at IS NULL " +
 		"ORDER BY VEC_DISTANCE_EUCLIDEAN(cand_vec.embedding, src_vec.embedding), a.id DESC " +
 		"LIMIT ?"
 

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -1353,7 +1353,22 @@ func GetSearch(conn *sql.DB) http.HandlerFunc {
 	}
 }
 
+// articleDetailCondition builds the WHERE clause for a single-article lookup.
+// The endpoint is public and returns the FULL article body, so an anonymous
+// caller is restricted to live content: knowing or guessing a slug must not
+// hand out an unpublished draft or a soft-deleted article. A miss falls through
+// to the same 404 as a nonexistent slug, so the response never reveals that the
+// article exists. Editors are identified by OptionalAuth on the route and still
+// see everything.
+func articleDetailCondition(r *http.Request) string {
+	if _, isEditor := middleware.UserFromContext(r.Context()); isEditor {
+		return "`slug` = ?"
+	}
+	return "`slug` = ? AND `pub_date` IS NOT NULL AND `archived_at` IS NULL"
+}
+
 // @Summary Get an article by slug
+// @Description Public. Unauthenticated callers only see published, non-archived articles; anything else answers 404, the same as an unknown slug. An authenticated editor sees drafts and archived articles too.
 // @Tags articles
 // @Produce json
 // @Param slug path string true "Article slug"
@@ -1369,7 +1384,13 @@ func GetArticle(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "slug must be canonical")
 			return
 		}
-		rows, err := db.Select(r.Context(), conn, "articles", db.ArticleColumns, "`slug` = ?", slug)
+		// This endpoint is public and returns the FULL article body, so an
+		// anonymous caller is restricted to live content: knowing or guessing a
+		// slug must not hand out an unpublished draft or a soft-deleted article.
+		// The miss falls through to the same 404 as a nonexistent slug, so the
+		// response does not reveal that the article exists at all. Editors are
+		// identified by OptionalAuth on the route and still see everything.
+		rows, err := db.Select(r.Context(), conn, "articles", db.ArticleColumns, articleDetailCondition(r), slug)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -280,3 +280,29 @@ func TestArticleQueryFilters_EditorKeepsDraftAndArchivedFilters(t *testing.T) {
 		t.Fatalf("editor must keep the archived filter, got %q", joined)
 	}
 }
+
+// The single-article endpoint is public AND returns the full article body, so
+// the anonymous restriction matters more here than on the listing.
+func TestArticleDetailCondition_AnonymousSeesOnlyLiveArticles(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles/some-slug", nil)
+
+	got := articleDetailCondition(req)
+
+	if !strings.Contains(got, "`pub_date` IS NOT NULL") {
+		t.Fatalf("anonymous lookup must exclude drafts, got %q", got)
+	}
+	if !strings.Contains(got, "`archived_at` IS NULL") {
+		t.Fatalf("anonymous lookup must exclude archived articles, got %q", got)
+	}
+}
+
+func TestArticleDetailCondition_EditorSeesEverything(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles/some-slug", nil)
+	req = req.WithContext(middleware.ContextWithUser(req.Context(), &models.User{ID: 1, Role: models.RoleAdmin}))
+
+	got := articleDetailCondition(req)
+
+	if got != "`slug` = ?" {
+		t.Fatalf("editor lookup must not be narrowed, got %q", got)
+	}
+}

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -45,7 +45,7 @@ func Register(mux *http.ServeMux, conn *sql.DB, verifier *oidc.IDTokenVerifier, 
 	mux.Handle("GET /v1/authors/{slug}/articles", optionalAuth(handlers.GetAuthorArticles(conn)))
 
 	mux.Handle("GET /v1/articles", optionalAuth(handlers.GetArticles(conn)))
-	mux.Handle("GET /v1/articles/{slug}", handlers.GetArticle(conn))
+	mux.Handle("GET /v1/articles/{slug}", optionalAuth(handlers.GetArticle(conn)))
 	mux.Handle("GET /v1/articles/{slug}/comments", handlers.GetArticleComments(conn))
 	mux.Handle("POST /v1/articles/{slug}/comments", middleware.RateLimitByIP(5, time.Minute)(handlers.PostArticleComment(conn, spamChecker)))
 	mux.Handle("GET /v1/search", handlers.GetSearch(conn))


### PR DESCRIPTION
`GET /v1/articles/{slug}` is public and returns the **full article body**, but it looked articles up by slug alone:

```go
db.Select(ctx, conn, "articles", db.ArticleColumns, "`slug` = ?", slug)
```

Anyone who knew or guessed the slug of an unpublished draft or a soft-deleted article got the whole thing — title, content, authors, SEO fields.

This predates #112. That PR un-gated the *list* endpoints and pinned anonymous callers there to published, non-archived rows; the single-article endpoint was **already public** and was left alone, which I flagged at the time as out of scope. It is the more severe of the two, because the listing was excerpt-only while this returns the entire body.

## Fix

Anonymous callers are restricted to `pub_date IS NOT NULL AND archived_at IS NULL`. A miss falls through to the **existing 404** rather than a 403, so the response does not reveal that the slug exists. Editors are identified by `OptionalAuth` on the route — the mechanism #112 introduced — and still see drafts and archived articles, which the CMS preview needs.

## The Related block had the same hole

`GetRelatedArticlesBySlug` matched purely on vector distance with no publication filter, so a *published* article could surface drafts and soft-deleted articles as "related reading" to an anonymous reader. Fixed in the same response path.

That one is filtered **unconditionally**, not just for anonymous callers: linking to an unpublished article is wrong from the CMS preview too, so editors get the same live-content-only list. Flagging it explicitly since it is a behaviour change for logged-in users.

## Verification

`go build`, `go vet`, `go test ./...` pass; routes and docs agree on paths and auth for all 44 endpoints.

The condition is covered by unit tests both ways, and I checked the SQL against the dev database rather than only the generated string. It has 46 real drafts; for the draft slug `19-tips-for-the-class-of-2019-and-2020`:

| clause | rows returned |
| --- | --- |
| editor (`slug = ?`) | 1 |
| anonymous (`+ pub_date IS NOT NULL AND archived_at IS NULL`) | **0** |

So that draft is a 404 for the public and still reachable for an editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)