### PR TITLE
feat: build a Triangle database on any MariaDB target

### DIFF
--- a/deploy/proxmox/README.md
+++ b/deploy/proxmox/README.md
@@ -1,0 +1,111 @@
+# Proxmox host tooling
+
+Runs on the **Proxmox host**, not on Delta and not in a container.
+
+## Why the IP-conflict watch exists
+
+`10.248.40.154` (DB1) and `10.248.40.183` (MaxScale) were taken from Drexel's
+DHCP pool by one-off `dhclient` runs. They are now static in **both** the
+container config (`pct config <id>` → `net0 ... ip=`) and inside the container
+(`/etc/systemd/network/10-eth0-static.network`), so our hosts keep their
+addresses — that part is solved, and it is what fixed DB1's ~20-minute outage
+when its lease lapsed on 2026-07-29.
+
+What is **not** solved: those addresses were never excluded from the pool.
+DHCP for this subnet is central Drexel (`dhcp-server-identifier 10.254.5.41`,
+off-subnet via a relay), so **nothing on the Proxmox host can reserve or exclude
+an address** — that needs a request to Drexel IT, and as of 2026-07-30 none has
+been made. The old leases expire **2026-08-05**, after which that server may
+hand `.154` or `.183` to another device.
+
+Two hosts answering for one address does not fail cleanly. It looks like
+intermittent, unexplainable connection errors against the database. This check
+turns that into an immediate, named alert.
+
+**It detects; it does not prevent.** The fix is still a pool exclusion from
+Drexel IT.
+
+## Install
+
+```bash
+install -m 0755 ip-conflict-watch.sh /usr/local/sbin/ip-conflict-watch.sh
+install -m 0644 ip-conflict-watch.service /etc/systemd/system/
+install -m 0644 ip-conflict-watch.timer   /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now ip-conflict-watch.timer
+```
+
+Verify, and confirm it reports the expected MACs:
+
+```bash
+systemctl start ip-conflict-watch.service
+journalctl -t triangle-ip-watch -n 10 --no-pager
+systemctl list-timers ip-conflict-watch.timer
+```
+
+Expected output:
+
+```
+[daemon.info] 10.248.40.154 OK (bc:24:11:e5:cc:58)
+[daemon.info] 10.248.40.183 OK (bc:24:11:83:05:ea)
+```
+
+## Exit codes
+
+| code | meaning |
+| --- | --- |
+| 0 | both addresses answered, only from the expected MAC |
+| 1 | **conflict** — a foreign MAC also answered |
+| 2 | a host did not answer ARP at all (container down, or wrong `IFACE`) |
+
+A non-zero exit fails the unit, so `systemctl status ip-conflict-watch` and
+`systemctl list-units --failed` both surface it.
+
+## Configuration
+
+Defaults are in the script. To change the interface or watch more hosts without
+editing it, drop `/etc/triangle-ip-watch.conf`:
+
+```bash
+IFACE=vmbr0
+WATCH=(
+  "10.248.40.154=bc:24:11:e5:cc:58"
+  "10.248.40.183=bc:24:11:83:05:ea"
+)
+```
+
+Keep the MACs in step with `pct config <id> | grep net0`. A stale expected MAC
+produces a false conflict alert.
+
+## Getting alerted
+
+The check logs to the journal under tag `triangle-ip-watch`, at `daemon.err`
+for a conflict. That is deliberately the whole of it — how alerts leave this
+box is a local decision. Two options:
+
+- **systemd**, mail on failure — add `OnFailure=status-email@%n.service` to the
+  service unit with a mail-sending template unit.
+- **Promtail**, if the observability stack is ever pointed at this host — scrape
+  the journal and alert on the `triangle-ip-watch` tag at priority 3.
+
+## After 2026-08-05
+
+Re-check by hand once the old leases have lapsed, since that is the window when
+a reassignment can first happen:
+
+```bash
+arping -I vmbr0 -c 2 10.248.40.154   # expect bc:24:11:e5:cc:58
+arping -I vmbr0 -c 2 10.248.40.183   # expect bc:24:11:83:05:ea
+```
+
+Note `arping -D` from the Proxmox host **always** gets a reply — our own
+containers answer their own probes. That is not a conflict. Identity needs plain
+`arping` (which prints the responder MAC) or `ip neigh show <ip>`.
+
+## Still to do
+
+- Request a **pool exclusion** (not a reservation — these hosts never request a
+  lease, so a reservation would never be exercised) for `.154` and `.183` from
+  Drexel IT, and ask them to confirm the dynamic range so it can be verified.
+- CT 113 `THETRIANGLE-REACT` is still `ip=dhcp`. It *does* request a lease, so
+  for that one a **reservation** is the right ask.

