### PR TITLE
feat(proxmox): detect IP conflicts on the DB tier addresses

### DIFF
--- a/deploy/proxmox/README.md
+++ b/deploy/proxmox/README.md
@@ -1,0 +1,111 @@
+# Proxmox host tooling
+
+Runs on the **Proxmox host**, not on Delta and not in a container.
+
+## Why the IP-conflict watch exists
+
+`10.248.40.154` (DB1) and `10.248.40.183` (MaxScale) were taken from Drexel's
+DHCP pool by one-off `dhclient` runs. They are now static in **both** the
+container config (`pct config <id>` → `net0 ... ip=`) and inside the container
+(`/etc/systemd/network/10-eth0-static.network`), so our hosts keep their
+addresses — that part is solved, and it is what fixed DB1's ~20-minute outage
+when its lease lapsed on 2026-07-29.
+
+What is **not** solved: those addresses were never excluded from the pool.
+DHCP for this subnet is central Drexel (`dhcp-server-identifier 10.254.5.41`,
+off-subnet via a relay), so **nothing on the Proxmox host can reserve or exclude
+an address** — that needs a request to Drexel IT, and as of 2026-07-30 none has
+been made. The old leases expire **2026-08-05**, after which that server may
+hand `.154` or `.183` to another device.
+
+Two hosts answering for one address does not fail cleanly. It looks like
+intermittent, unexplainable connection errors against the database. This check
+turns that into an immediate, named alert.
+
+**It detects; it does not prevent.** The fix is still a pool exclusion from
+Drexel IT.
+
+## Install
+
+```bash
+install -m 0755 ip-conflict-watch.sh /usr/local/sbin/ip-conflict-watch.sh
+install -m 0644 ip-conflict-watch.service /etc/systemd/system/
+install -m 0644 ip-conflict-watch.timer   /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now ip-conflict-watch.timer
+```
+
+Verify, and confirm it reports the expected MACs:
+
+```bash
+systemctl start ip-conflict-watch.service
+journalctl -t triangle-ip-watch -n 10 --no-pager
+systemctl list-timers ip-conflict-watch.timer
+```
+
+Expected output:
+
+```
+[daemon.info] 10.248.40.154 OK (bc:24:11:e5:cc:58)
+[daemon.info] 10.248.40.183 OK (bc:24:11:83:05:ea)
+```
+
+## Exit codes
+
+| code | meaning |
+| --- | --- |
+| 0 | both addresses answered, only from the expected MAC |
+| 1 | **conflict** — a foreign MAC also answered |
+| 2 | a host did not answer ARP at all (container down, or wrong `IFACE`) |
+
+A non-zero exit fails the unit, so `systemctl status ip-conflict-watch` and
+`systemctl list-units --failed` both surface it.
+
+## Configuration
+
+Defaults are in the script. To change the interface or watch more hosts without
+editing it, drop `/etc/triangle-ip-watch.conf`:
+
+```bash
+IFACE=vmbr0
+WATCH=(
+  "10.248.40.154=bc:24:11:e5:cc:58"
+  "10.248.40.183=bc:24:11:83:05:ea"
+)
+```
+
+Keep the MACs in step with `pct config <id> | grep net0`. A stale expected MAC
+produces a false conflict alert.
+
+## Getting alerted
+
+The check logs to the journal under tag `triangle-ip-watch`, at `daemon.err`
+for a conflict. That is deliberately the whole of it — how alerts leave this
+box is a local decision. Two options:
+
+- **systemd**, mail on failure — add `OnFailure=status-email@%n.service` to the
+  service unit with a mail-sending template unit.
+- **Promtail**, if the observability stack is ever pointed at this host — scrape
+  the journal and alert on the `triangle-ip-watch` tag at priority 3.
+
+## After 2026-08-05
+
+Re-check by hand once the old leases have lapsed, since that is the window when
+a reassignment can first happen:
+
+```bash
+arping -I vmbr0 -c 2 10.248.40.154   # expect bc:24:11:e5:cc:58
+arping -I vmbr0 -c 2 10.248.40.183   # expect bc:24:11:83:05:ea
+```
+
+Note `arping -D` from the Proxmox host **always** gets a reply — our own
+containers answer their own probes. That is not a conflict. Identity needs plain
+`arping` (which prints the responder MAC) or `ip neigh show <ip>`.
+
+## Still to do
+
+- Request a **pool exclusion** (not a reservation — these hosts never request a
+  lease, so a reservation would never be exercised) for `.154` and `.183` from
+  Drexel IT, and ask them to confirm the dynamic range so it can be verified.
+- CT 113 `THETRIANGLE-REACT` is still `ip=dhcp`. It *does* request a lease, so
+  for that one a **reservation** is the right ask.

--- a/deploy/proxmox/ip-conflict-watch.service
+++ b/deploy/proxmox/ip-conflict-watch.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Triangle DB tier IP-conflict check
+Documentation=https://github.com/DrexelTriangle/triangle-cms/blob/main/deploy/proxmox/README.md
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/ip-conflict-watch.sh
+# arping needs raw sockets; everything else is dropped.
+CapabilityBoundingSet=CAP_NET_RAW
+AmbientCapabilities=CAP_NET_RAW
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true

