### PR TITLE
chore(frontend): point View Live at the configured public site

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-ARG VITE_PUBLIC_SITE_URL="https://www.thetriangle.org"
+# Baked in at build time (Vite inlines import.meta.env), so this is the origin
+# every "View Live" link and permalink preview in the published image points at.
+# Override with --build-arg to publish an image aimed at another site.
+ARG VITE_PUBLIC_SITE_URL="https://dev.thetriangle.org"
 ENV VITE_PUBLIC_SITE_URL=${VITE_PUBLIC_SITE_URL}
 
 COPY package.json package-lock.json ./

--- a/frontend/src/auth/urls.ts
+++ b/frontend/src/auth/urls.ts
@@ -10,8 +10,11 @@ export function authBaseUrl() {
   return trimTrailingSlashes(import.meta.env.VITE_AUTH_BASE_URL ?? "")
 }
 
-// Public-facing site origin, used to build article permalinks (e.g. so Yoast can
-// tell internal links from outbound ones).
+// Public-facing site origin, used for article permalinks (e.g. so Yoast can
+// tell internal links from outbound ones) and for the "View Live" links.
+// Defaults to the dev site: the CMS is not yet driving production, so an
+// unconfigured build pointing at www would send editors to pages that do not
+// reflect what they just saved.
 export function publicSiteUrl() {
-  return trimTrailingSlashes(import.meta.env.VITE_PUBLIC_SITE_URL ?? "https://www.thetriangle.org")
+  return trimTrailingSlashes(import.meta.env.VITE_PUBLIC_SITE_URL ?? "https://dev.thetriangle.org")
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { useApiFetch } from "../hooks/useApiFetch"
+import { publicSiteUrl } from "../auth/urls"
 import { useSessionAuth } from "../auth/sessionAuthContext"
 import {
   FileText,
@@ -336,7 +337,7 @@ export default function DashboardPage() {
             variant="outline"
             size="sm"
             className="gap-1.5"
-            onClick={() => window.open("https://www.thetriangle.org", "_blank", "noopener,noreferrer")}
+            onClick={() => window.open(publicSiteUrl(), "_blank", "noopener,noreferrer")}
           >
             <ExternalLink className="w-3.5 h-3.5" />
             View site

--- a/frontend/src/pages/articleView.tsx
+++ b/frontend/src/pages/articleView.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { ExternalLink, Search, Pencil, Plus, Trash2, X, ChevronFirst, ChevronLast, ChevronLeft, ChevronRight, Undo2 } from "lucide-react"
 import { useNavigate } from "react-router-dom"
+import { publicSiteUrl } from "../auth/urls"
 import { useApiFetch } from "../hooks/useApiFetch"
 
 type ArticleStatus = "Published" | "Draft" | "Archived"
@@ -103,6 +104,9 @@ const writeSessionJSON = (key: string, value: unknown) => {
 function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: ArticleViewProps) {
   const navigate = useNavigate()
   const apiFetch = useApiFetch()
+  // Same origin the comments view and the editor's permalink preview use, so
+  // "View Live" cannot point at a different site than the rest of the CMS.
+  const siteUrl = useMemo(() => publicSiteUrl(), [])
   const storageKeyBase = `articleView:${fixedType ?? "all"}:${excludeType ?? "none"}`
   const uiStateKey = `${storageKeyBase}:ui`
   const resultsCacheKey = `${storageKeyBase}:results`
@@ -603,7 +607,7 @@ function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: Article
                       {activeTab !== "trash" && item.status === "Published" && (
                         <a
                           className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
-                          href={item.slug ? `https://www.thetriangle.org/article/${encodeURIComponent(item.slug)}` : "#"}
+                          href={item.slug ? `${siteUrl}/article/${encodeURIComponent(item.slug)}` : "#"}
                           rel="noreferrer"
                           target="_blank"
                         >


### PR DESCRIPTION
The **View Live** link on the articles list built its URL from a hardcoded `https://www.thetriangle.org`, even though `VITE_PUBLIC_SITE_URL` already existed and was already plumbed through the frontend image as a build arg — the comments view and the editor's permalink preview both read it. Only this link didn't, so it could send an editor to a different site than the rest of the CMS pointed at.

## Changes
- `View Live` uses the existing `publicSiteUrl()` helper.
- Default set to `https://dev.thetriangle.org` in **both** places that define it: the runtime fallback in `src/auth/urls.ts`, and the `ARG` in `frontend/Dockerfile` — the latter is what the published image actually gets, since `publish.yml` passes no `--build-arg`. Changing only one would leave the other on www.
- The dashboard's **View site** button had the same hardcoded origin; included, since fixing only one would split the two buttons across two sites.

## Verification
`npm run build` clean; grepped the built bundle — `dev.thetriangle.org` present, `www.thetriangle.org` gone. No hardcoded origin remains in the frontend.

## Note
Vite inlines `import.meta.env` at build time, so this is baked into the image rather than read at container start. Retargeting a deployed image means rebuilding with `--build-arg VITE_PUBLIC_SITE_URL=…`. Adding `build-args` to the frontend step in `publish.yml` would give CI per-environment control; not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)