### PR TITLE
feat(media): move reindex to Settings, and unblock uploads at Nginx

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -114,6 +114,12 @@ Nginx will not start without `active-upstreams.conf`, since the site `include`s
 it unconditionally. A passing `nginx -t` *before* the site is enabled only
 validates the stock config and proves nothing.
 
+The site sets `client_max_body_size 26m` on `/v1/` to sit just above the
+backend's `MEDIA_MAX_UPLOAD_BYTES` (25 MiB default). Nginx's stock limit is 1m,
+which rejects an ordinary phone photo with a 413 before the CMS ever sees it, so
+a deploy that skips re-copying this file leaves media uploads broken while the
+app looks correctly configured. Raise both together, never just one.
+
 ### Media serving
 
 `location /wp-content/` reads the migrated WordPress corpus straight off CephFS.

--- a/deploy/nginx/triangle-cms.conf
+++ b/deploy/nginx/triangle-cms.conf
@@ -39,6 +39,12 @@ server {
     }
 
     location /v1/ {
+        # POST /v1/media accepts up to MEDIA_MAX_UPLOAD_BYTES (25 MiB by
+        # default). Nginx's own default is 1m, so without this it rejects any
+        # ordinary phone photo with a 413 before the request reaches the CMS,
+        # and the app-side limit never gets a say. Keep this at or above the
+        # backend's limit so the backend is the one that decides.
+        client_max_body_size 26m;
         proxy_pass $triangle_cms_backend;
     }
 

--- a/frontend/src/pages/mediaView.tsx
+++ b/frontend/src/pages/mediaView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Copy, Check, ImageOff, RefreshCw, Search, Trash2, Upload, X } from "lucide-react"
+import { Copy, Check, ImageOff, Search, Trash2, Upload, X } from "lucide-react"
 import { useApiFetch } from "../hooks/useApiFetch"
 import { useCurrentUserRole } from "../hooks/useCurrentUserRole"
 
@@ -24,21 +24,6 @@ type MediaResponse = {
     has_more?: boolean
     total_count?: number
   }
-}
-
-type IndexReport = {
-  walked?: number
-  scanned?: number
-  added?: number
-  skipped?: number
-}
-
-type IndexStatus = {
-  running: boolean
-  started_at?: string
-  finished_at?: string
-  progress?: IndexReport
-  error?: string
 }
 
 const PAGE_SIZE = 60
@@ -81,9 +66,6 @@ function MediaView() {
   const [search, setSearch] = useState("")
   const [selected, setSelected] = useState<MediaItem | null>(null)
   const [uploadStatus, setUploadStatus] = useState<string | null>(null)
-  const [isIndexing, setIsIndexing] = useState(false)
-  const [indexProgress, setIndexProgress] = useState<string | null>(null)
-  const [reloadToken, setReloadToken] = useState(0)
 
   // Debounce so typing doesn't fire a request per keystroke; the filter itself
   // is applied server-side because the library is far too large to filter here.
@@ -128,7 +110,7 @@ function MediaView() {
 
     void load()
     return () => controller.abort()
-  }, [fetchPage, reloadToken])
+  }, [fetchPage])
 
   const loadMore = async () => {
     setIsLoadingMore(true)
@@ -143,11 +125,6 @@ function MediaView() {
       setIsLoadingMore(false)
     }
   }
-
-  // Bumping a token is what actually re-runs the load effect. Re-setting `search`
-  // to its current value does not: React bails out of a same-value setState, so
-  // the effect never re-fires and the list silently stays stale.
-  const refresh = useCallback(() => setReloadToken((n) => n + 1), [])
 
   const handleUpload = async (files: FileList | null) => {
     if (!files || files.length === 0) return
@@ -237,57 +214,6 @@ function MediaView() {
     }
   }
 