--- a/deploy/proxmox/ip-conflict-watch.sh
+++ b/deploy/proxmox/ip-conflict-watch.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Detect an IP conflict on the Triangle DB tier.
+#
+# The DB hosts' addresses are static in Proxmox and inside the containers, but
+# they were taken from Drexel's DHCP pool and were never excluded from it
+# (central DHCP lives on 10.254.5.41; Proxmox is not the DHCP server, so nothing
+# on this host can reserve them). Our hosts therefore keep their addresses, but
+# nothing stops that server leasing the same address to some other device once
+# the old leases lapse. This cannot prevent that -- it detects it quickly.
+#
+# Runs on the PROXMOX HOST, which shares a bridge with the containers. ARP is
+# link-local, so this does not work from a routed workstation.
+#
+# Exit: 0 all good, 1 conflict (a foreign MAC answered), 2 a host did not answer.
+set -uo pipefail
+
+IFACE="${IFACE:-vmbr0}"
+TAG="triangle-ip-watch"
+
+# ip=expected-mac. Keep in sync with `pct config <id> | grep net0`.
+WATCH=(
+  "10.248.40.154=bc:24:11:e5:cc:58"  # THETRIANGLE-DB1-LXC   (CT 108, MariaDB)
+  "10.248.40.183=bc:24:11:83:05:ea"  # THETRIANGLE-MAXSCALE  (CT 109)
+)
+
+# Optional overrides, e.g. to add a host without editing this file.
+# shellcheck source=/dev/null
+[[ -r /etc/triangle-ip-watch.conf ]] && source /etc/triangle-ip-watch.conf
+
+log() { logger -t "$TAG" -p "$1" -- "$2"; echo "[$1] $2"; }
+
+status=0
+
+for entry in "${WATCH[@]}"; do
+  ip="${entry%%=*}"
+  expected="$(tr '[:upper:]' '[:lower:]' <<<"${entry#*=}")"
+
+  # -c 3 -w 3: three probes, give up after three seconds either way.
+  out="$(arping -c 3 -w 3 -I "$IFACE" "$ip" 2>/dev/null)"
+  macs="$(grep -oiE '([0-9a-f]{2}:){5}[0-9a-f]{2}' <<<"$out" | tr '[:upper:]' '[:lower:]' | sort -u)"
+
+  if [[ -z "$macs" ]]; then
+    # Not a conflict: the container is probably down, or the bridge is wrong.
+    # Worth surfacing, but it must not read as "someone stole the address".
+    log daemon.warning "$ip did not answer ARP on $IFACE (host down, or wrong interface?)"
+    [[ $status -eq 0 ]] && status=2
+    continue
+  fi
+
+  foreign="$(grep -v "^${expected}$" <<<"$macs" || true)"
+  if [[ -n "$foreign" ]]; then
+    # Two devices answering for one address. On a database host this shows up
+    # as intermittent, inexplicable connection failures rather than a clean
+    # outage, so it is worth an alarm rather than a warning.
+    log daemon.err "IP CONFLICT on $ip: expected $expected, also answered by: $(tr '\n' ' ' <<<"$foreign")"
+    status=1
+  else
+    log daemon.info "$ip OK ($expected)"
+  fi
+done
+
+exit "$status"

--- a/deploy/proxmox/ip-conflict-watch.timer
+++ b/deploy/proxmox/ip-conflict-watch.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run the Triangle DB tier IP-conflict check every 15 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+# Keeps every PVE node from probing on the same second if this is ever cloned.
+RandomizedDelaySec=60s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## The situation

`10.248.40.154` (DB1) and `10.248.40.183` (MaxScale) took their addresses from Drexel's DHCP pool via one-off `dhclient` runs. They are now static in **both** the container config (`pct config` → `net0 ... ip=`) and inside the container (`10-eth0-static.network`), so our hosts keep their addresses — that is what fixed DB1's ~20-minute outage when its lease lapsed on 2026-07-29.

**What is not fixed:** those addresses were never excluded from the pool. DHCP for this subnet is central Drexel — `dhcp-server-identifier 10.254.5.41`, off-subnet via a relay — so **nothing on the Proxmox host can reserve or exclude an address**. That needs a request to Drexel IT, and as of 2026-07-30 none has been made. The old leases expire **2026-08-05**, after which that server may lease `.154` or `.183` to another device.

Two hosts answering for one address does not fail cleanly. It surfaces as intermittent, unexplainable connection errors against the database rather than a clean outage — the kind of thing that burns a day before anyone suspects the network.

## What this does

A systemd timer on the **Proxmox host** (ARP is link-local — the host shares a bridge with the containers; a routed workstation cannot see any of this) that ARPs both addresses every 15 minutes and alerts if anything other than the expected MAC answers.

```
[daemon.info] 10.248.40.154 OK (bc:24:11:e5:cc:58)
[daemon.info] 10.248.40.183 OK (bc:24:11:83:05:ea)
```

| exit | meaning |
| --- | --- |
| 0 | both answered, only from the expected MAC |
| 1 | **conflict** — a foreign MAC also answered |
| 2 | a host did not answer at all (container down, or wrong `IFACE`) |

A down container is a **warning and exit 2**, deliberately distinct from a conflict's exit 1, so a stopped CT does not read as somebody stealing the address.

## Scope

**Detection only — it cannot prevent a conflict.** The actual fix is still a pool exclusion from Drexel IT. Note that's an *exclusion*, not a *reservation*: these hosts never request a lease, so a reservation would sit unexercised. CT 113 `THETRIANGLE-REACT` is still `ip=dhcp` and *does* want a reservation. Both are tracked under "Still to do" in the README.

## Verification

Tested against a stubbed `arping` across all three paths (clean, foreign MAC, no reply), and with both `arping` output formats and upper/lower-case MACs — `pct config` prints uppercase, `arping` prints lowercase, and a case mismatch would have produced a false conflict alert on every run.

Not yet installed on the Proxmox host; the README has the install steps and the expected first-run output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)