### PR TITLE
fix(media): close the paths where stored assets could be lost or orphaned

### DIFF
--- a/deploy/cms.env.example
+++ b/deploy/cms.env.example
@@ -19,4 +19,8 @@ AKISMET_BLOG_URL=
 MEDIA_HOST_PATH=
 MEDIA_ROOT=
 MEDIA_BASE_URL=
+# Path under MEDIA_ROOT that must exist for uploads to be accepted; proves the
+# CephFS media tree is actually mounted. Leave this line out to take the default
+# (wp-content/uploads); set it empty only to disable the check.
+MEDIA_ROOT_SENTINEL=wp-content/uploads
 MEDIA_MAX_UPLOAD_BYTES=

--- a/deploy/compose.cms.yml
+++ b/deploy/compose.cms.yml
@@ -35,6 +35,12 @@ x-backend-base: &backend-base
     # assets under MEDIA_ROOT; MEDIA_BASE_URL is the public host that serves them.
     MEDIA_ROOT: ${MEDIA_ROOT:-/mnt/cephfs/media}
     MEDIA_BASE_URL: ${MEDIA_BASE_URL:-}
+    # Mount guard. The bind below silently creates an empty host directory when
+    # CephFS is not mounted, and uploads into it look successful right up until
+    # the mount is repaired and shadows them. This path must exist under
+    # MEDIA_ROOT or the backend refuses to store anything. Set it empty only for
+    # an install with no migrated corpus.
+    MEDIA_ROOT_SENTINEL: ${MEDIA_ROOT_SENTINEL-wp-content/uploads}
     # Per-file upload cap. Must stay at or below Nginx's client_max_body_size
     # (91m) and below Cloudflare's 100 MB tunnel limit; raise all of them
     # together or the smallest one silently wins.

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -2043,6 +2043,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2108,6 +2114,12 @@ const docTemplate = `{
                     },
                     "502": {
                         "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
@@ -2217,6 +2229,12 @@ const docTemplate = `{
                     },
                     "501": {
                         "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -2040,6 +2040,12 @@
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2105,6 +2111,12 @@
                     },
                     "502": {
                         "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
@@ -2214,6 +2226,12 @@
                     },
                     "501": {
                         "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -2407,6 +2407,10 @@ paths:
           description: Not Implemented
           schema:
             $ref: '#/definitions/models.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Upload a media asset
@@ -2556,6 +2560,10 @@ paths:
           description: Bad Gateway
           schema:
             $ref: '#/definitions/models.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Sideload a remote image into the library
@@ -2621,6 +2629,10 @@ paths:
             $ref: '#/definitions/models.ErrorResponse'
         "501":
           description: Not Implemented
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "503":
+          description: Service Unavailable
           schema:
             $ref: '#/definitions/models.ErrorResponse'
       security:

--- a/server/internal/database/media.go
+++ b/server/internal/database/media.go
@@ -323,16 +323,37 @@ func DeleteMediaRow(ctx context.Context, conn *sql.DB, id int64) error {
 	return nil
 }
 
+// likeEscaper neutralises the LIKE metacharacters in a value being matched
+// literally. Underscore is the one that bites here: the migrated corpus is full
+// of names like IMG_1234.jpg, and an unescaped "_" matches any single character.
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
 // MediaPathInUse reports whether any article still points at this asset, so the
 // handler can refuse a delete that would break a published page.
+//
+// Two places have to be checked. photo_url is the article's lead image and holds
+// an absolute URL from the ETL, hence the suffix match. Body images are embedded
+// by the editor as <img src> inside the article text, and checking only
+// photo_url meant an asset used solely inline looked unreferenced -- the delete
+// went through and unlinked a file a published article was still rendering.
 func MediaPathInUse(ctx context.Context, conn *sql.DB, relPath string) (bool, error) {
+	relPath = strings.TrimSpace(relPath)
+	if relPath == "" {
+		return false, nil
+	}
+	escaped := likeEscaper.Replace(relPath)
+
 	var exists int
-	err := conn.QueryRowContext(ctx,
-		"SELECT 1 FROM `articles` WHERE `photo_url` LIKE ? LIMIT 1", "%"+relPath).Scan(&exists)
+	err := conn.QueryRowContext(ctx, `
+		SELECT 1 FROM `+"`articles`"+`
+		WHERE `+"`photo_url`"+` LIKE ? ESCAPE '\\'
+		   OR `+"`text`"+` LIKE ? ESCAPE '\\'
+		LIMIT 1
+	`, "%"+escaped, "%"+escaped+"%").Scan(&exists)
 	if err == nil {
 		return true, nil
 	}
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
 	return false, fmt.Errorf("check media usage: %w", err)
@@ -392,11 +413,23 @@ func IndexMediaRootWithProgress(
 		if report.Walked%progressInterval == 0 {
 			notify()
 		}
+		// Skip dotfiles, before the directory check so hidden subtrees are pruned
+		// too. The upload path writes its temp file as ".upload-*<ext>" in the
+		// destination directory, so a container kill mid-copy leaves a truncated
+		// image with a real extension sitting next to the finished ones. Adopting
+		// those would fill the library with entries that can never load -- Nginx
+		// refuses to serve dotfiles -- and whose bytes are partial anyway.
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") && absPath != uploadsDir {
+			if entry.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
 		if entry.IsDir() {
 			return nil
 		}
 
-		name := entry.Name()
 		ext := strings.ToLower(filepath.Ext(name))
 		mimeType, ok := mediaMimeByExt[ext]
 		if !ok {

--- a/server/internal/database/media_integration_test.go
+++ b/server/internal/database/media_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -139,6 +140,37 @@ func TestIndexMediaRoot_SkipsDerivativesAndRepeats(t *testing.T) {
 	}
 	if preserved.AltText != altText {
 		t.Fatalf("alt text = %q, want %q preserved across reindex", preserved.AltText, altText)
+	}
+}
+
+// An upload killed mid-copy leaves its ".upload-*" temp file, with a real image
+// extension, next to the finished assets. Indexing those would add rows for
+// truncated files that Nginx refuses to serve anyway (it denies dotfiles).
+func TestIndexMediaRoot_SkipsDotfiles(t *testing.T) {
+	conn := mediaTestDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+
+	writeFile(t, root, "wp-content/uploads/2026/07/story.jpg")
+	writeFile(t, root, "wp-content/uploads/2026/07/.upload-9f2c1a.jpg") // abandoned temp
+	writeFile(t, root, "wp-content/uploads/2026/07/.hidden/buried.jpg") // hidden subtree
+
+	report, err := IndexMediaRoot(ctx, conn, root, "wp-content/uploads")
+	if err != nil {
+		t.Fatalf("index: %v", err)
+	}
+	if report.Added != 1 || report.Scanned != 1 {
+		t.Fatalf("report = %+v, want 1 added / 1 scanned", report)
+	}
+
+	items, _, err := ListMedia(ctx, conn, models.MediaListParams{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, item := range items {
+		if strings.Contains(item.Path, "/.") {
+			t.Fatalf("indexed a dotfile: %s", item.Path)
+		}
 	}
 }
 

--- a/server/internal/handlers/media.go
+++ b/server/internal/handlers/media.go
@@ -71,6 +71,7 @@ const (
 // durable on disk and only the library row is missing.
 var (
 	errMediaNotConfigured = errors.New("media storage is not configured")
+	errMediaUnavailable   = errors.New("media storage is unavailable")
 	errUnsupportedType    = errors.New("unsupported file type")
 	errStoreFailed        = errors.New("failed to store upload")
 	errIndexFailed        = errors.New("file stored but could not be added to the media library")
@@ -88,8 +89,47 @@ var allowedImageTypes = map[string]string{
 
 var nonSlugChars = regexp.MustCompile(`[^a-z0-9]+`)
 
+// wpDerivativeSuffix matches the "-800x600" WordPress appends to generated
+// thumbnails. The indexer skips names of this shape (they are derivatives of an
+// original that is already in the library), so an *upload* must never be given
+// one: its row exists now, but a rebuild of the media table -- which the reseed
+// plan calls for -- would not adopt the file back while articles still point at
+// it. sanitizeBaseName defuses the shape instead.
+var wpDerivativeSuffix = regexp.MustCompile(`-\d+x\d+$`)
+
 func mediaRoot() string {
 	return strings.TrimRight(strings.TrimSpace(os.Getenv("MEDIA_ROOT")), "/")
+}
+
+// mediaSentinel is a MEDIA_ROOT-relative path that must exist for the media tree
+// to be considered mounted. Empty (the default) disables the check.
+func mediaSentinel() string {
+	return strings.Trim(strings.TrimSpace(os.Getenv("MEDIA_ROOT_SENTINEL")), "/")
+}
+
+// CheckMediaStorage reports whether MEDIA_ROOT looks like the real media tree
+// rather than an empty directory standing in for an unmounted filesystem.
+//
+// This matters because the Docker bind mount silently creates MEDIA_HOST_PATH if
+// CephFS is not mounted at deploy time. Without this check uploads land on the
+// host's local disk and index cleanly, and are then shadowed -- effectively lost
+// -- the moment the mount is repaired. MEDIA_ROOT_SENTINEL names something the
+// migrated corpus is known to contain (the uploads directory itself is the
+// natural choice); a fresh install with no corpus should leave it unset.
+func CheckMediaStorage() error {
+	root := mediaRoot()
+	if root == "" {
+		return errMediaNotConfigured
+	}
+	sentinel := mediaSentinel()
+	if sentinel == "" {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(sentinel))); err != nil {
+		return fmt.Errorf("%w: sentinel %q missing under MEDIA_ROOT %s (is the media filesystem mounted?)",
+			errMediaUnavailable, sentinel, root)
+	}
+	return nil
 }
 
 func maxUploadBytes() int64 {
@@ -128,13 +168,15 @@ func uploadURL(relPath string) string {
 // @Failure 415 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Failure 501 {object} models.ErrorResponse
+// @Failure 503 {object} models.ErrorResponse
 // @Security BearerAuth
 // @Router /v1/media [post]
 func PostMedia(conn *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		root := mediaRoot()
-		if root == "" {
-			writeError(w, http.StatusNotImplemented, "media storage is not configured")
+		if err := CheckMediaStorage(); err != nil {
+			// Checked before reading the body: there is no point streaming 90 MiB
+			// into a directory we are about to refuse to write to.
+			writeStoreImageError(w, err)
 			return
 		}
 
@@ -185,10 +227,10 @@ func PostMedia(conn *sql.DB) http.Handler {
 // src must be seekable: sniffing the content type consumes the leading bytes,
 // which have to be rewound before the file is written.
 func storeImage(ctx context.Context, conn *sql.DB, src io.ReadSeeker, filename string) (models.MediaUploadResponse, error) {
-	root := mediaRoot()
-	if root == "" {
-		return models.MediaUploadResponse{}, errMediaNotConfigured
+	if err := CheckMediaStorage(); err != nil {
+		return models.MediaUploadResponse{}, err
 	}
+	root := mediaRoot()
 
 	// Sniff the real content type from the leading bytes; never trust the
 	// client-provided extension or Content-Type.
@@ -262,6 +304,12 @@ func writeStoreImageError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, errMediaNotConfigured):
 		writeError(w, http.StatusNotImplemented, errMediaNotConfigured.Error())
+	case errors.Is(err, errMediaUnavailable):
+		// 503, not 500: the bytes were never touched and the request is worth
+		// retrying once the mount is back. The detail names a filesystem path,
+		// so it stays in the log.
+		slog.Error("media storage unavailable", "error", err)
+		writeError(w, http.StatusServiceUnavailable, errMediaUnavailable.Error())
 	case errors.Is(err, errUnsupportedType):
 		// Safe to echo in full: the only variable part is a sniffed MIME type.
 		writeError(w, http.StatusUnsupportedMediaType, err.Error())
@@ -292,12 +340,13 @@ func writeStoreImageError(w http.ResponseWriter, err error) {
 // @Failure 415 {object} models.ErrorResponse
 // @Failure 502 {object} models.ErrorResponse
 // @Failure 501 {object} models.ErrorResponse
+// @Failure 503 {object} models.ErrorResponse
 // @Security BearerAuth
 // @Router /v1/media/fetch [post]
 func PostMediaFetch(conn *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if mediaRoot() == "" {
-			writeError(w, http.StatusNotImplemented, errMediaNotConfigured.Error())
+		if err := CheckMediaStorage(); err != nil {
+			writeStoreImageError(w, err)
 			return
 		}
 
@@ -470,6 +519,13 @@ func sanitizeBaseName(filename string) string {
 	if base == "" {
 		base = "file"
 	}
+	// Never hand back a name the indexer would mistake for a WordPress
+	// derivative and skip (see wpDerivativeSuffix). "-" is already the separator
+	// this function emits, so "-img" cannot collide with a slug shape it
+	// produces for any other input.
+	if wpDerivativeSuffix.MatchString(base) {
+		base += "-img"
+	}
 	return base
 }
 
@@ -532,7 +588,27 @@ func storeUpload(dir, base, ext string, src io.Reader) (name string, size int64,
 		return "", 0, err
 	}
 	cleanup = false // renamed away
+
+	// tmp.Sync() above made the *contents* durable; the directory entry carrying
+	// the final name is separate metadata. Without this a crash between the
+	// rename and the next metadata flush could leave the DB row pointing at a
+	// name that never landed. Best effort: a failure here does not make the
+	// stored file any less usable right now.
+	syncDir(dir)
 	return name, size, nil
+}
+
+// syncDir flushes a directory's entries so a rename into it survives a crash.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		slog.Debug("media upload: could not open directory to sync", "dir", dir, "error", err)
+		return
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		slog.Debug("media upload: could not sync directory", "dir", dir, "error", err)
+	}
 }
 
 // reserveAndRename finds an unused "<base><ext>" / "<base>-N<ext>" name in dir by
@@ -920,7 +996,16 @@ func DeleteMediaItem(conn *sql.DB) http.Handler {
 		if !boolParam(r, "keep_file") {
 			if root := mediaRoot(); root != "" {
 				if abs, ok := resolveMediaPath(root, item.Path); ok {
-					_ = os.Remove(abs)
+					// The row is already gone, so a failed unlink leaves a file the
+					// next reindex will re-adopt -- as a new row, without the alt
+					// text and caption this one had. That looks like the delete
+					// silently undid itself, so it has to be visible in the log.
+					if err := os.Remove(abs); err != nil && !errors.Is(err, os.ErrNotExist) {
+						slog.Error("media delete: could not remove file; a reindex will re-add it",
+							"path", item.Path, "error", err)
+					} else {
+						syncDir(filepath.Dir(abs))
+					}
 				}
 			}
 		}
@@ -1019,15 +1104,19 @@ var mediaIndexer = &mediaIndexJob{}
 // @Success 202 {object} models.MediaIndexStatusResponse
 // @Failure 409 {object} models.ErrorResponse
 // @Failure 501 {object} models.ErrorResponse
+// @Failure 503 {object} models.ErrorResponse
 // @Security BearerAuth
 // @Router /v1/media/index [post]
 func PostMediaIndex(conn *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		root := mediaRoot()
-		if root == "" {
-			writeError(w, http.StatusNotImplemented, "media storage is not configured")
+		// An index over an unmounted root would walk an empty tree and report a
+		// clean "0 added", which reads as "the corpus is gone" rather than as the
+		// mount failure it is.
+		if err := CheckMediaStorage(); err != nil {
+			writeStoreImageError(w, err)
 			return
 		}
+		root := mediaRoot()
 
 		if !mediaIndexer.tryStart() {
 			writeError(w, http.StatusConflict, "a media index is already running")

--- a/server/internal/handlers/media_integration_test.go
+++ b/server/internal/handlers/media_integration_test.go
@@ -69,14 +69,16 @@ func mediaHTTPTestDB(t *testing.T) *sql.DB {
 	}
 
 	// Deleting an asset checks whether any article still points at it, so the
-	// fixture needs the one column that check reads.
+	// fixture needs the two columns that check reads: the lead image and the
+	// body HTML, which carries editor-inserted <img> tags.
 	if _, err := conn.ExecContext(ctx, "DROP TABLE IF EXISTS articles"); err != nil {
 		t.Fatalf("drop articles table: %v", err)
 	}
 	if _, err := conn.ExecContext(ctx, `
 		CREATE TABLE articles (
 			id BIGINT AUTO_INCREMENT PRIMARY KEY,
-			photo_url LONGTEXT
+			photo_url LONGTEXT,
+			`+"`text`"+` LONGTEXT
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
 	`); err != nil {
 		t.Fatalf("create articles table: %v", err)
@@ -239,6 +241,81 @@ func TestMediaHTTP_DeleteRefusesAssetInUse(t *testing.T) {
 	}
 	if _, err := db.GetMediaByID(context.Background(), conn, created.ID); err != nil {
 		t.Fatalf("a refused delete must leave the row alone: %v", err)
+	}
+}
+
+// The same protection for an image that only ever appears inside the article
+// body. Checking photo_url alone let this delete through and unlink a file a
+// published article was still rendering -- the one path here that destroyed
+// content rather than just confusing the library.
+func TestMediaHTTP_DeleteRefusesAssetUsedInArticleBody(t *testing.T) {
+	conn := mediaHTTPTestDB(t)
+	root := t.TempDir()
+	t.Setenv("MEDIA_ROOT", root)
+
+	rec := httptest.NewRecorder()
+	PostMedia(conn).ServeHTTP(rec, uploadRequest(t, "inline.png", pngBytes(t, 5, 5)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("upload status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var created models.MediaUploadResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode upload: %v", err)
+	}
+
+	// No photo_url at all: the reference exists only as an editor-inserted tag
+	// in the middle of the body HTML.
+	body := `<p>before</p><figure><img src="/` + created.Path + `" alt="x"></figure><p>after</p>`
+	if _, err := conn.ExecContext(context.Background(),
+		"INSERT INTO articles (`text`) VALUES (?)", body); err != nil {
+		t.Fatalf("seed article: %v", err)
+	}
+
+	delRec := httptest.NewRecorder()
+	DeleteMediaItem(conn).ServeHTTP(delRec, mediaIDRequest(t, http.MethodDelete, "/v1/media/1", created.ID, ""))
+	if delRec.Code != http.StatusConflict {
+		t.Fatalf("delete status = %d, want 409; body = %s", delRec.Code, delRec.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(created.Path))); err != nil {
+		t.Fatalf("a refused delete must leave the file alone: %v", err)
+	}
+}
+
+// An underscore is a LIKE single-char wildcard, and the migrated corpus is full
+// of names like IMG_1234.jpg. Unescaped, the usage check matched articles that
+// reference a *different* file and refused a legitimate delete.
+func TestMediaHTTP_DeleteIsNotBlockedByWildcardLookalike(t *testing.T) {
+	conn := mediaHTTPTestDB(t)
+	root := t.TempDir()
+	t.Setenv("MEDIA_ROOT", root)
+
+	relPath := "wp-content/uploads/2019/01/IMG_1234.jpg"
+	abs := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o775); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(abs, pngBytes(t, 2, 2), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	id, err := db.InsertMedia(context.Background(), conn, relPath, "image/jpeg", 10, 2, 2)
+	if err != nil {
+		t.Fatalf("insert media: %v", err)
+	}
+
+	// Differs from relPath only where the wildcard would match.
+	if _, err := conn.ExecContext(context.Background(),
+		"INSERT INTO articles (photo_url) VALUES (?)",
+		"https://media.example.org/wp-content/uploads/2019/01/IMGx1234.jpg"); err != nil {
+		t.Fatalf("seed article: %v", err)
+	}
+
+	delRec := httptest.NewRecorder()
+	DeleteMediaItem(conn).ServeHTTP(delRec, mediaIDRequest(t, http.MethodDelete, "/v1/media/1", id, ""))
+	if delRec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204; body = %s", delRec.Code, delRec.Body.String())
+	}
+	if _, err := os.Stat(abs); !os.IsNotExist(err) {
+		t.Fatalf("file should have been removed, stat err = %v", err)
 	}
 }
 

--- a/server/internal/handlers/media_test.go
+++ b/server/internal/handlers/media_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
@@ -147,6 +148,10 @@ func TestSanitizeBaseName(t *testing.T) {
 		{"discards windows separators", `C:\Users\me\pic.png`, "pic"},
 		{"falls back when nothing survives", "!!!.png", "file"},
 		{"truncates very long names", strings.Repeat("a", 300) + ".png", strings.Repeat("a", maxBaseNameLen)},
+		// A name shaped like a WordPress derivative would be skipped by the
+		// indexer, so a table rebuild would never re-adopt the file.
+		{"defuses the wp derivative shape", "poster-1920x1080.jpg", "poster-1920x1080-img"},
+		{"leaves a non-terminal size alone", "poster-1920x1080-crop.jpg", "poster-1920x1080-crop"},
 	}
 
 	for _, tt := range tests {
@@ -191,6 +196,59 @@ func TestStoreUpload_NeverClobbers(t *testing.T) {
 		if strings.HasPrefix(entry.Name(), ".upload-") {
 			t.Fatalf("leftover temp file: %s", entry.Name())
 		}
+	}
+}
+
+// The mount guard. An empty MEDIA_ROOT standing in for an unmounted CephFS must
+// not accept uploads: they would land on local disk and be shadowed -- lost --
+// as soon as the mount was repaired.
+func TestCheckMediaStorage(t *testing.T) {
+	t.Run("passes when the sentinel is unset", func(t *testing.T) {
+		t.Setenv("MEDIA_ROOT", t.TempDir())
+		t.Setenv("MEDIA_ROOT_SENTINEL", "")
+		if err := CheckMediaStorage(); err != nil {
+			t.Fatalf("CheckMediaStorage() = %v, want nil", err)
+		}
+	})
+
+	t.Run("fails on an unmounted-looking root", func(t *testing.T) {
+		t.Setenv("MEDIA_ROOT", t.TempDir())
+		t.Setenv("MEDIA_ROOT_SENTINEL", "wp-content/uploads")
+		if err := CheckMediaStorage(); !errors.Is(err, errMediaUnavailable) {
+			t.Fatalf("CheckMediaStorage() = %v, want errMediaUnavailable", err)
+		}
+	})
+
+	t.Run("passes once the sentinel exists", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "wp-content", "uploads"), 0o775); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		t.Setenv("MEDIA_ROOT", root)
+		t.Setenv("MEDIA_ROOT_SENTINEL", "wp-content/uploads")
+		if err := CheckMediaStorage(); err != nil {
+			t.Fatalf("CheckMediaStorage() = %v, want nil", err)
+		}
+	})
+
+	t.Run("reports unconfigured separately", func(t *testing.T) {
+		t.Setenv("MEDIA_ROOT", "")
+		if err := CheckMediaStorage(); !errors.Is(err, errMediaNotConfigured) {
+			t.Fatalf("CheckMediaStorage() = %v, want errMediaNotConfigured", err)
+		}
+	})
+}
+
+// A 503 rather than a 500 or a silent success: the bytes were never written and
+// the upload is worth retrying once the mount is back.
+func TestPostMedia_UnavailableStorageIs503(t *testing.T) {
+	t.Setenv("MEDIA_ROOT", t.TempDir())
+	t.Setenv("MEDIA_ROOT_SENTINEL", "wp-content/uploads")
+
+	rec := httptest.NewRecorder()
+	PostMedia(nil).ServeHTTP(rec, uploadRequest(t, "pic.png", pngBytes(t, 2, 2)))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body = %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -14,6 +14,7 @@ import (
 	"server/internal/akismet"
 	"server/internal/auth"
 	"server/internal/database"
+	"server/internal/handlers"
 	"server/internal/middleware"
 	"server/internal/routes"
 
@@ -128,6 +129,14 @@ func main() {
 	if err := database.EnsureMediaTable(context.Background(), db); err != nil {
 		slog.Error("failed to create media table", "error", err)
 		os.Exit(1)
+	}
+
+	// Surface a missing media mount at boot rather than on the first failed
+	// upload. Deliberately not fatal: the rest of the CMS works fine without the
+	// media tree, and taking the whole newsroom down over it would be worse than
+	// refusing uploads (which the handlers do on their own).
+	if err := handlers.CheckMediaStorage(); err != nil {
+		slog.Error("media storage check failed; uploads will be refused", "error", err)
 	}
 
 	if err := database.EnsureUsersTable(context.Background(), db); err != nil {


### PR DESCRIPTION
An audit of the media storage layer turned up one way to destroy published content and several ways for the library and the filesystem to drift apart.

The naming scheme itself is fine — `reserveAndRename`'s `O_EXCL` claim genuinely prevents an upload from ever clobbering the migrated WordPress corpus, even under concurrency, and `media.path` has a unique key. Everything here is around the edges of that.

## Content loss

**Deleting an asset only checked `articles.photo_url`.** Body images are embedded by the editor as `<img src>` inside `articles.text`, so an image used *only* inline looked unreferenced — the delete passed the in-use guard, dropped the row, and unlinked a file a published article was still rendering. The check now covers both columns.

While in there, it escapes LIKE metacharacters. `_` is a single-character wildcard and the corpus is full of names like `IMG_1234.jpg`, so the check was also refusing deletes for files nothing actually referenced.

## Silent loss on an unmounted media tree

The compose bind creates `MEDIA_HOST_PATH` if CephFS is not mounted at deploy time. Uploads into that empty directory succeed and index cleanly, then get shadowed — effectively lost — the moment the mount is repaired.

`MEDIA_ROOT_SENTINEL` (defaulted to `wp-content/uploads`) now names a path that must exist under `MEDIA_ROOT`. Upload, sideload, and reindex refuse with **503** when it is missing, and startup logs it.

Deliberately **not** fatal at startup: the rest of the CMS works fine without the media tree, so taking the whole backend down over it would be worse than refusing uploads. Set the var empty to disable the check on an install with no migrated corpus.

## Library/filesystem drift

- **Indexer skips dotfiles.** An upload killed mid-copy leaves its `.upload-*` temp file, carrying a real image extension, next to the finished assets. Adopting those filled the library with truncated entries that Nginx refuses to serve anyway. Placed before the directory check so hidden subtrees are pruned too.
- **Failed unlinks are logged, not swallowed.** The row is already gone by then, so the file returns as a *new* row on the next reindex, minus its alt text and caption — which reads as the delete having silently undone itself.
- **`sanitizeBaseName` defuses `-1920x1080`-shaped names.** The indexer treats that shape as a WordPress derivative and skips it, so a rebuild of the media table — which the reseed plan calls for — would not have re-adopted such an upload while articles still pointed at it.
- **Destination directory is fsynced** after the rename and after a delete. `tmp.Sync()` made the contents durable, but the directory entry carrying the final name is separate metadata.

## Testing

Two new integration tests were confirmed to fail against the old logic — the inline-body case returned **204** (deleting an in-use file) and the wildcard case **409** (blocking a valid delete), exactly the reported bugs. Verified against a real MariaDB 11.8; all 15 media tests pass, as does the full suite.

The handler integration fixture needed a `text` column on its `articles` table, since the in-use check now reads it.

Swagger regenerated with `swag` v1.16.6 to match `go.mod` — the only changes are the three new 503 responses, no incidental drift.

## Deliberately out of scope

Two items from the audit are features rather than fixes, and are storage growth only with no correctness risk: content-hash dedupe (repeated sideloads of the same URL still store fresh copies), and garbage-collecting the WP derivatives orphaned when a legacy original is deleted.

## Deploy note

`MEDIA_ROOT_SENTINEL` takes its default from `compose.cms.yml`, so no `cms.env` change is required — but confirm `/mnt/cephfs/media/wp-content/uploads` exists on Delta before rolling this out, or uploads will start answering 503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