-  // The index walks ~145k filesystem entries and takes minutes, so the server
-  // runs it in the background and we poll. A synchronous request could never
-  // finish: Nginx cuts an upstream read at 60s and Cloudflare at ~100s.
-  const pollIndexStatus = useCallback(async (): Promise<boolean> => {
-    const response = await apiFetch("/v1/media/index")
-    if (!response.ok) throw new Error(await errorMessage(response, `Status check failed (${response.status})`))
-    const status = (await response.json()) as IndexStatus
-
-    const p = status.progress
-    if (status.running) {
-      setIndexProgress(
-        `Indexing… ${String(p?.walked ?? 0)} files scanned, ${String(p?.added ?? 0)} added`,
-      )
-      return true
-    }
-
-    setIndexProgress(null)
-    if (status.error) {
-      setError(`Reindex failed: ${status.error}`)
-    } else if (status.finished_at) {
-      setNotice(`Indexed ${String(p?.scanned ?? 0)} assets — ${String(p?.added ?? 0)} new, ${String(p?.skipped ?? 0)} already known.`)
-      if ((p?.added ?? 0) > 0) refresh()
-    }
-    return false
-  }, [apiFetch, refresh])
-
-  const handleReindex = async () => {
-    setIsIndexing(true)
-    setError(null)
-    setNotice(null)
-
-    try {
-      const response = await apiFetch("/v1/media/index", { method: "POST" })
-      // 409 means one is already running — join its progress rather than error.
-      if (!response.ok && response.status !== 409) {
-        setError(await errorMessage(response, `Reindex failed (${response.status})`))
-        setIsIndexing(false)
-        return
-      }
-
-      while (await pollIndexStatus()) {
-        await new Promise((resolve) => setTimeout(resolve, 2000))
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unable to reindex media.")
-      setIndexProgress(null)
-    } finally {
-      setIsIndexing(false)
-    }
-  }
-
   return (
     <div className="flex flex-col gap-6 p-6">
       {/* Header */}
@@ -304,16 +230,6 @@ function MediaView() {
 
         {isAdmin && (
           <div className="flex items-center gap-2">
-            <button
-              className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50 transition-colors"
-              disabled={isIndexing}
-              onClick={() => void handleReindex()}
-              title="Scan the media filesystem for files missing from the library"
-              type="button"
-            >
-              <RefreshCw className={`w-4 h-4 ${isIndexing ? "animate-spin" : ""}`} aria-hidden="true" />
-              {indexProgress ?? (isIndexing ? "Starting…" : "Reindex")}
-            </button>
             <input
               accept="image/jpeg,image/png,image/gif,image/webp"
               className="hidden"
@@ -373,7 +289,9 @@ function MediaView() {
           <ImageOff className="w-10 h-10" />
           <p className="text-sm">{search ? `No results for "${search}"` : "No media items yet."}</p>
           {!search && isAdmin && (
-            <p className="text-xs">Upload a file, or run Reindex to pull in already-migrated images.</p>
+            <p className="text-xs">
+              Upload a file, or run Reindex Media in Settings to pull in already-migrated images.
+            </p>
           )}
         </div>
       ) : (

--- a/frontend/src/pages/settingsPage.tsx
+++ b/frontend/src/pages/settingsPage.tsx
@@ -1,8 +1,17 @@
-import { LogOut } from "lucide-react"
-import { useEffect, useState } from "react"
+import { LogOut, RefreshCw } from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useApiFetch } from "../hooks/useApiFetch"
+import { useCurrentUserRole } from "../hooks/useCurrentUserRole"
 import { useNavigate } from "react-router-dom"
 import { useSessionAuth } from "../auth/sessionAuthContext"
+
+type IndexStatus = {
+  running: boolean
+  started_at?: string
+  finished_at?: string
+  progress?: { walked?: number; scanned?: number; added?: number; skipped?: number }
+  error?: string
+}
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -15,6 +24,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 export default function SettingsPage() {
   const { user, logout } = useSessionAuth()
+  const { isAdmin } = useCurrentUserRole()
   const navigate = useNavigate()
   const apiFetch = useApiFetch()
   const name = user?.name ?? "—"
@@ -33,6 +43,10 @@ export default function SettingsPage() {
   const [breakingSaved, setBreakingSaved] = useState<{ enabled: boolean; text: string }>({ enabled: false, text: "" })
   const [breakingSaving, setBreakingSaving] = useState(false)
   const [breakingMessage, setBreakingMessage] = useState<string | null>(null)
+  const [mediaIndexRunning, setMediaIndexRunning] = useState(false)
+  const [mediaIndexMessage, setMediaIndexMessage] = useState<string | null>(null)
+  // Guards against two poll loops (mount-resume plus a click) racing each other.
+  const mediaPollActive = useRef(false)
 
   useEffect(() => {
     let cancelled = false
@@ -153,6 +167,78 @@ export default function SettingsPage() {
       setTaxonomyRebuildMessage(err instanceof Error ? err.message : "Failed to rebuild taxonomy counts")
     } finally {
       setTaxonomyRebuildRunning(false)
+    }
+  }
+
+  // The index walks ~145k filesystem entries and takes minutes, so the server runs
+  // it in the background and we poll. A synchronous request could never finish:
+  // Nginx cuts an upstream read at 60s and Cloudflare at ~100s.
+  const followMediaIndex = useCallback(async () => {
+    // A second caller would double the poll rate and fight over the message.
+    if (mediaPollActive.current) return
+    mediaPollActive.current = true
+    setMediaIndexRunning(true)
+    try {
+      for (;;) {
+        const res = await apiFetch("/v1/media/index")
+        if (!res.ok) throw new Error(`Failed to read index status (${res.status})`)
+        const status = (await res.json()) as IndexStatus
+        const p = status.progress
+
+        if (!status.running) {
+          if (status.error) {
+            setMediaIndexMessage(`Reindex failed: ${status.error}`)
+          } else if (status.finished_at) {
+            setMediaIndexMessage(
+              `Indexed ${String(p?.scanned ?? 0)} assets — ${String(p?.added ?? 0)} new, ${String(p?.skipped ?? 0)} already known.`,
+            )
+          }
+          return
+        }
+
+        setMediaIndexMessage(`Indexing… ${String(p?.walked ?? 0)} files scanned, ${String(p?.added ?? 0)} added`)
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+      }
+    } catch (err) {
+      setMediaIndexMessage(err instanceof Error ? err.message : "Failed to read index status")
+    } finally {
+      mediaPollActive.current = false
+      setMediaIndexRunning(false)
+    }
+  }, [apiFetch])
+
+  // An index started before this page was opened (or by another admin) is still
+  // running server-side, so pick up its progress rather than showing an idle button.
+  useEffect(() => {
+    if (!isAdmin) return
+    let cancelled = false
+    async function resumeMediaIndex() {
+      try {
+        const res = await apiFetch("/v1/media/index")
+        if (!res.ok) return
+        const status = (await res.json()) as IndexStatus
+        if (!cancelled && status.running) void followMediaIndex()
+      } catch {
+        // Nothing to resume, and this is not worth an error banner on load.
+      }
+    }
+    void resumeMediaIndex()
+    return () => {
+      cancelled = true
+    }
+  }, [apiFetch, followMediaIndex, isAdmin])
+
+  async function reindexMedia() {
+    setMediaIndexMessage(null)
+    try {
+      const res = await apiFetch("/v1/media/index", { method: "POST" })
+      // 409 means one is already running — join its progress rather than error.
+      if (!res.ok && res.status !== 409) {
+        throw new Error(`Failed to start reindex (${res.status})`)
+      }
+      await followMediaIndex()
+    } catch (err) {
+      setMediaIndexMessage(err instanceof Error ? err.message : "Failed to start reindex")
     }
   }
 
@@ -287,6 +373,28 @@ export default function SettingsPage() {
           {taxonomyRebuildMessage && <span className="text-sm text-muted-foreground">{taxonomyRebuildMessage}</span>}
         </div>
       </div>
+
+      {isAdmin && (
+        <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-4">
+          <h2 className="text-lg font-semibold text-foreground">Media Library</h2>
+          <p className="text-sm text-muted-foreground">
+            Scan the media filesystem for files missing from the library. This walks every asset on the
+            media server and takes several minutes; existing entries are left untouched.
+          </p>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => void reindexMedia()}
+              disabled={mediaIndexRunning}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-60"
+            >
+              <RefreshCw className={`w-4 h-4 ${mediaIndexRunning ? "animate-spin" : ""}`} aria-hidden="true" />
+              {mediaIndexRunning ? "Reindexing…" : "Reindex Media"}
+            </button>
+            {mediaIndexMessage && <span className="text-sm text-muted-foreground">{mediaIndexMessage}</span>}
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Reindex moves to Settings

It is a maintenance action, not a browsing action, so it now sits alongside Taxonomy in Settings instead of in the Media page header.

Two behaviours the old button did not have:

- **Resumes on mount.** A `GET /v1/media/index` on load joins an index already running — started before the page was opened, or by another admin — rather than showing an idle button while work is in flight.
- **Single poll loop.** A `mediaPollActive` ref stops the mount-resume and a click from both polling and fighting over the status message.

409 is still treated as "join the running one", not an error. The empty-state hint on the Media page now points at Settings.

## Uploads were failing with 413

Nginx's stock `client_max_body_size` is **1m**. The backend allows 25 MiB (`MEDIA_MAX_UPLOAD_BYTES`), but Nginx rejected anything larger than 1 MB before the request ever reached it — so any ordinary phone photo failed, with the app looking correctly configured.

`/v1/` now sets `client_max_body_size 26m`, just above the backend limit, so the backend stays the component that decides. `deploy/README.md` records that the two must be raised together.

**This one needs a deploy action:** the site file has to be re-copied to Delta and Nginx reloaded. Merging alone does not fix the 413.

## Checks

`tsc --noEmit`, `eslint`, and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)