### PR TITLE
feat: manage sections and columns

### DIFF
--- a/frontend/src/pages/editArticleView.tsx
+++ b/frontend/src/pages/editArticleView.tsx
@@ -21,6 +21,7 @@ type ApiArticleDetail = {
   featured_image?: string
   categories?: Array<{
     name?: string
+    slug?: string
   }>
   authors?: Array<{
     id?: number
@@ -58,6 +59,14 @@ type ApiAuthor = {
   display_name: string
 }
 
+type TaxonomyItem = {
+  id: number
+  type: string
+  slug: string
+  canonical_title: string
+  parent_slug?: string | null
+}
+
 type AuthorsResponse = {
   authors?: ApiAuthor[]
   pagination?: {
@@ -71,6 +80,13 @@ type AuthorsResponse = {
 // The ETL pipeline normalizes the source, but this keeps the editor resilient.
 const normalizeCommentStatus = (raw: string | undefined): string =>
   (raw ?? "").trim().toLowerCase() === "closed" ? "closed" : "open"
+
+const slugifyCategory = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
 
 // ArticleView caches list results in sessionStorage keyed by query; clear those
 // entries so the list refetches after an article is created or edited.
@@ -151,7 +167,8 @@ function EditArticleView() {
   const [status, setStatus] = useState<EditableStatus>("draft")
   const [commentStatus, setCommentStatus] = useState("open")
   const [photoURL, setPhotoURL] = useState("")
-  const [categoriesInput, setCategoriesInput] = useState("")
+  const [selectedCategorySlugs, setSelectedCategorySlugs] = useState<string[]>([])
+  const [legacyCategoryTitlesBySlug, setLegacyCategoryTitlesBySlug] = useState<Record<string, string>>({})
   const [keyphrase, setKeyphrase] = useState("")
   const [metaDescription, setMetaDescription] = useState("")
   const [seoTitle, setSeoTitle] = useState("")
@@ -160,6 +177,9 @@ function EditArticleView() {
   const [authors, setAuthors] = useState<ApiAuthor[]>([])
   const [authorsLoading, setAuthorsLoading] = useState(false)
   const [authorsError, setAuthorsError] = useState<string | null>(null)
+  const [taxonomyItems, setTaxonomyItems] = useState<TaxonomyItem[]>([])
+  const [taxonomyLoading, setTaxonomyLoading] = useState(false)
+  const [taxonomyError, setTaxonomyError] = useState<string | null>(null)
   const [mediaItems, setMediaItems] = useState<MediaItem[]>([])
   const [mediaLoading, setMediaLoading] = useState(false)
   const [mediaError, setMediaError] = useState<string | null>(null)
@@ -200,12 +220,19 @@ function EditArticleView() {
           setStatus((payload.status ?? "draft").toLowerCase() === "published" ? "published" : "draft")
           setCommentStatus(normalizeCommentStatus(payload.comment_status))
           setPhotoURL(payload.featured_image ?? "")
-          setCategoriesInput(
-            (payload.categories ?? [])
-              .map((category) => (category.name ?? "").trim())
-              .filter((name) => name.length > 0)
-              .join(", "),
-          )
+          const legacyCategories: Record<string, string> = {}
+          const categorySlugs = (payload.categories ?? [])
+            .map((category) => {
+              const name = (category.name ?? "").trim()
+              const categorySlug = slugifyCategory(category.slug ?? name)
+              if (categorySlug && name) {
+                legacyCategories[categorySlug] = name
+              }
+              return categorySlug
+            })
+            .filter((categorySlug) => categorySlug.length > 0)
+          setLegacyCategoryTitlesBySlug(legacyCategories)
+          setSelectedCategorySlugs([...new Set(categorySlugs)])
           const firstAuthorId = payload.authors?.[0]?.id
           setSelectedAuthorId(typeof firstAuthorId === "number" ? String(firstAuthorId) : "")
         }
@@ -329,6 +356,44 @@ function EditArticleView() {
   }, [apiFetch])
 
   useEffect(() => {
+    let cancelled = false
+
+    const fetchTaxonomy = async () => {
+      setTaxonomyLoading(true)
+      setTaxonomyError(null)
+      try {
+        const response = await apiFetch("/v1/taxonomy")
+        if (!response.ok) {
+          throw new Error(`Taxonomy request failed (${response.status})`)
+        }
+        const payload = (await response.json()) as TaxonomyItem[]
+        if (!cancelled) {
+          setTaxonomyItems(
+            (Array.isArray(payload) ? payload : []).filter(
+              (item) => item.type === "section" || item.type === "subsection",
+            ),
+          )
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : "Unable to load sections."
+          setTaxonomyError(message)
+          setTaxonomyItems([])
+        }
+      } finally {
+        if (!cancelled) {
+          setTaxonomyLoading(false)
+        }
+      }
+    }
+
+    void fetchTaxonomy()
+    return () => {
+      cancelled = true
+    }
+  }, [apiFetch])
+
+  useEffect(() => {
     if (!imagePickerOpen) return
     let cancelled = false
 
@@ -370,9 +435,13 @@ function EditArticleView() {
     setSuccessMessage(null)
 
     const effectiveStatus = nextStatus ?? status
-    const categories = categoriesInput
-      .split(",")
-      .map((category) => category.trim())
+    const taxonomyBySlug = new Map(taxonomyItems.map((item) => [item.slug, item]))
+    const categories = selectedCategorySlugs
+      .map((categorySlug) => (
+        taxonomyBySlug.get(categorySlug)?.canonical_title
+        ?? legacyCategoryTitlesBySlug[categorySlug]
+        ?? categorySlug
+      ).trim())
       .filter((category) => category.length > 0)
 
     try {
@@ -456,6 +525,43 @@ function EditArticleView() {
   const selectClass = "w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition"
   const labelClass = "flex flex-col gap-1.5"
   const labelTextClass = "text-xs font-semibold text-muted-foreground uppercase tracking-wide"
+  const taxonomyBySlug = useMemo(() => new Map(taxonomyItems.map((item) => [item.slug, item])), [taxonomyItems])
+  const categoryGroups = useMemo(() => {
+    const sections = taxonomyItems
+      .filter((item) => item.type === "section")
+      .sort((left, right) => left.canonical_title.localeCompare(right.canonical_title))
+    const subsectionsByParent = new Map<string, TaxonomyItem[]>()
+    for (const item of taxonomyItems) {
+      if (item.type !== "subsection") continue
+      const parentSlug = item.parent_slug ?? ""
+      if (!subsectionsByParent.has(parentSlug)) {
+        subsectionsByParent.set(parentSlug, [])
+      }
+      subsectionsByParent.get(parentSlug)?.push(item)
+    }
+    for (const subsections of subsectionsByParent.values()) {
+      subsections.sort((left, right) => left.canonical_title.localeCompare(right.canonical_title))
+    }
+    return sections.map((section) => ({
+      section,
+      subsections: subsectionsByParent.get(section.slug) ?? [],
+    }))
+  }, [taxonomyItems])
+  const legacyCategoryChoices = useMemo(() => (
+    selectedCategorySlugs
+      .filter((categorySlug) => !taxonomyBySlug.has(categorySlug))
+      .map((categorySlug) => ({
+        slug: categorySlug,
+        title: legacyCategoryTitlesBySlug[categorySlug] ?? categorySlug,
+      }))
+  ), [legacyCategoryTitlesBySlug, selectedCategorySlugs, taxonomyBySlug])
+  const toggleCategory = (categorySlug: string) => {
+    setSelectedCategorySlugs((current) => (
+      current.includes(categorySlug)
+        ? current.filter((slugValue) => slugValue !== categorySlug)
+        : [...current, categorySlug]
+    ))
+  }
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -621,10 +727,67 @@ function EditArticleView() {
               </select>
             </label>
 
-            <label className={labelClass}>
-              <span className={labelTextClass}>Categories (comma-separated)</span>
-              <input className={inputClass} onChange={(e) => setCategoriesInput(e.target.value)} type="text" value={categoriesInput} />
-            </label>
+            <div className={labelClass}>
+              <span className={labelTextClass}>Sections</span>
+              <div className="max-h-64 overflow-y-auto rounded-lg border border-border bg-background p-2">
+                {taxonomyLoading ? (
+                  <p className="px-2 py-3 text-xs text-muted-foreground">Loading sections...</p>
+                ) : categoryGroups.length === 0 && legacyCategoryChoices.length === 0 ? (
+                  <p className="px-2 py-3 text-xs text-muted-foreground">No sections available.</p>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {categoryGroups.map(({ section, subsections }) => (
+                      <div key={section.slug} className="flex flex-col gap-1">
+                        <label className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 cursor-pointer">
+                          <input
+                            checked={selectedCategorySlugs.includes(section.slug)}
+                            className="h-4 w-4 rounded border-border"
+                            onChange={() => toggleCategory(section.slug)}
+                            type="checkbox"
+                          />
+                          <span className="font-medium text-foreground">{section.canonical_title}</span>
+                        </label>
+                        {subsections.length > 0 ? (
+                          <div className="ml-6 flex flex-col gap-0.5">
+                            {subsections.map((subsection) => (
+                              <label key={subsection.slug} className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 cursor-pointer">
+                                <input
+                                  checked={selectedCategorySlugs.includes(subsection.slug)}
+                                  className="h-4 w-4 rounded border-border"
+                                  onChange={() => toggleCategory(subsection.slug)}
+                                  type="checkbox"
+                                />
+                                <span className="text-muted-foreground">{subsection.canonical_title}</span>
+                              </label>
+                            ))}
+                          </div>
+                        ) : null}
+                      </div>
+                    ))}
+                    {legacyCategoryChoices.length > 0 ? (
+                      <div className="border-t border-border pt-2">
+                        {legacyCategoryChoices.map((category) => (
+                          <label key={category.slug} className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 cursor-pointer">
+                            <input
+                              checked={selectedCategorySlugs.includes(category.slug)}
+                              className="h-4 w-4 rounded border-border"
+                              onChange={() => toggleCategory(category.slug)}
+                              type="checkbox"
+                            />
+                            <span className="text-muted-foreground">{category.title}</span>
+                          </label>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                )}
+              </div>
+              {taxonomyError ? (
+                <p className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+                  {taxonomyError}
+                </p>
+              ) : null}
+            </div>
 
             <label className={labelClass}>
               <span className={labelTextClass}>Focus Keyphrase</span>

--- a/frontend/src/pages/sectionsView.tsx
+++ b/frontend/src/pages/sectionsView.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { Search, Plus, Pencil, Trash2, RefreshCw } from "lucide-react"
+import { Columns3, Pencil, Plus, RefreshCw, Search, Trash2, X } from "lucide-react"
 import { useApiFetch } from "../hooks/useApiFetch"
+
+type TaxonomyKind = "section" | "subsection"
 
 type TaxonomyItem = {
   id: number
@@ -12,16 +14,23 @@ type TaxonomyItem = {
 }
 
 type SectionRow = {
-  section: {
-    id: number
-    name: string
-    slug: string
-    parent: string | null
-    articles: number | null
-  }
+  item: TaxonomyItem
+  parentTitle: string | null
+  childCount: number
   isChild: boolean
   isLast: boolean
 }
+
+type FormState = {
+  type: TaxonomyKind
+  canonicalTitle: string
+  slug: string
+  parentSlug: string
+}
+
+type EditorState =
+  | { mode: "create"; label: string }
+  | { mode: "edit"; item: TaxonomyItem; label: string }
 
 const SECTION_ORDER = [
   "news",
@@ -33,6 +42,20 @@ const SECTION_ORDER = [
   "special-editions",
 ]
 
+const emptyForm: FormState = {
+  type: "section",
+  canonicalTitle: "",
+  slug: "",
+  parentSlug: "",
+}
+
+const slugify = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
 async function readErrorMessage(response: Response) {
   try {
     const body = await response.json() as { error?: string }
@@ -42,12 +65,23 @@ async function readErrorMessage(response: Response) {
   }
 }
 
+function typeLabel(item: TaxonomyItem) {
+  if (item.type === "section") return "Section"
+  if (item.parent_slug === "columns") return "Column"
+  return "Subsection"
+}
+
 export default function SectionsView() {
   const apiFetch = useApiFetch()
   const [search, setSearch] = useState("")
   const [items, setItems] = useState<TaxonomyItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [editor, setEditor] = useState<EditorState | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<TaxonomyItem | null>(null)
+  const [form, setForm] = useState<FormState>(emptyForm)
+  const [slugTouched, setSlugTouched] = useState(false)
 
   const loadSections = useCallback(async () => {
     setIsLoading(true)
@@ -72,14 +106,11 @@ export default function SectionsView() {
   }, [apiFetch])
 
   useEffect(() => {
-    const handle = window.setTimeout(() => {
-      void loadSections()
-    }, 0)
-    return () => window.clearTimeout(handle)
+    void loadSections()
   }, [loadSections])
 
-  const rows = useMemo(() => {
-    const parents = items
+  const parentSections = useMemo(() => {
+    return items
       .filter((item) => item.type === "section")
       .sort((left, right) => {
         const leftIndex = SECTION_ORDER.indexOf(left.slug)
@@ -89,11 +120,14 @@ export default function SectionsView() {
           if (rightIndex === -1) return -1
           return leftIndex - rightIndex
         }
-        return left.id - right.id
+        return left.canonical_title.localeCompare(right.canonical_title)
       })
+  }, [items])
+
+  const rows = useMemo(() => {
     const children = items
       .filter((item) => item.type === "subsection")
-      .sort((left, right) => left.id - right.id)
+      .sort((left, right) => left.canonical_title.localeCompare(right.canonical_title))
 
     const childrenByParent = new Map<string, TaxonomyItem[]>()
     for (const child of children) {
@@ -105,52 +139,190 @@ export default function SectionsView() {
     }
 
     const nextRows: SectionRow[] = []
-    for (const parent of parents) {
-      const parentName = parent.canonical_title
+    const renderedChildren = new Set<number>()
+
+    for (const parent of parentSections) {
       const parentChildren = childrenByParent.get(parent.slug) ?? []
       nextRows.push({
-        section: {
-          id: parent.id,
-          name: parentName,
-          slug: parent.slug,
-          parent: null,
-          articles: parent.article_count ?? 0,
-        },
+        item: parent,
+        parentTitle: null,
+        childCount: parentChildren.length,
         isChild: false,
         isLast: false,
       })
       parentChildren.forEach((child, index) => {
+        renderedChildren.add(child.id)
         nextRows.push({
-          section: {
-            id: child.id,
-            name: child.canonical_title,
-            slug: child.slug,
-            parent: parentName,
-            articles: child.article_count ?? 0,
-          },
+          item: child,
+          parentTitle: parent.canonical_title,
+          childCount: 0,
           isChild: true,
           isLast: index === parentChildren.length - 1,
         })
       })
     }
 
-    return nextRows
-  }, [items])
+    for (const child of children) {
+      if (renderedChildren.has(child.id)) continue
+      nextRows.push({
+        item: child,
+        parentTitle: child.parent_slug ? `Unknown parent: ${child.parent_slug}` : "No parent",
+        childCount: 0,
+        isChild: true,
+        isLast: true,
+      })
+    }
 
-  const filtered = useMemo(() => (
-    rows.filter(({ section }) =>
-      section.name.toLowerCase().includes(search.toLowerCase())
-      || section.slug.toLowerCase().includes(search.toLowerCase()),
+    return nextRows
+  }, [items, parentSections])
+
+  const filtered = useMemo(() => {
+    const query = search.toLowerCase().trim()
+    if (!query) return rows
+    return rows.filter(({ item, parentTitle }) =>
+      item.canonical_title.toLowerCase().includes(query)
+      || item.slug.toLowerCase().includes(query)
+      || typeLabel(item).toLowerCase().includes(query)
+      || (parentTitle ?? "").toLowerCase().includes(query),
     )
-  ), [rows, search])
+  }, [rows, search])
+
+  const openCreate = (type: TaxonomyKind, parentSlug = "") => {
+    const parentExists = parentSlug && parentSections.some((section) => section.slug === parentSlug)
+    const nextParent = type === "subsection"
+      ? (parentExists ? parentSlug : parentSections.some((section) => section.slug === "columns") ? "columns" : parentSections[0]?.slug ?? "")
+      : ""
+    setForm({ ...emptyForm, type, parentSlug: nextParent })
+    setSlugTouched(false)
+    setError(null)
+    setEditor({ mode: "create", label: nextParent === "columns" ? "Add Column" : type === "section" ? "Add Section" : "Add Subsection" })
+  }
+
+  const openEdit = (item: TaxonomyItem) => {
+    if (item.type !== "section" && item.type !== "subsection") return
+    setForm({
+      type: item.type,
+      canonicalTitle: item.canonical_title,
+      slug: item.slug,
+      parentSlug: item.parent_slug ?? "",
+    })
+    setSlugTouched(true)
+    setError(null)
+    setEditor({ mode: "edit", item, label: `Edit ${typeLabel(item)}` })
+  }
+
+  const closeEditor = () => {
+    if (isSaving) return
+    setEditor(null)
+    setForm(emptyForm)
+    setSlugTouched(false)
+  }
+
+  const updateTitle = (value: string) => {
+    setForm((current) => ({
+      ...current,
+      canonicalTitle: value,
+      slug: slugTouched ? current.slug : slugify(value),
+    }))
+  }
+
+  const updateType = (type: TaxonomyKind) => {
+    setForm((current) => ({
+      ...current,
+      type,
+      parentSlug: type === "subsection"
+        ? current.parentSlug || (parentSections.some((section) => section.slug === "columns") ? "columns" : parentSections[0]?.slug ?? "")
+        : "",
+    }))
+  }
+
+  const saveTaxonomy = async () => {
+    if (!editor) return
+    const canonicalTitle = form.canonicalTitle.trim()
+    const slug = slugify(form.slug)
+    const parentSlug = form.type === "subsection" ? form.parentSlug.trim() : ""
+
+    if (!canonicalTitle) {
+      setError("Name is required.")
+      return
+    }
+    if (!slug) {
+      setError("Slug is required.")
+      return
+    }
+    if (form.type === "subsection" && !parentSlug) {
+      setError("Choose a parent section.")
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+    try {
+      const body = {
+        type: form.type,
+        slug,
+        canonical_title: canonicalTitle,
+        parent_slug: form.type === "subsection" ? parentSlug : null,
+      }
+
+      const response = editor.mode === "create"
+        ? await apiFetch("/v1/taxonomy", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        })
+        : await apiFetch(`/v1/taxonomy/${encodeURIComponent(editor.item.type)}/${encodeURIComponent(editor.item.slug)}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            slug,
+            canonical_title: canonicalTitle,
+            parent_slug: form.type === "subsection" ? parentSlug : null,
+          }),
+        })
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response))
+      }
+      setEditor(null)
+      setForm(emptyForm)
+      setSlugTouched(false)
+      await loadSections()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to save taxonomy item")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const deleteTaxonomy = async () => {
+    if (!deleteTarget) return
+    setIsSaving(true)
+    setError(null)
+    try {
+      const response = await apiFetch(`/v1/taxonomy/${encodeURIComponent(deleteTarget.type)}/${encodeURIComponent(deleteTarget.slug)}`, {
+        method: "DELETE",
+      })
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response))
+      }
+      setDeleteTarget(null)
+      await loadSections()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to delete taxonomy item")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+  const hasColumnsSection = parentSections.some((section) => section.slug === "columns")
 
   return (
     <div className="flex flex-col gap-6 p-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-foreground">Sections</h1>
           <p className="text-sm text-muted-foreground mt-0.5">
-            {isLoading ? "Loading..." : `${items.length} taxonomy items`}
+            {isLoading ? "Loading..." : `${parentSections.length} sections, ${items.filter((item) => item.type === "subsection").length} subsections`}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -163,10 +335,19 @@ export default function SectionsView() {
             Refresh
           </button>
           <button
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-colors opacity-60 cursor-not-allowed"
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm font-medium hover:bg-muted/40 transition-colors disabled:opacity-50"
             type="button"
-            disabled
-            title="Editing is not wired on this screen yet."
+            disabled={!hasColumnsSection}
+            title={hasColumnsSection ? "Add a column under Columns" : "Create the Columns section before adding a column."}
+            onClick={() => openCreate("subsection", "columns")}
+          >
+            <Columns3 className="w-4 h-4" />
+            Add Column
+          </button>
+          <button
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+            type="button"
+            onClick={() => openCreate("section")}
           >
             <Plus className="w-4 h-4" />
             Add Section
@@ -178,10 +359,10 @@ export default function SectionsView() {
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
         <input
           className="w-full pl-9 pr-4 py-2 rounded-lg border border-border bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition"
-          placeholder="Search sections..."
+          placeholder="Search sections, columns, or slugs..."
           type="search"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(event) => setSearch(event.target.value)}
         />
       </div>
 
@@ -195,6 +376,7 @@ export default function SectionsView() {
           <thead>
             <tr className="border-b border-border bg-muted/40">
               <th className="text-left px-4 py-3 font-semibold text-muted-foreground">Name</th>
+              <th className="text-left px-4 py-3 font-semibold text-muted-foreground">Type</th>
               <th className="text-left px-4 py-3 font-semibold text-muted-foreground">Slug</th>
               <th className="text-left px-4 py-3 font-semibold text-muted-foreground">Articles</th>
               <th className="text-right px-4 py-3 font-semibold text-muted-foreground">Actions</th>
@@ -203,63 +385,195 @@ export default function SectionsView() {
           <tbody>
             {isLoading ? (
               <tr>
-                <td className="px-4 py-8 text-center text-muted-foreground" colSpan={4}>Loading sections...</td>
+                <td className="px-4 py-8 text-center text-muted-foreground" colSpan={5}>Loading sections...</td>
               </tr>
             ) : filtered.length === 0 ? (
               <tr>
-                <td className="px-4 py-8 text-center text-muted-foreground" colSpan={4}>No sections found.</td>
+                <td className="px-4 py-8 text-center text-muted-foreground" colSpan={5}>No sections found.</td>
               </tr>
             ) : (
-              filtered.map(({ section: s, isChild, isLast }) => (
-                <tr key={`${s.parent ?? "root"}-${s.slug}`} className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors">
-                  <td className="px-4 py-3 font-medium text-foreground">
-                    {isChild ? (
-                      <span className="flex items-start gap-1.5">
-                        <span className="flex flex-col items-center w-4 shrink-0 mt-0.5">
-                          <span className="w-px h-2 bg-border" />
-                          <span className="w-3 h-px bg-border" />
-                          {!isLast && <span className="w-px flex-1 bg-transparent" />}
+              filtered.map(({ item, parentTitle, childCount, isChild, isLast }) => {
+                const articleCount = item.article_count ?? 0
+                const canDelete = articleCount === 0 && childCount === 0
+                const deleteTitle = articleCount > 0
+                  ? "Cannot delete while articles use this item."
+                  : childCount > 0
+                    ? "Cannot delete while subsections use this section."
+                    : `Delete ${item.canonical_title}`
+
+                return (
+                  <tr key={`${item.type}-${item.slug}-${item.id}`} className="border-b border-border last:border-0 hover:bg-muted/30 transition-colors">
+                    <td className="px-4 py-3 font-medium text-foreground">
+                      {isChild ? (
+                        <span className="flex items-start gap-1.5">
+                          <span className="flex flex-col items-center w-4 shrink-0 mt-0.5">
+                            <span className="w-px h-2 bg-border" />
+                            <span className="w-3 h-px bg-border" />
+                            {!isLast && <span className="w-px flex-1 bg-transparent" />}
+                          </span>
+                          <span>
+                            <span className="text-muted-foreground">{item.canonical_title}</span>
+                            {parentTitle ? <span className="block text-xs text-muted-foreground/70">{parentTitle}</span> : null}
+                          </span>
                         </span>
-                        <span className="text-muted-foreground">{s.name}</span>
+                      ) : (
+                        <span>
+                          {item.canonical_title}
+                          {childCount > 0 ? <span className="ml-2 text-xs text-muted-foreground">({childCount})</span> : null}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{typeLabel(item)}</td>
+                    <td className="px-4 py-3 text-muted-foreground font-mono text-xs">{item.slug}</td>
+                    <td className="px-4 py-3">
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
+                        {articleCount.toLocaleString()}
                       </span>
-                    ) : (
-                      s.name
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground font-mono text-xs">{s.slug}</td>
-                  <td className="px-4 py-3">
-                    <span
-                      className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary"
-                    >
-                      {s.articles?.toLocaleString() ?? "0"}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center justify-end gap-1">
-                      <button
-                        className="p-1.5 rounded-lg text-muted-foreground transition-colors opacity-50 cursor-not-allowed"
-                        type="button"
-                        disabled
-                        title="Editing is not wired on this screen yet."
-                      >
-                        <Pencil className="w-4 h-4" />
-                      </button>
-                      <button
-                        className="p-1.5 rounded-lg text-muted-foreground transition-colors opacity-50 cursor-not-allowed"
-                        type="button"
-                        disabled
-                        title="Deletion is not wired on this screen yet."
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          className="p-1.5 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                          type="button"
+                          title={`Edit ${item.canonical_title}`}
+                          onClick={() => openEdit(item)}
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          className="p-1.5 rounded-lg text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                          type="button"
+                          disabled={!canDelete}
+                          title={deleteTitle}
+                          onClick={() => setDeleteTarget(item)}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })
             )}
           </tbody>
         </table>
       </div>
+
+      {editor ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" role="dialog" aria-modal="true">
+          <div className="w-full max-w-lg rounded-xl border border-border bg-card shadow-xl">
+            <div className="flex items-center justify-between border-b border-border px-5 py-4">
+              <h2 className="text-base font-semibold text-foreground">{editor.label}</h2>
+              <button className="p-1.5 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground" type="button" onClick={closeEditor}>
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="flex flex-col gap-4 px-5 py-4">
+              {editor.mode === "create" ? (
+                <label className="flex flex-col gap-1.5">
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Type</span>
+                  <select
+                    className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    value={form.type}
+                    onChange={(event) => updateType(event.target.value as TaxonomyKind)}
+                  >
+                    <option value="section">Section</option>
+                    <option value="subsection">Subsection / Column</option>
+                  </select>
+                </label>
+              ) : null}
+
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Name</span>
+                <input
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                  value={form.canonicalTitle}
+                  onChange={(event) => updateTitle(event.target.value)}
+                />
+              </label>
+
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Slug</span>
+                <input
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-background font-mono text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                  value={form.slug}
+                  onChange={(event) => {
+                    setSlugTouched(true)
+                    setForm((current) => ({ ...current, slug: slugify(event.target.value) }))
+                  }}
+                />
+              </label>
+
+              {form.type === "subsection" ? (
+                <label className="flex flex-col gap-1.5">
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Parent Section</span>
+                  <select
+                    className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    value={form.parentSlug}
+                    onChange={(event) => setForm((current) => ({ ...current, parentSlug: event.target.value }))}
+                  >
+                    <option value="">Choose a section</option>
+                    {parentSections.map((section) => (
+                      <option key={section.slug} value={section.slug}>
+                        {section.canonical_title}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+            </div>
+            <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-4">
+              <button
+                className="px-4 py-2 rounded-lg border border-border text-sm font-medium hover:bg-muted/40 transition-colors"
+                type="button"
+                disabled={isSaving}
+                onClick={closeEditor}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+                type="button"
+                disabled={isSaving}
+                onClick={() => void saveTaxonomy()}
+              >
+                {isSaving ? "Saving..." : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {deleteTarget ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" role="dialog" aria-modal="true">
+          <div className="w-full max-w-md rounded-xl border border-border bg-card shadow-xl">
+            <div className="border-b border-border px-5 py-4">
+              <h2 className="text-base font-semibold text-foreground">Delete {typeLabel(deleteTarget)}</h2>
+            </div>
+            <div className="px-5 py-4 text-sm text-muted-foreground">
+              Delete <span className="font-medium text-foreground">{deleteTarget.canonical_title}</span>? This only works for empty items with no articles or child sections.
+            </div>
+            <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-4">
+              <button
+                className="px-4 py-2 rounded-lg border border-border text-sm font-medium hover:bg-muted/40 transition-colors"
+                type="button"
+                disabled={isSaving}
+                onClick={() => setDeleteTarget(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-4 py-2 rounded-lg bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 transition-colors disabled:opacity-50"
+                type="button"
+                disabled={isSaving}
+                onClick={() => void deleteTaxonomy()}
+              >
+                {isSaving ? "Deleting..." : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/server/internal/handlers/article_params.go
+++ b/server/internal/handlers/article_params.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
 	db "server/internal/database"
+	"server/internal/models"
 )
 
 var allowedSubsectionsBySection = map[string]map[string]struct{}{
@@ -47,7 +50,7 @@ var allowedSubsectionsBySection = map[string]map[string]struct{}{
 	},
 }
 
-func normalizeAndValidateArticleParams(params ArticleParams) (ArticleParams, error) {
+func normalizeAndValidateArticleParams(ctx context.Context, conn *sql.DB, params ArticleParams) (ArticleParams, error) {
 	params.AuthorSlug = strings.TrimSpace(params.AuthorSlug)
 	params.Section = normalizeSectionSlug(params.Section)
 	params.Subsection = strings.ToLower(strings.TrimSpace(params.Subsection))
@@ -57,13 +60,20 @@ func normalizeAndValidateArticleParams(params ArticleParams) (ArticleParams, err
 	}
 
 	if params.Section != "" {
-		if _, ok := allowedSubsectionsBySection[params.Section]; !ok {
+		ok, err := taxonomySectionExists(ctx, conn, params.Section)
+		if err != nil {
+			return ArticleParams{}, err
+		}
+		if !ok {
 			return ArticleParams{}, fmt.Errorf("invalid section_slug")
 		}
 	}
 
 	if params.Subsection != "" {
-		parentSection, ok := sectionForSubsection(params.Subsection)
+		parentSection, ok, err := parentSectionForSubsection(ctx, conn, params.Subsection)
+		if err != nil {
+			return ArticleParams{}, err
+		}
 		if !ok {
 			return ArticleParams{}, fmt.Errorf("invalid subsection_slug")
 		}
@@ -81,11 +91,43 @@ func normalizeSectionSlug(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
 
-func sectionForSubsection(subsection string) (string, bool) {
+func taxonomySectionExists(ctx context.Context, conn *sql.DB, section string) (bool, error) {
+	if conn == nil {
+		_, ok := allowedSubsectionsBySection[section]
+		return ok, nil
+	}
+
+	var exists int
+	err := conn.QueryRowContext(ctx,
+		"SELECT 1 FROM site_taxonomy WHERE kind = ? AND slug = ? LIMIT 1",
+		string(models.TaxonomyTypeSection), section,
+	).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func parentSectionForSubsection(ctx context.Context, conn *sql.DB, subsection string) (string, bool, error) {
+	if conn != nil {
+		var parent sql.NullString
+		err := conn.QueryRowContext(ctx,
+			"SELECT parent_slug FROM site_taxonomy WHERE kind = ? AND slug = ? LIMIT 1",
+			string(models.TaxonomyTypeSubsection), subsection,
+		).Scan(&parent)
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		if err != nil {
+			return "", false, err
+		}
+		return parent.String, parent.Valid && parent.String != "", nil
+	}
+
 	for section, subsections := range allowedSubsectionsBySection {
 		if _, ok := subsections[subsection]; ok {
-			return section, true
+			return section, true, nil
 		}
 	}
-	return "", false
+	return "", false, nil
 }

--- a/server/internal/handlers/article_params_test.go
+++ b/server/internal/handlers/article_params_test.go
@@ -1,6 +1,9 @@
 package handlers
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestNormalizeSectionSlug(t *testing.T) {
 	cases := []struct {
@@ -21,9 +24,21 @@ func TestNormalizeSectionSlug(t *testing.T) {
 }
 
 func TestNormalizeAndValidateArticleParams_RejectsUnknownSectionSlug(t *testing.T) {
-	if _, err := normalizeAndValidateArticleParams(ArticleParams{
+	if _, err := normalizeAndValidateArticleParams(context.Background(), nil, ArticleParams{
 		Section: "candp",
 	}); err == nil {
 		t.Fatal("expected error for unknown section_slug")
+	}
+}
+
+func TestNormalizeAndValidateArticleParams_FallbackAllowsKnownColumn(t *testing.T) {
+	got, err := normalizeAndValidateArticleParams(context.Background(), nil, ArticleParams{
+		Subsection: "the-love-triangle",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Section != "columns" {
+		t.Fatalf("section = %q, want columns", got.Section)
 	}
 }

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -828,7 +828,7 @@ func GetAuthorArticles(conn *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		params, err := normalizeAndValidateArticleParams(ArticleParams{
+		params, err := normalizeAndValidateArticleParams(r.Context(), conn, ArticleParams{
 			AuthorSlug: slug,
 			Section:    r.URL.Query().Get("section_slug"),
 			Subsection: r.URL.Query().Get("subsection_slug"),
@@ -899,7 +899,7 @@ func GetAuthorArticles(conn *sql.DB) http.HandlerFunc {
 // @Router /v1/articles [get]
 func GetArticles(conn *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		params, err := normalizeAndValidateArticleParams(ArticleParams{
+		params, err := normalizeAndValidateArticleParams(r.Context(), conn, ArticleParams{
 			AuthorSlug: r.URL.Query().Get("author_slug"),
 			Section:    r.URL.Query().Get("section_slug"),
 			Subsection: r.URL.Query().Get("subsection_slug"),
@@ -956,7 +956,7 @@ func GetArticles(conn *sql.DB) http.HandlerFunc {
 // @Router /v1/sections/{section_slug}/articles [get]
 func GetSectionArticles(conn *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		params, err := normalizeAndValidateArticleParams(ArticleParams{
+		params, err := normalizeAndValidateArticleParams(r.Context(), conn, ArticleParams{
 			AuthorSlug: r.URL.Query().Get("author_slug"),
 			Section:    r.PathValue("section_slug"),
 			Subsection: r.URL.Query().Get("subsection_slug"),
@@ -1031,7 +1031,7 @@ func GetSectionArticles(conn *sql.DB) http.HandlerFunc {
 // @Router /v1/subsections/{subsection_slug}/articles [get]
 func GetSubsectionArticles(conn *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		params, err := normalizeAndValidateArticleParams(ArticleParams{
+		params, err := normalizeAndValidateArticleParams(r.Context(), conn, ArticleParams{
 			AuthorSlug: r.URL.Query().Get("author_slug"),
 			Section:    r.URL.Query().Get("section_slug"),
 			Subsection: r.PathValue("subsection_slug"),

--- a/server/internal/handlers/taxonomy.go
+++ b/server/internal/handlers/taxonomy.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -33,6 +34,68 @@ func scanTaxonomyRow(row interface{ Scan(...any) error }) (models.TaxonomyItem, 
 		item.ParentSlug = &s
 	}
 	return item, nil
+}
+
+func taxonomyItemArticleCount(ctx context.Context, conn *sql.DB, taxType, slug string) (int64, error) {
+	var count int64
+	err := conn.QueryRowContext(ctx,
+		"SELECT article_count FROM site_taxonomy WHERE kind = ? AND slug = ?",
+		taxType, slug,
+	).Scan(&count)
+	return count, err
+}
+
+func taxonomyItemExists(ctx context.Context, conn *sql.DB, taxType, slug string) (bool, error) {
+	var exists int
+	err := conn.QueryRowContext(ctx,
+		"SELECT 1 FROM site_taxonomy WHERE kind = ? AND slug = ? LIMIT 1",
+		taxType, slug,
+	).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func taxonomySectionHasChildren(ctx context.Context, conn *sql.DB, sectionSlug string) (bool, error) {
+	var exists int
+	err := conn.QueryRowContext(ctx,
+		"SELECT 1 FROM site_taxonomy WHERE kind = ? AND parent_slug = ? LIMIT 1",
+		string(models.TaxonomyTypeSubsection), sectionSlug,
+	).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func validateTaxonomyParent(ctx context.Context, conn *sql.DB, taxType string, parentSlug *string) (any, error) {
+	if parentSlug == nil || strings.TrimSpace(*parentSlug) == "" {
+		if taxType == string(models.TaxonomyTypeSubsection) {
+			return nil, fmt.Errorf("parent_slug is required for subsections")
+		}
+		return nil, nil
+	}
+
+	parent := strings.TrimSpace(*parentSlug)
+	if !isValidCanonicalSlug(parent) {
+		return nil, fmt.Errorf("parent_slug must be canonical")
+	}
+	if taxType != string(models.TaxonomyTypeSubsection) {
+		return nil, fmt.Errorf("parent_slug is only allowed for subsections")
+	}
+	if conn == nil {
+		return parent, nil
+	}
+
+	exists, err := taxonomyItemExists(ctx, conn, string(models.TaxonomyTypeSection), parent)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("parent_slug must reference an existing section")
+	}
+	return parent, nil
 }
 
 // @Summary List taxonomy items
@@ -159,12 +222,10 @@ func PostTaxonomy(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "canonical_title is required")
 			return
 		}
-		if body.ParentSlug != nil {
-			ps := strings.TrimSpace(*body.ParentSlug)
-			if ps != "" && !isValidCanonicalSlug(ps) {
-				writeError(w, http.StatusBadRequest, "parent_slug must be canonical")
-				return
-			}
+		parentSlug, err := validateTaxonomyParent(r.Context(), conn, taxType, body.ParentSlug)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 
 		var nextID int64
@@ -173,12 +234,7 @@ func PostTaxonomy(conn *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		var parentSlug any
-		if body.ParentSlug != nil && strings.TrimSpace(*body.ParentSlug) != "" {
-			parentSlug = strings.TrimSpace(*body.ParentSlug)
-		}
-
-		_, err := db.Insert(r.Context(), conn, "site_taxonomy",
+		_, err = db.Insert(r.Context(), conn, "site_taxonomy",
 			[]string{"id", "kind", "slug", "canonical_title", "parent_slug", "article_count"},
 			nextID, taxType, slug, title, parentSlug, 0,
 		)
@@ -242,17 +298,36 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			}
 		}
 
-		if body.ParentSlug != nil {
-			ps := strings.TrimSpace(*body.ParentSlug)
-			if ps != "" && !isValidCanonicalSlug(ps) {
-				writeError(w, http.StatusBadRequest, "parent_slug must be canonical")
+		parentSlug, err := validateTaxonomyParent(r.Context(), conn, taxType, body.ParentSlug)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if newSlug != slug && conn != nil {
+			count, err := taxonomyItemArticleCount(r.Context(), conn, taxType, slug)
+			if err == sql.ErrNoRows {
+				writeError(w, http.StatusNotFound, "taxonomy item not found")
 				return
 			}
-		}
-
-		var parentSlug any
-		if body.ParentSlug != nil && strings.TrimSpace(*body.ParentSlug) != "" {
-			parentSlug = strings.TrimSpace(*body.ParentSlug)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if count > 0 {
+				writeError(w, http.StatusBadRequest, "slug cannot be changed while articles use this taxonomy item")
+				return
+			}
+			if taxType == string(models.TaxonomyTypeSection) {
+				hasChildren, err := taxonomySectionHasChildren(r.Context(), conn, slug)
+				if err != nil {
+					writeError(w, http.StatusInternalServerError, err.Error())
+					return
+				}
+				if hasChildren {
+					writeError(w, http.StatusBadRequest, "section slug cannot be changed while subsections use it")
+					return
+				}
+			}
 		}
 
 		result, err := db.Update(r.Context(), conn, "site_taxonomy",
@@ -304,6 +379,32 @@ func DeleteTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 		if !isValidCanonicalSlug(slug) {
 			writeError(w, http.StatusBadRequest, "slug must be canonical")
 			return
+		}
+		if conn != nil {
+			count, err := taxonomyItemArticleCount(r.Context(), conn, taxType, slug)
+			if err == sql.ErrNoRows {
+				writeError(w, http.StatusNotFound, "taxonomy item not found")
+				return
+			}
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if count > 0 {
+				writeError(w, http.StatusBadRequest, "taxonomy item cannot be deleted while articles use it")
+				return
+			}
+			if taxType == string(models.TaxonomyTypeSection) {
+				hasChildren, err := taxonomySectionHasChildren(r.Context(), conn, slug)
+				if err != nil {
+					writeError(w, http.StatusInternalServerError, err.Error())
+					return
+				}
+				if hasChildren {
+					writeError(w, http.StatusBadRequest, "section cannot be deleted while subsections use it")
+					return
+				}
+			}
 		}
 
 		result, err := db.Delete(r.Context(), conn, "site_taxonomy", "kind = ? AND slug = ?", taxType, slug)

--- a/server/internal/handlers/taxonomy_test.go
+++ b/server/internal/handlers/taxonomy_test.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"server/internal/models"
+)
+
+func TestValidateTaxonomyParent_RequiresParentForSubsection(t *testing.T) {
+	if _, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSubsection), nil); err == nil {
+		t.Fatal("expected missing parent_slug to be rejected")
+	}
+}
+
+func TestValidateTaxonomyParent_RejectsParentForSection(t *testing.T) {
+	parent := "news"
+
+	if _, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSection), &parent); err == nil {
+		t.Fatal("expected section parent_slug to be rejected")
+	}
+}
+
+func TestValidateTaxonomyParent_NormalizesSubsectionParent(t *testing.T) {
+	parent := "columns"
+
+	got, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSubsection), &parent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "columns" {
+		t.Fatalf("parent = %v, want columns", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a functional Sections admin page with create/edit/delete flows for sections, subsections, and columns
- add backend taxonomy validation for parent relationships, slug changes, and delete safety
- make article category selection use managed taxonomy entries instead of comma-separated free text
- validate section and subsection routes against site_taxonomy when a database is available

## Validation
- go test ./...
- npm run build
- npm run lint

## Notes
Scalene's footer currently hardcodes section links in Footer.astro; it does not consume /v1/taxonomy yet.