--- a/deploy/proxmox/ip-conflict-watch.service
+++ b/deploy/proxmox/ip-conflict-watch.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Triangle DB tier IP-conflict check
+Documentation=https://github.com/DrexelTriangle/triangle-cms/blob/main/deploy/proxmox/README.md
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/ip-conflict-watch.sh
+# arping needs raw sockets; everything else is dropped.
+CapabilityBoundingSet=CAP_NET_RAW
+AmbientCapabilities=CAP_NET_RAW
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true

--- a/deploy/proxmox/ip-conflict-watch.sh
+++ b/deploy/proxmox/ip-conflict-watch.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Detect an IP conflict on the Triangle DB tier.
+#
+# The DB hosts' addresses are static in Proxmox and inside the containers, but
+# they were taken from Drexel's DHCP pool and were never excluded from it
+# (central DHCP lives on 10.254.5.41; Proxmox is not the DHCP server, so nothing
+# on this host can reserve them). Our hosts therefore keep their addresses, but
+# nothing stops that server leasing the same address to some other device once
+# the old leases lapse. This cannot prevent that -- it detects it quickly.
+#
+# Runs on the PROXMOX HOST, which shares a bridge with the containers. ARP is
+# link-local, so this does not work from a routed workstation.
+#
+# Exit: 0 all good, 1 conflict (a foreign MAC answered), 2 a host did not answer.
+set -uo pipefail
+
+IFACE="${IFACE:-vmbr0}"
+TAG="triangle-ip-watch"
+
+# ip=expected-mac. Keep in sync with `pct config <id> | grep net0`.
+WATCH=(
+  "10.248.40.154=bc:24:11:e5:cc:58"  # THETRIANGLE-DB1-LXC   (CT 108, MariaDB)
+  "10.248.40.183=bc:24:11:83:05:ea"  # THETRIANGLE-MAXSCALE  (CT 109)
+)
+
+# Optional overrides, e.g. to add a host without editing this file.
+# shellcheck source=/dev/null
+[[ -r /etc/triangle-ip-watch.conf ]] && source /etc/triangle-ip-watch.conf
+
+log() { logger -t "$TAG" -p "$1" -- "$2"; echo "[$1] $2"; }
+
+status=0
+
+for entry in "${WATCH[@]}"; do
+  ip="${entry%%=*}"
+  expected="$(tr '[:upper:]' '[:lower:]' <<<"${entry#*=}")"
+
+  # -c 3 -w 3: three probes, give up after three seconds either way.
+  out="$(arping -c 3 -w 3 -I "$IFACE" "$ip" 2>/dev/null)"
+  macs="$(grep -oiE '([0-9a-f]{2}:){5}[0-9a-f]{2}' <<<"$out" | tr '[:upper:]' '[:lower:]' | sort -u)"
+
+  if [[ -z "$macs" ]]; then
+    # Not a conflict: the container is probably down, or the bridge is wrong.
+    # Worth surfacing, but it must not read as "someone stole the address".
+    log daemon.warning "$ip did not answer ARP on $IFACE (host down, or wrong interface?)"
+    [[ $status -eq 0 ]] && status=2
+    continue
+  fi
+
+  foreign="$(grep -v "^${expected}$" <<<"$macs" || true)"
+  if [[ -n "$foreign" ]]; then
+    # Two devices answering for one address. On a database host this shows up
+    # as intermittent, inexplicable connection failures rather than a clean
+    # outage, so it is worth an alarm rather than a warning.
+    log daemon.err "IP CONFLICT on $ip: expected $expected, also answered by: $(tr '\n' ' ' <<<"$foreign")"
+    status=1
+  else
+    log daemon.info "$ip OK ($expected)"
+  fi
+done
+
+exit "$status"

--- a/deploy/proxmox/ip-conflict-watch.timer
+++ b/deploy/proxmox/ip-conflict-watch.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run the Triangle DB tier IP-conflict check every 15 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+# Keeps every PVE node from probing on the same second if this is ever cloned.
+RandomizedDelaySec=60s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/build_database.py
+++ b/scripts/build_database.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Build a complete Triangle database on any MariaDB target, from ETL seed SQL.
+
+Unlike scripts/reseed_from_etl.py -- which rebuilds the LOCAL Docker stack by
+deleting its volume -- this talks to a target over the network, so it works
+against local Docker, a scratch database, a test container, or DB1 via MaxScale.
+That makes it the tool for repeatable infrastructure tests and, eventually, the
+final migration.
+
+The order below is not interchangeable. The CMS cannot bootstrap a database
+from nothing: EnsureArticlesSchema is `ALTER TABLE articles ADD COLUMN IF NOT
+EXISTS`, so it completes tables the ETL created rather than creating them.
+Seed first, migrate second.
+
+  1. DROP and CREATE the target database
+  2. load the ETL seed SQL in order (01..08)
+  3. run the CMS's own migrations against it (CMS_MIGRATE_ONLY=1)
+  4. verify row counts, the id=0 article, and the CMS-owned tables
+
+  python ./scripts/build_database.py --host 127.0.0.1 --database triangle_test
+  python ./scripts/build_database.py --dsn 'u:pw@tcp(10.248.40.183:4006)/triangle_test'
+  python ./scripts/build_database.py --host 10.248.40.183 --port 4006 \
+      --database triangle_test --skip-migrate
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+SEED_DIR = ROOT_DIR / "server" / "internal" / "database" / "wordpress_etl"
+
+SEED_FILES = (
+    "01-authors.sql",
+    "02-articles.sql",
+    "03-articles-authors.sql",
+    "04-seo.sql",
+    "05-article-embeddings.sql",
+    "06-taxonomy.sql",
+    "07-poll-counts.sql",
+    "08-comments.sql",
+)
+
+# Created by the ETL seed.
+CONTENT_TABLES = ("articles", "authors", "articles_authors", "seo", "comments")
+# Also from the seed, but legitimately absent: with no ETL embeddings artifact
+# the generated 05-article-embeddings.sql is a placeholder whose whole body is
+# DROP TABLE IF EXISTS. Missing means related-articles is empty, not a failure.
+OPTIONAL_TABLES = ("article_embeddings",)
+# Created by the CMS's own migrations; their absence means step 3 did not run.
+CMS_TABLES = ("cms_users", "cms_sessions", "cms_settings", "media", "cms_polls", "site_taxonomy")
+
+# Hosts that must never be rebuilt without saying so out loud. DB1 direct and
+# MaxScale both reach production data.
+PRODUCTION_HOSTS = {"10.248.40.154", "10.248.40.183"}
+PRODUCTION_DATABASES = {"triangle"}
+
+DSN_RE = re.compile(
+    r"^(?P<user>[^:@/]+)(?::(?P<password>[^@]*))?@tcp\((?P<host>[^:)]+)(?::(?P<port>\d+))?\)/(?P<database>[^?]+)"
+)
+
+
+class Fail(Exception):
+    """A preflight or verification failure with a human-readable reason."""
+
+
+def info(msg: str) -> None:
+    print(f"  {msg}")
+
+
+def step(msg: str) -> None:
+    print(f"\n==> {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"  WARNING: {msg}", file=sys.stderr)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build a Triangle database on a MariaDB target (destructive).")
+    parser.add_argument("--dsn", help="Go-style DSN: user:pass@tcp(host:port)/database (password optional)")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=3306)
+    parser.add_argument("--user", default="triangle_user")
+    parser.add_argument("--database", help="target schema; it will be DROPPED and recreated")
+    parser.add_argument(
+        "--password-env",
+        default="DB_PASSWORD",
+        help="env var holding the password (default: DB_PASSWORD); prompted for if unset",
+    )
+    parser.add_argument("--seed-dir", default=str(SEED_DIR), help=f"seed SQL directory (default: {SEED_DIR})")
+    parser.add_argument(
+        "--skip-migrate",
+        action="store_true",
+        help="load the seed but do not run the CMS migrations (leaves CMS-owned tables missing)",
+    )
+    parser.add_argument("--yes", "-y", action="store_true", help="skip the destructive-action confirmation")
+    parser.add_argument(
+        "--allow-production",
+        action="store_true",
+        help="permit a production host/database as the target; refuses without it",
+    )
+    return parser.parse_args()
+
+
+def resolve_target(args: argparse.Namespace) -> dict:
+    """Merge --dsn and the discrete flags into one connection description."""
+    target = {
+        "host": args.host,
+        "port": args.port,
+        "user": args.user,
+        "database": args.database,
+        "password": None,
+    }
+
+    if args.dsn:
+        match = DSN_RE.match(args.dsn.strip())
+        if not match:
+            raise Fail("--dsn must look like user:password@tcp(host:port)/database")
+        parts = match.groupdict()
+        target["user"] = parts["user"]
+        target["host"] = parts["host"]
+        target["port"] = int(parts["port"] or 3306)
+        target["database"] = parts["database"]
+        if parts["password"]:
+            target["password"] = parts["password"]
+
+    if not target["database"]:
+        raise Fail("no target database; pass --database or include one in --dsn")
+
+    if target["password"] is None:
+        target["password"] = os.getenv(args.password_env) or ""
+    if not target["password"]:
+        if not sys.stdin.isatty():
+            raise Fail(f"no password: set {args.password_env}, or run interactively.")
+        target["password"] = getpass.getpass(f"Password for {target['user']}@{target['host']}: ")
+
+    return target
+
+
+def mysql_client() -> str:
+    for candidate in ("mariadb", "mysql"):
+        if shutil.which(candidate):
+            return candidate
+    raise Fail("neither `mariadb` nor `mysql` is on PATH; install a MariaDB client.")
+
+
+class Client:
+    """Runs SQL against the target without ever putting the password in argv."""
+
+    def __init__(self, target: dict):
+        self.target = target
+        self.binary = mysql_client()
+        # An option file keeps the password out of `ps` and shell history. 0600,
+        # in a private temp dir, removed on exit.
+        self._dir = tempfile.mkdtemp(prefix="triangle-build-")
+        self.defaults = Path(self._dir) / "my.cnf"
+        self.defaults.write_text(
+            "[client]\n"
+            f"host={target['host']}\n"
+            f"port={target['port']}\n"
+            f"user={target['user']}\n"
+            f"password={target['password']}\n",
+            encoding="utf-8",
+        )
+        self.defaults.chmod(0o600)
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    def _base(self) -> list[str]:
+        return [self.binary, f"--defaults-file={self.defaults}"]
+
+    def query(self, sql: str, database: str | None = None) -> str | None:
+        cmd = [*self._base(), "-N", "-B", "-e", sql]
+        if database:
+            cmd.insert(2, database)
+        done = subprocess.run(cmd, capture_output=True, text=True)
+        if done.returncode != 0:
+            return None
+        return done.stdout.strip()
+
+    def execute(self, sql: str, database: str | None = None) -> None:
+        cmd = [*self._base(), "-e", sql]
+        if database:
+            cmd.insert(2, database)
+        done = subprocess.run(cmd, capture_output=True, text=True)
+        if done.returncode != 0:
+            raise Fail(f"SQL failed ({sql[:60]}...): {done.stderr.strip()}")
+
+    def load_file(self, path: Path, database: str) -> None:
+        with path.open("rb") as handle:
+            done = subprocess.run([*self._base(), database], stdin=handle, capture_output=True, text=True)
+        if done.returncode != 0:
+            raise Fail(f"loading {path.name} failed: {done.stderr.strip()}")
+
+
+def preflight(args: argparse.Namespace, target: dict, client: Client) -> Path:
+    if target["host"] in PRODUCTION_HOSTS or target["database"] in PRODUCTION_DATABASES:
+        if not args.allow_production:
+            raise Fail(
+                f"{target['user']}@{target['host']}/{target['database']} looks like production. "
+                "Re-run with --allow-production if that is genuinely the intent."
+            )
+        warn(f"targeting PRODUCTION: {target['host']}/{target['database']} (--allow-production given)")
+
+    if client.query("SELECT 1") is None:
+        raise Fail(f"cannot connect to {target['user']}@{target['host']}:{target['port']}.")
+
+    seed_dir = Path(args.seed_dir).expanduser().resolve()
+    missing = [name for name in SEED_FILES if not (seed_dir / name).is_file()]
+    if missing:
+        raise Fail(f"{seed_dir} is missing {', '.join(missing)}. Run scripts/generate_wordpress_sql.py first.")
+    empty = [name for name in SEED_FILES if (seed_dir / name).stat().st_size == 0]
+    if empty:
+        raise Fail(f"{seed_dir} has empty seed files ({', '.join(empty)}); regenerate them.")
+
+    # The id=0 article is destroyed silently without this, and it is unrecoverable.
+    articles = (seed_dir / "02-articles.sql").read_text(encoding="utf-8", errors="replace")[:4096]
+    if "NO_AUTO_VALUE_ON_ZERO" not in articles:
+        raise Fail("02-articles.sql has no NO_AUTO_VALUE_ON_ZERO preamble; the id=0 article would be renumbered.")
+
+    if not args.skip_migrate:
+        if shutil.which("go") is None:
+            raise Fail("`go` is not on PATH, which --skip-migrate avoids needing (CMS tables will be absent).")
+        if not (ROOT_DIR / "server" / "main.go").is_file():
+            raise Fail("server/main.go not found; run from the triangle-cms checkout.")
+
+    return seed_dir
+
+
+def confirm(args: argparse.Namespace, target: dict, client: Client, seed_dir: Path) -> None:
+    existing = client.query(
+        "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = "
+        f"'{target['database']}'"
+    )
+    print("\n" + "=" * 72)
+    print("  DESTRUCTIVE: the target database is dropped and rebuilt.")
+    print("=" * 72)
+    print(f"\n  Target:  {target['user']}@{target['host']}:{target['port']}/{target['database']}")
+    print(f"  Seed:    {seed_dir}")
+    if existing and existing.isdigit() and int(existing) > 0:
+        print(f"\n  That schema currently holds {existing} tables. ALL of it is destroyed,")
+        print("  including any cms_users, cms_settings and media rows.")
+    else:
+        print("\n  That schema does not exist yet (or is empty); nothing to lose.")
+    print()
+
+    if args.yes:
+        info("--yes given; continuing without confirmation.")
+        return
+    if not sys.stdin.isatty():
+        raise Fail("not a terminal and --yes was not given; refusing to drop a database unprompted.")
+    if input(f'  Type the database name "{target["database"]}" to continue: ').strip() != target["database"]:
+        raise Fail("aborted at the confirmation prompt; nothing was changed.")
+
+
+def load_seed(client: Client, target: dict, seed_dir: Path) -> None:
+    client.execute(f"DROP DATABASE IF EXISTS `{target['database']}`")
+    client.execute(
+        f"CREATE DATABASE `{target['database']}` "
+        "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+    )
+    for name in SEED_FILES:
+        info(f"loading {name} ...")
+        client.load_file(seed_dir / name, target["database"])
+
+
+def run_migrations(target: dict) -> None:
+    """Let the CMS binary produce its own schema, so no DDL is duplicated here."""
+    env = {
+        **os.environ,
+        "CMS_MIGRATE_ONLY": "1",
+        "DB_NAME": target["database"],
+        "DB_USER": target["user"],
+        "DB_PASSWORD": target["password"],
+        "DB_HOST": target["host"],
+        "DB_PORT": str(target["port"]),
+    }
+    # A configured issuer would send the binary into OIDC discovery, which a
+    # migrate-only run has no use for and which fails on an offline host.
+    env.pop("OIDC_ISSUER_URL", None)
+
+    done = subprocess.run(
+        ["go", "run", "./main.go"],
+        cwd=ROOT_DIR / "server",
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if done.returncode != 0 or "migrate_only_complete" not in done.stdout + done.stderr:
+        tail = (done.stderr or done.stdout).strip().splitlines()[-5:]
+        raise Fail("CMS migrations failed:\n    " + "\n    ".join(tail))
+
+
+def verify(client: Client, target: dict, skipped_migrate: bool) -> None:
+    db = target["database"]
+    for table in CONTENT_TABLES:
+        count = client.query(f"SELECT COUNT(*) FROM `{table}`", db)
+        if count is None:
+            raise Fail(f"{table} is missing after the seed load.")
+        info(f"{table:<20} {count:>10}")
+        if table in ("articles", "authors", "seo") and count == "0":
+            raise Fail(f"{table} loaded 0 rows; the seed did not apply.")
+
+    for table in OPTIONAL_TABLES:
+        count = client.query(f"SELECT COUNT(*) FROM `{table}`", db)
+        if count is None or count == "0":
+            warn(f"{table} is absent or empty; /v1/articles/{{slug}} Related will be empty.")
+        else:
+            info(f"{table:<20} {count:>10}")
+
+    min_id = client.query("SELECT MIN(id) FROM articles", db)
+    if min_id == "0":
+        info("articles.id = 0 preserved")
+    else:
+        warn(f"MIN(articles.id) is {min_id}, expected 0 — the id=0 row was renumbered.")
+
+    if skipped_migrate:
+        warn("--skip-migrate: CMS-owned tables were not created; the CMS will create them at first start.")
+        return
+
+    missing = [t for t in CMS_TABLES if client.query(f"SELECT 1 FROM `{t}` LIMIT 1", db) is None]
+    if missing:
+        raise Fail(f"CMS migrations did not create: {', '.join(missing)}")
+    total = client.query(f"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='{db}'")
+    info(f"{'tables total':<20} {total:>10}")
+
+
+def main() -> int:
+    args = parse_args()
+    client = None
+    try:
+        target = resolve_target(args)
+        client = Client(target)
+
+        step("Preflight")
+        seed_dir = preflight(args, target, client)
+        info(f"target: {target['user']}@{target['host']}:{target['port']}/{target['database']}")
+
+        confirm(args, target, client, seed_dir)
+
+        step("Loading seed SQL")
+        load_seed(client, target, seed_dir)
+
+        if args.skip_migrate:
+            step("Skipping CMS migrations (--skip-migrate)")
+        else:
+            step("Running CMS migrations")
+            run_migrations(target)
+
+        step("Verifying")
+        verify(client, target, args.skip_migrate)
+
+        print(f"\nDone. {target['database']} on {target['host']} is built and verified.")
+        return 0
+    except Fail as exc:
+        print(f"\nERROR: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\nInterrupted.", file=sys.stderr)
+        return 130
+    finally:
+        if client:
+            client.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/main.go
+++ b/server/main.go
@@ -188,6 +188,16 @@ func main() {
 		slog.Info("cms startup", "event", "startup", "stage", "db_table_count", "table_count", tableCount)
 	}
 
+	// Migrate-and-exit. Everything above this point is schema work; everything
+	// below needs OIDC and TLS, which a provisioning run has no use for. Lets a
+	// build/seed tool point the real binary at a fresh database and get exactly
+	// the schema this version expects, instead of a second copy of the DDL that
+	// can drift from these Ensure* calls.
+	if strings.TrimSpace(os.Getenv("CMS_MIGRATE_ONLY")) == "1" {
+		slog.Info("cms startup", "event", "startup", "stage", "migrate_only_complete", "table_count", tableCount)
+		return
+	}
+
 	var verifier *oidc.IDTokenVerifier
 	var oidcCfg auth.OIDCConfig
 	if issuerURL := strings.TrimSpace(os.Getenv("OIDC_ISSUER_URL")); issuerURL != "" {


### PR DESCRIPTION
Groundwork for repeatable full-infrastructure tests, and for the final migration. Two commits.

## 1. `CMS_MIGRATE_ONLY` (`server/main.go`)

Provisioning a database means applying whatever schema the current CMS expects. The only way to do that was to start the whole server — which wants TLS certs and an OIDC issuer a provisioning run has no use for. So tooling had to carry a **second copy of the DDL**, which drifts from the `Ensure*` calls the moment either side changes.

`main()` already has a clean seam: everything before the table-count log is schema work, everything after needs OIDC and TLS. `CMS_MIGRATE_ONLY=1` returns at that seam.

```bash
CMS_MIGRATE_ONLY=1 DB_NAME=... DB_HOST=... go run ./main.go
```

## 2. `scripts/build_database.py`

`reseed_from_etl.py` (#117) rebuilds the **local** Docker stack by deleting its volume, so it cannot target anything else. This takes a *target* instead: drop and create the schema, load the ETL seed in order, run the CMS's own migrations, verify. Discrete flags or a Go-style `--dsn`.

```bash
python ./scripts/build_database.py --host 127.0.0.1 --database triangle_test
python ./scripts/build_database.py --dsn 'u:pw@tcp(10.248.40.183:4006)/triangle_test'
```

## The non-obvious constraint

**The CMS cannot bootstrap a database from nothing.** `EnsureArticlesSchema` is `ALTER TABLE articles ADD COLUMN IF NOT EXISTS`, so against an empty schema it fails outright:

```
failed to migrate articles schema: Error 1146: Table 'x.articles' doesn't exist
```

It *completes* what the ETL created. Seed first, migrate second — the script enforces that order, and both commits document it.

## Guards

This drops databases, so:

- production hosts (`10.248.40.154`, `10.248.40.183`) and the `triangle` schema are **refused outright** without `--allow-production`
- confirmation requires typing the **target database name**, not "yes"
- no TTY and no `--yes` refuses rather than proceeding
- **the password never reaches argv** — it goes into a 0600 option file in a private temp dir, so it stays out of `ps` and shell history. `--dsn` accepts an inline password for convenience, but that is not the default path
- `02-articles.sql` is re-checked for the `NO_AUTO_VALUE_ON_ZERO` preamble before loading, since a renumbered `id = 0` article is unrecoverable

Migrations run by invoking the real binary, not by restating DDL, so this tool cannot drift from `Ensure*`. `OIDC_ISSUER_URL` is stripped from that environment — a configured issuer sends the binary into OIDC discovery, which fails outright on an offline host.

## Verification

End to end against MariaDB 11.7, on a scratch database created and dropped for the purpose:

| | |
|---|---|
| articles | 9243 (`MIN(id) = 0` intact) |
| authors | 829 |
| articles_authors | 6746 |
| seo | 9243 |
| comments | 1539 |
| tables total | 14 |

Run via both the discrete flags and `--dsn`. The production guard, the malformed-DSN error, and the non-TTY refusal were each exercised.

`article_embeddings` is **optional**, not required: with no ETL embeddings artifact the generated `05-article-embeddings.sql` is a placeholder whose whole body is `DROP TABLE IF EXISTS`, so its absence is a warning about related-articles being empty rather than a failed build. That is also why the counts above show no embeddings row.

## Not in scope

WordPress sync. This builds from a seed; keeping WP and the CMS in step is a different tool and brings back the merge-policy question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)