### PR TITLE
fix(comments): open the comments view on approved

### DIFF
--- a/frontend/src/pages/commentsView.tsx
+++ b/frontend/src/pages/commentsView.tsx
@@ -138,7 +138,10 @@ export default function CommentsView() {
   const [comments, setComments] = useState<Comment[]>([])
   const [search, setSearch] = useState("")
   const [debouncedSearch, setDebouncedSearch] = useState("")
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
+  // Opens on approved rather than all: "all" mixes spam and trash into the
+  // first thing an editor sees. Pending comments stay discoverable through the
+  // count on the Comments nav item.
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("approved")
   const [page, setPage] = useState(0)
   const [totalCount, setTotalCount] = useState(0)
   const [counts, setCounts] = useState<Record<StatusFilter, number>>({


### PR DESCRIPTION
The moderation view defaulted to `all`, so the first thing an editor saw was approved comments interleaved with spam and trash. Defaults to `approved` instead.

Pending comments don't become harder to find: the Comments nav item already carries a live pending count, which is what should pull an editor to the queue.

One-line change. Nothing else needed adjusting — the existing effect already resets pagination when the filter changes, and the fetch only omits the `status` param for `all`, so the first load now sends `?status=approved` and every tab's count still populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)