### PR TITLE
feat(polls): make start dates actually schedule polls

### DIFF
--- a/frontend/src/components/ui/datetime-field.tsx
+++ b/frontend/src/components/ui/datetime-field.tsx
@@ -1,0 +1,122 @@
+import * as React from "react"
+import { CalendarClock, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export type DateTimeFieldProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "onChange"> & {
+  label?: string
+  hint?: string
+  /** Shown in destructive styling under the field; also marks the input invalid. */
+  error?: string
+  /** Renders a clear button once a value is set. */
+  clearable?: boolean
+  value: string
+  onChange: (value: string) => void
+}
+
+// A native <input type="datetime-local"> styled to match the app's Input.
+//
+// Left alone, the control is the odd one out on every form it appears on: the
+// browser draws it in its own font at its own height, and the picker button is
+// a grey glyph that ignores the theme entirely. So the built-in indicator is
+// hidden and replaced with a real button that calls showPicker(), which keeps
+// the native picker (and native keyboard entry) while putting the trigger under
+// our own styling.
+const DateTimeField = React.forwardRef<HTMLInputElement, DateTimeFieldProps>(
+  ({ label, hint, error, clearable, value, onChange, className, disabled, id, ...props }, forwardedRef) => {
+    const generatedId = React.useId()
+    const fieldId = id ?? generatedId
+    const inputRef = React.useRef<HTMLInputElement | null>(null)
+
+    const setRefs = (node: HTMLInputElement | null) => {
+      inputRef.current = node
+      if (typeof forwardedRef === "function") forwardedRef(node)
+      else if (forwardedRef) forwardedRef.current = node
+    }
+
+    const openPicker = () => {
+      const input = inputRef.current
+      if (!input || disabled) return
+      // showPicker throws if the browser blocks it (no user gesture, or the
+      // control is not focusable); focusing is a fine fallback since the field
+      // is still typeable.
+      try {
+        input.showPicker()
+      } catch {
+        input.focus()
+      }
+    }
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        {label && (
+          <label htmlFor={fieldId} className="text-sm font-medium text-foreground">
+            {label}
+          </label>
+        )}
+        <div className="relative">
+          <input
+            {...props}
+            ref={setRefs}
+            id={fieldId}
+            type="datetime-local"
+            value={value}
+            disabled={disabled}
+            aria-invalid={error ? true : undefined}
+            onChange={(e) => onChange(e.target.value)}
+            className={cn(
+              "flex h-10 w-full rounded-lg border border-input bg-background font-sans text-sm text-foreground",
+              // Room on the right for the trigger (and the clear button beside it).
+              "pl-3 py-2",
+              clearable && value ? "pr-16" : "pr-10",
+              "ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              // The app is light-themed; saying so stops the browser painting
+              // the field's internals from the OS preference instead.
+              "[color-scheme:light]",
+              // Drop the browser's own picker glyph; ours replaces it. Removing
+              // it rather than covering it keeps clicking a segment (the month,
+              // the hour) working the way it does natively.
+              "[&::-webkit-calendar-picker-indicator]:hidden",
+              // An empty field otherwise shows near-black "mm/dd/yyyy" that
+              // reads as filled in; muted matches every other placeholder.
+              !value && "text-muted-foreground",
+              error && "border-destructive focus-visible:ring-destructive/40",
+              className,
+            )}
+          />
+          <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center gap-0.5 pr-1.5">
+            {clearable && value && (
+              <button
+                type="button"
+                onClick={() => onChange("")}
+                disabled={disabled}
+                aria-label={label ? `Clear ${label.toLowerCase()}` : "Clear date"}
+                className="pointer-events-auto rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+            <button
+              type="button"
+              tabIndex={-1}
+              onClick={openPicker}
+              disabled={disabled}
+              aria-label={label ? `Open ${label.toLowerCase()} picker` : "Open date picker"}
+              className="pointer-events-auto rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-primary"
+            >
+              <CalendarClock className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+        {error ? (
+          <p className="text-xs text-destructive">{error}</p>
+        ) : (
+          hint && <p className="text-xs text-muted-foreground">{hint}</p>
+        )}
+      </div>
+    )
+  },
+)
+DateTimeField.displayName = "DateTimeField"
+
+export { DateTimeField }

--- a/frontend/src/pages/pollView.tsx
+++ b/frontend/src/pages/pollView.tsx
@@ -2,8 +2,22 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import type { FormEvent } from "react"
 import { Pencil, Plus, Trash2, RefreshCw, Check, X, Play, Archive } from "lucide-react"
 import { useApiFetch } from "../hooks/useApiFetch"
+import { DateTimeField } from "../components/ui/datetime-field"
 
 type PollStatus = "draft" | "active" | "closed"
+
+// What the poll is doing right now, computed server-side from its status and
+// its date window. The editor displays this rather than status so it can never
+// claim a poll is running when readers cannot see it.
+type PollState = "draft" | "scheduled" | "live" | "ended" | "superseded" | "closed"
+
+type PublishTiming = "draft" | "now" | "schedule"
+
+const TIMING_OPTIONS: { value: PublishTiming; label: string; blurb: string }[] = [
+  { value: "draft", label: "Save as draft", blurb: "Nobody sees it until you publish." },
+  { value: "now", label: "Publish now", blurb: "Goes on the site as soon as you save." },
+  { value: "schedule", label: "Schedule", blurb: "Goes on the site at the start date." },
+]
 
 type PollOption = {
   id: number
@@ -16,6 +30,7 @@ type Poll = {
   id: number
   question: string
   status: PollStatus
+  state: PollState
   starts_at?: string
   ends_at?: string
   total_votes: number
@@ -26,10 +41,13 @@ type PollListResponse = {
   polls?: Poll[]
 }
 
-const STATUS_STYLES: Record<PollStatus, string> = {
-  active: "bg-emerald-500/10 text-emerald-600 border-emerald-500/30",
-  draft: "bg-amber-500/10 text-amber-600 border-amber-500/30",
-  closed: "bg-muted text-muted-foreground border-border",
+const STATE_META: Record<PollState, { label: string; className: string }> = {
+  live: { label: "Live", className: "bg-emerald-500/10 text-emerald-600 border-emerald-500/30" },
+  scheduled: { label: "Scheduled", className: "bg-blue-500/10 text-blue-600 border-blue-500/30" },
+  draft: { label: "Draft", className: "bg-amber-500/10 text-amber-600 border-amber-500/30" },
+  ended: { label: "Ended", className: "bg-muted text-muted-foreground border-border" },
+  superseded: { label: "Replaced", className: "bg-muted text-muted-foreground border-border" },
+  closed: { label: "Closed", className: "bg-muted text-muted-foreground border-border" },
 }
 
 // The API speaks RFC3339; <input type="datetime-local"> speaks "YYYY-MM-DDTHH:mm"
@@ -56,6 +74,80 @@ function formatRunDate(value?: string): string {
   })
 }
 
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ["minute", 60_000],
+  ["hour", 3_600_000],
+  ["day", 86_400_000],
+  ["week", 604_800_000],
+  ["month", 2_629_800_000],
+  ["year", 31_557_600_000],
+]
+
+// "in 3 days" / "2 hours ago". An absolute timestamp alone makes an editor do
+// the arithmetic to answer the only question they actually have, which is
+// whether this happens before or after the thing they are about to do.
+function relativeDate(value?: string): string {
+  if (!value) return ""
+  const target = new Date(value).getTime()
+  if (Number.isNaN(target)) return ""
+  const diff = target - Date.now()
+  if (Math.abs(diff) < 60_000) return diff >= 0 ? "any moment now" : "just now"
+
+  let unit = RELATIVE_UNITS[0]
+  for (const candidate of RELATIVE_UNITS) {
+    if (Math.abs(diff) >= candidate[1]) unit = candidate
+  }
+  return new Intl.RelativeTimeFormat(undefined, { numeric: "auto" }).format(
+    Math.round(diff / unit[1]),
+    unit[0],
+  )
+}
+
+// One plain-language sentence about where the poll sits in its schedule.
+function scheduleSummary(poll: Poll): string {
+  switch (poll.state) {
+    case "live":
+      return poll.ends_at
+        ? `On the site now — closes ${relativeDate(poll.ends_at)}, ${formatRunDate(poll.ends_at)}`
+        : "On the site now — runs until you replace or close it"
+    case "scheduled":
+      return `Goes live ${relativeDate(poll.starts_at)}, ${formatRunDate(poll.starts_at)}${
+        poll.ends_at ? ` — closes ${formatRunDate(poll.ends_at)}` : ""
+      }`
+    case "draft":
+      return poll.starts_at
+        ? `Not published. Publishing keeps its start date of ${formatRunDate(poll.starts_at)}`
+        : "Not published — readers cannot see this"
+    case "ended":
+      return `Ended ${relativeDate(poll.ends_at)}, ${formatRunDate(poll.ends_at)}`
+    case "superseded":
+      return "Taken off the site by a later poll"
+    case "closed":
+      return poll.starts_at ? `Closed — ran from ${formatRunDate(poll.starts_at)}` : "Closed"
+  }
+}
+
+// Local "YYYY-MM-DDTHH:mm" strings compare correctly as strings, but only
+// against each other; anything involving "now" has to go through Date.
+function isPast(localValue: string): boolean {
+  return localValue !== "" && new Date(localValue).getTime() <= Date.now()
+}
+
+// Whether publishing this poll would queue it rather than put it straight on
+// the site -- the difference between "this replaces what is running" and "this
+// waits its turn".
+function startsLater(poll: Poll): boolean {
+  return !!poll.starts_at && new Date(poll.starts_at).getTime() > Date.now()
+}
+
+// Ordering only. Editing a poll that has already run must stay possible, so a
+// date in the past is not by itself an error -- the create form checks that
+// separately, where it really would mean "publish something already over".
+function windowError(startsAt: string, endsAt: string): string {
+  if (startsAt && endsAt && endsAt <= startsAt) return "The end date must come after the start date."
+  return ""
+}
+
 export default function PollView() {
   const apiFetch = useApiFetch()
   const [polls, setPolls] = useState<Poll[]>([])
@@ -68,7 +160,9 @@ export default function PollView() {
   const [newOptions, setNewOptions] = useState("")
   const [newStartsAt, setNewStartsAt] = useState("")
   const [newEndsAt, setNewEndsAt] = useState("")
-  const [newActivate, setNewActivate] = useState(false)
+  // Publishing is one decision with three answers, not a checkbox plus two
+  // dates that quietly mean different things depending on which are filled in.
+  const [newTiming, setNewTiming] = useState<PublishTiming>("draft")
 
   const [editingPollId, setEditingPollId] = useState<number | null>(null)
   const [editQuestion, setEditQuestion] = useState("")
@@ -80,7 +174,23 @@ export default function PollView() {
   const [renamingOptionId, setRenamingOptionId] = useState<number | null>(null)
   const [renameValue, setRenameValue] = useState("")
 
-  const activePoll = useMemo(() => polls.find((poll) => poll.status === "active"), [polls])
+  const livePoll = useMemo(() => polls.find((poll) => poll.state === "live"), [polls])
+  const queuedPolls = useMemo(() => polls.filter((poll) => poll.state === "scheduled"), [polls])
+
+  const editWindowError = useMemo(
+    () => windowError(editStartsAt, editEndsAt),
+    [editStartsAt, editEndsAt],
+  )
+
+  const newWindowError = useMemo(() => {
+    if (newTiming === "schedule" && newStartsAt && isPast(newStartsAt)) {
+      return "That start date has already passed. Pick a later one, or choose Publish now."
+    }
+    const ordering = windowError(newTiming === "schedule" ? newStartsAt : "", newEndsAt)
+    if (ordering) return ordering
+    if (newEndsAt && isPast(newEndsAt)) return "That end date has already passed."
+    return ""
+  }, [newTiming, newStartsAt, newEndsAt])
 
   const loadPolls = useCallback(async () => {
     setIsLoading(true)
@@ -135,7 +245,8 @@ export default function PollView() {
   const createPoll = async (e: FormEvent) => {
     e.preventDefault()
     const question = newQuestion.trim()
-    if (!question) return
+    if (!question || newWindowError) return
+    if (newTiming === "schedule" && !newStartsAt) return
 
     const options = newOptions
       .split("\n")
@@ -150,9 +261,11 @@ export default function PollView() {
         body: JSON.stringify({
           question,
           options,
-          status: newActivate ? "active" : "draft",
-          starts_at: newStartsAt || null,
-          ends_at: newEndsAt || null,
+          // "Now" and "scheduled" are the same published status; the start date
+          // is what decides when readers see it.
+          status: newTiming === "draft" ? "draft" : "active",
+          starts_at: newTiming === "schedule" ? newStartsAt : null,
+          ends_at: newTiming === "draft" ? null : newEndsAt || null,
         }),
       },
       "Failed to create poll",
@@ -163,14 +276,14 @@ export default function PollView() {
       setNewOptions("")
       setNewStartsAt("")
       setNewEndsAt("")
-      setNewActivate(false)
+      setNewTiming("draft")
       setIsCreating(false)
     }
   }
 
   const savePollEdits = async (pollId: number) => {
     const question = editQuestion.trim()
-    if (!question) return
+    if (!question || editWindowError) return
     const ok = await mutate(
       `/v1/polls/${pollId}`,
       {
@@ -198,6 +311,22 @@ export default function PollView() {
       },
       "Failed to change poll status",
     )
+
+  // Publishing something that goes live immediately displaces the poll on the
+  // site, which is not recoverable from the editor -- so ask. A poll queued
+  // behind a start date displaces nothing yet, so it just publishes.
+  const publishPoll = (poll: Poll) => {
+    if (!startsLater(poll) && livePoll && livePoll.id !== poll.id) {
+      if (
+        !confirm(
+          `Publish "${poll.question}" now?\n\nThis takes "${livePoll.question}" off the site immediately. Its results are kept.`,
+        )
+      ) {
+        return
+      }
+    }
+    void setStatus(poll.id, "active")
+  }
 
   const deletePoll = (poll: Poll) => {
     if (
@@ -263,8 +392,8 @@ export default function PollView() {
             {isLoading
               ? "Loading..."
               : `${polls.length} poll${polls.length === 1 ? "" : "s"} • ${
-                  activePoll ? `running: ${activePoll.question}` : "none running"
-                }`}
+                  livePoll ? `on the site: ${livePoll.question}` : "nothing on the site"
+                }${queuedPolls.length ? ` • ${queuedPolls.length} scheduled` : ""}`}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -318,41 +447,86 @@ export default function PollView() {
             />
             <p className="text-xs text-muted-foreground">One option per line. You can add more later.</p>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium text-foreground">Start date</label>
-              <input
-                type="datetime-local"
-                value={newStartsAt}
-                onChange={(e) => setNewStartsAt(e.target.value)}
-                className="px-3 py-2 rounded-lg border border-border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium text-foreground">End date</label>
-              <input
-                type="datetime-local"
-                value={newEndsAt}
-                onChange={(e) => setNewEndsAt(e.target.value)}
-                className="px-3 py-2 rounded-lg border border-border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
-              />
-              <p className="text-xs text-muted-foreground">Leave blank for no expiry.</p>
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium text-foreground">When should this run?</span>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {TIMING_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className={`cursor-pointer rounded-lg border px-3 py-2.5 transition-colors ${
+                    newTiming === option.value
+                      ? "border-primary bg-primary/5 ring-1 ring-primary/30"
+                      : "border-border hover:bg-muted/40"
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="poll-timing"
+                      className="accent-primary"
+                      checked={newTiming === option.value}
+                      onChange={() => setNewTiming(option.value)}
+                    />
+                    <span className="text-sm font-medium text-foreground">{option.label}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1 pl-6">{option.blurb}</p>
+                </label>
+              ))}
             </div>
           </div>
-          <label className="flex items-center gap-2 text-sm text-foreground">
-            <input type="checkbox" checked={newActivate} onChange={(e) => setNewActivate(e.target.checked)} />
-            Publish immediately
-            {activePoll && newActivate && (
-              <span className="text-xs text-amber-600">(this will close "{activePoll.question}")</span>
-            )}
-          </label>
+
+          {newTiming !== "draft" && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {newTiming === "schedule" && (
+                <DateTimeField
+                  label="Start date"
+                  value={newStartsAt}
+                  onChange={setNewStartsAt}
+                  clearable
+                  hint={
+                    newStartsAt && !isPast(newStartsAt)
+                      ? `Goes on the site ${relativeDate(newStartsAt)}.`
+                      : "Readers see the poll from this moment."
+                  }
+                />
+              )}
+              <DateTimeField
+                label="End date"
+                value={newEndsAt}
+                onChange={setNewEndsAt}
+                clearable
+                hint="Optional. Leave blank to run until you replace it."
+              />
+            </div>
+          )}
+
+          {newWindowError && <p className="text-xs text-destructive">{newWindowError}</p>}
+
+          {/* Publishing takes a slot that only holds one poll, so say up front
+              what happens to whatever is in it. */}
+          {newTiming === "now" && livePoll && (
+            <p className="text-xs text-amber-600">
+              This closes "{livePoll.question}" as soon as you save.
+            </p>
+          )}
+          {newTiming === "schedule" && newStartsAt && !newWindowError && livePoll && (
+            <p className="text-xs text-muted-foreground">
+              "{livePoll.question}" keeps running until then, and is replaced automatically.
+            </p>
+          )}
+
           <div className="flex items-center gap-2">
             <button
               type="submit"
-              disabled={isSaving || !newQuestion.trim()}
+              disabled={
+                isSaving ||
+                !newQuestion.trim() ||
+                !!newWindowError ||
+                (newTiming === "schedule" && !newStartsAt)
+              }
               className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-60"
             >
-              Create poll
+              {newTiming === "now" ? "Publish poll" : newTiming === "schedule" ? "Schedule poll" : "Save draft"}
             </button>
             <button
               type="button"
@@ -389,30 +563,31 @@ export default function PollView() {
                         className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
                       />
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                          Start date
-                          <input
-                            type="datetime-local"
-                            value={editStartsAt}
-                            onChange={(e) => setEditStartsAt(e.target.value)}
-                            className="px-2 py-1.5 rounded-md border border-border bg-background text-sm text-foreground"
-                          />
-                        </label>
-                        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-                          End date (blank = no expiry)
-                          <input
-                            type="datetime-local"
-                            value={editEndsAt}
-                            onChange={(e) => setEditEndsAt(e.target.value)}
-                            className="px-2 py-1.5 rounded-md border border-border bg-background text-sm text-foreground"
-                          />
-                        </label>
+                        <DateTimeField
+                          label="Start date"
+                          value={editStartsAt}
+                          onChange={setEditStartsAt}
+                          clearable
+                          hint={
+                            poll.status === "active" && editStartsAt && !isPast(editStartsAt)
+                              ? "Published, but held back until this date."
+                              : "Blank means it starts the moment it is published."
+                          }
+                        />
+                        <DateTimeField
+                          label="End date"
+                          value={editEndsAt}
+                          onChange={setEditEndsAt}
+                          clearable
+                          error={editWindowError}
+                          hint="Blank means no expiry."
+                        />
                       </div>
                       <div className="flex items-center gap-2">
                         <button
                           type="button"
                           onClick={() => savePollEdits(poll.id)}
-                          disabled={isSaving || !editQuestion.trim()}
+                          disabled={isSaving || !editQuestion.trim() || !!editWindowError}
                           className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-primary text-primary-foreground disabled:opacity-60"
                         >
                           <Check className="w-3.5 h-3.5" />
@@ -433,15 +608,14 @@ export default function PollView() {
                       <div className="flex items-center gap-2 flex-wrap">
                         <h2 className="font-semibold text-foreground">{poll.question}</h2>
                         <span
-                          className={`text-[11px] uppercase tracking-wide px-2 py-0.5 rounded-full border ${STATUS_STYLES[poll.status]}`}
+                          className={`text-[11px] uppercase tracking-wide px-2 py-0.5 rounded-full border ${STATE_META[poll.state].className}`}
                         >
-                          {poll.status}
+                          {STATE_META[poll.state].label}
                         </span>
                       </div>
-                      <p className="text-xs text-muted-foreground mt-1">
+                      <p className="text-xs text-muted-foreground mt-1">{scheduleSummary(poll)}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
                         {poll.total_votes.toLocaleString()} vote{poll.total_votes === 1 ? "" : "s"}
-                        {poll.starts_at && ` • Start: ${formatRunDate(poll.starts_at)}`}
-                        {` • End: ${poll.ends_at ? formatRunDate(poll.ends_at) : "No Expiry"}`}
                       </p>
                     </>
                   )}
@@ -452,10 +626,14 @@ export default function PollView() {
                     {poll.status !== "active" && (
                       <button
                         type="button"
-                        onClick={() => setStatus(poll.id, "active")}
+                        onClick={() => publishPoll(poll)}
                         disabled={isSaving}
                         className="p-1.5 rounded-lg text-muted-foreground hover:text-emerald-600 hover:bg-emerald-500/10 transition-colors"
-                        title="Make this the running poll"
+                        title={
+                          startsLater(poll)
+                            ? `Publish — goes live ${formatRunDate(poll.starts_at)}`
+                            : "Publish — goes on the site now"
+                        }
                       >
                         <Play className="w-4 h-4" />
                       </button>
@@ -466,7 +644,7 @@ export default function PollView() {
                         onClick={() => setStatus(poll.id, "closed")}
                         disabled={isSaving}
                         className="p-1.5 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 transition-colors"
-                        title="Close this poll"
+                        title={poll.state === "scheduled" ? "Cancel this scheduled poll" : "Take this poll off the site"}
                       >
                         <Archive className="w-4 h-4" />
                       </button>

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -2782,7 +2782,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creating a poll with status \"active\" closes whichever poll was previously active.",
+                "description": "Creating a poll with status \"active\" publishes it when its start date arrives; if that date has already passed (or none was given) it goes live at once and closes the poll that was running.",
                 "consumes": [
                     "application/json"
                 ],
@@ -5624,6 +5624,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "starts_at": {
+                    "type": "string"
+                },
+                "state": {
                     "type": "string"
                 },
                 "status": {

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -2779,7 +2779,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creating a poll with status \"active\" closes whichever poll was previously active.",
+                "description": "Creating a poll with status \"active\" publishes it when its start date arrives; if that date has already passed (or none was given) it goes live at once and closes the poll that was running.",
                 "consumes": [
                     "application/json"
                 ],
@@ -5621,6 +5621,9 @@
                     "type": "string"
                 },
                 "starts_at": {
+                    "type": "string"
+                },
+                "state": {
                     "type": "string"
                 },
                 "status": {

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -899,6 +899,8 @@ definitions:
         type: string
       starts_at:
         type: string
+      state:
+        type: string
       status:
         type: string
       total_votes:
@@ -2878,8 +2880,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Creating a poll with status "active" closes whichever poll was
-        previously active.
+      description: Creating a poll with status "active" publishes it when its start
+        date arrives; if that date has already passed (or none was given) it goes
+        live at once and closes the poll that was running.
       parameters:
       - description: Poll
         in: body

--- a/server/internal/database/polls.go
+++ b/server/internal/database/polls.go
@@ -28,8 +28,13 @@ const (
 	LegacyPollTableName = "cms_poll_counts"
 )
 
-// Poll lifecycle. Only one poll may be Active at a time; PublishPoll enforces
-// that by closing whichever poll currently holds the status.
+// Poll lifecycle. Status is what an editor sets; it means "in rotation", not
+// "on the site right now". A poll is only served to readers once its start date
+// has arrived and its end date has not passed -- that is what makes start dates
+// actually schedule instead of being decoration. See LivePollID.
+//
+// Several polls may therefore hold Active at once (one running, others queued
+// behind their start dates). At most one is ever live.
 const (
 	PollStatusDraft  = "draft"
 	PollStatusActive = "active"
@@ -41,6 +46,24 @@ var ValidPollStatuses = map[string]bool{
 	PollStatusActive: true,
 	PollStatusClosed: true,
 }
+
+// Poll states are the derived, editor-facing view of status + date window.
+// Unlike status they are computed, never stored, so they cannot drift.
+//
+//	draft       not published
+//	scheduled   active, start date still in the future
+//	live        the one poll readers see right now
+//	ended       active, but its end date has passed
+//	superseded  active, but a later-starting poll took over
+//	closed      retired by an editor
+const (
+	PollStateDraft      = "draft"
+	PollStateScheduled  = "scheduled"
+	PollStateLive       = "live"
+	PollStateEnded      = "ended"
+	PollStateSuperseded = "superseded"
+	PollStateClosed     = "closed"
+)
 
 // ErrNoActivePoll is returned when a read or vote targets the active poll and
 // there isn't one. Callers map this to 404 rather than 500 -- "no poll running"
@@ -316,23 +339,72 @@ func GetPollByID(ctx context.Context, conn *sql.DB, id int64) (*Poll, error) {
 	return &polls[0], nil
 }
 
-// GetActivePoll returns the single active poll, or ErrNoActivePoll.
+// LivePollID returns the poll readers should see right now, or ErrNoActivePoll.
 //
-// Ordering by id DESC is a safety net: the write paths keep at most one poll
-// active, but if that invariant were ever broken the newest one wins instead of
-// the result being nondeterministic.
-func GetActivePoll(ctx context.Context, conn *sql.DB) (*Poll, error) {
+// The rule is "the most recently started active poll, unless it has ended":
+//
+//   - a poll scheduled for next week is invisible until next week, so an editor
+//     can queue one without disturbing what is running;
+//   - when it starts it takes over, because it started later;
+//   - an earlier poll can never come back afterwards, even if it never had an
+//     end date -- it was superseded, and resurrection would be baffling.
+//
+// The end date is checked in Go rather than in the WHERE clause on purpose. As
+// a SQL filter it would skip the ended poll and hand the slot back to the one
+// underneath it, which is exactly the resurrection this avoids.
+func LivePollID(ctx context.Context, conn *sql.DB) (int64, error) {
 	var id int64
-	err := conn.QueryRowContext(ctx,
-		`SELECT id FROM `+PollsTableName+` WHERE status = ? ORDER BY id DESC LIMIT 1`,
-		PollStatusActive).Scan(&id)
+	var endsAt *time.Time
+	// COALESCE mirrors ListPolls: a poll with no explicit start date is treated
+	// as having started when it was created.
+	err := conn.QueryRowContext(ctx, `
+		SELECT id, ends_at FROM `+PollsTableName+`
+		WHERE status = ? AND (starts_at IS NULL OR starts_at <= NOW())
+		ORDER BY COALESCE(starts_at, created_at) DESC, id DESC
+		LIMIT 1
+	`, PollStatusActive).Scan(&id, &endsAt)
 	if err == sql.ErrNoRows {
-		return nil, ErrNoActivePoll
+		return 0, ErrNoActivePoll
 	}
+	if err != nil {
+		return 0, err
+	}
+	if endsAt != nil && time.Now().After(*endsAt) {
+		return 0, ErrNoActivePoll
+	}
+	return id, nil
+}
+
+// GetActivePoll returns the poll that is live right now, or ErrNoActivePoll.
+func GetActivePoll(ctx context.Context, conn *sql.DB) (*Poll, error) {
+	id, err := LivePollID(ctx, conn)
 	if err != nil {
 		return nil, err
 	}
 	return GetPollByID(ctx, conn, id)
+}
+
+// State reports the poll's editor-facing state. liveID is the result of
+// LivePollID (0 when nothing is live); passing it in keeps this a pure function
+// so a list of polls can be labelled from a single query.
+func (p Poll) State(now time.Time, liveID int64) string {
+	switch p.Status {
+	case PollStatusDraft:
+		return PollStateDraft
+	case PollStatusClosed:
+		return PollStateClosed
+	}
+	if p.ID == liveID {
+		return PollStateLive
+	}
+	if p.StartsAt != nil && now.Before(*p.StartsAt) {
+		return PollStateScheduled
+	}
+	if p.EndsAt != nil && now.After(*p.EndsAt) {
+		return PollStateEnded
+	}
+	// Started, not ended, but something else holds the slot.
+	return PollStateSuperseded
 }
 
 // AcceptsVotes reports whether the poll is open right now. Status is the primary
@@ -358,8 +430,8 @@ func CreatePoll(ctx context.Context, conn *sql.DB, question, status string, star
 	}
 	defer tx.Rollback()
 
-	if status == PollStatusActive {
-		if err := closeActivePollsTx(ctx, tx); err != nil {
+	if status == PollStatusActive && startsNow(startsAt, endsAt, time.Now()) {
+		if err := closeRunningPollsTx(ctx, tx, 0); err != nil {
 			return 0, err
 		}
 	}
@@ -405,10 +477,17 @@ func UpdatePoll(ctx context.Context, conn *sql.DB, id int64, question *string, s
 	defer tx.Rollback()
 
 	if status != nil && *status == PollStatusActive {
-		if _, err := tx.ExecContext(ctx,
-			`UPDATE `+PollsTableName+` SET status = ? WHERE status = ? AND id <> ?`,
-			PollStatusClosed, PollStatusActive, id); err != nil {
+		// Whether this displaces the running poll depends on the dates the row
+		// will have *after* this update, which for an omitted field means the
+		// ones it already has -- so read them inside the transaction.
+		effStarts, effEnds, err := effectiveWindowTx(ctx, tx, id, startsAt, endsAt, clearStarts, clearEnds)
+		if err != nil {
 			return err
+		}
+		if startsNow(effStarts, effEnds, time.Now()) {
+			if err := closeRunningPollsTx(ctx, tx, id); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -458,10 +537,55 @@ func UpdatePoll(ctx context.Context, conn *sql.DB, id int64, question *string, s
 	return tx.Commit()
 }
 
-func closeActivePollsTx(ctx context.Context, tx *sql.Tx) error {
-	_, err := tx.ExecContext(ctx,
-		`UPDATE `+PollsTableName+` SET status = ? WHERE status = ?`,
-		PollStatusClosed, PollStatusActive)
+// startsNow reports whether a poll with this window would be on the site the
+// moment it is made active, as opposed to queued behind a future start date or
+// already past its end date.
+func startsNow(startsAt, endsAt *time.Time, now time.Time) bool {
+	if startsAt != nil && now.Before(*startsAt) {
+		return false
+	}
+	if endsAt != nil && now.After(*endsAt) {
+		return false
+	}
+	return true
+}
+
+// effectiveWindowTx resolves the dates a poll will have once the supplied
+// partial update is applied: an explicit clear wins, then a supplied value, and
+// otherwise whatever is already stored.
+func effectiveWindowTx(ctx context.Context, tx *sql.Tx, id int64, startsAt, endsAt *time.Time, clearStarts, clearEnds bool) (*time.Time, *time.Time, error) {
+	var storedStarts, storedEnds *time.Time
+	err := tx.QueryRowContext(ctx,
+		`SELECT starts_at, ends_at FROM `+PollsTableName+` WHERE id = ?`, id).
+		Scan(&storedStarts, &storedEnds)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, nil, err
+	}
+
+	resolve := func(supplied, stored *time.Time, clear bool) *time.Time {
+		if clear {
+			return nil
+		}
+		if supplied != nil {
+			return supplied
+		}
+		return stored
+	}
+	return resolve(startsAt, storedStarts, clearStarts), resolve(endsAt, storedEnds, clearEnds), nil
+}
+
+// closeRunningPollsTx retires the polls that are on the site right now, so a
+// poll being published immediately takes over a slot that only ever holds one.
+//
+// Polls queued behind a future start date are deliberately left alone: closing
+// them here is what used to make scheduling destructive, wiping the queue every
+// time someone published something. exceptID is skipped (0 matches no row).
+func closeRunningPollsTx(ctx context.Context, tx *sql.Tx, exceptID int64) error {
+	_, err := tx.ExecContext(ctx, `
+		UPDATE `+PollsTableName+`
+		SET status = ?
+		WHERE status = ? AND id <> ? AND (starts_at IS NULL OR starts_at <= NOW())
+	`, PollStatusClosed, PollStatusActive, exceptID)
 	return err
 }
 

--- a/server/internal/database/polls_integration_test.go
+++ b/server/internal/database/polls_integration_test.go
@@ -112,7 +112,7 @@ func TestPollMigrateLegacyPoll(t *testing.T) {
 	}
 }
 
-func TestPollOnlyOneActiveAtATime(t *testing.T) {
+func TestPollOnlyOneRunningAtATime(t *testing.T) {
 	conn := pollTestDB(t)
 	ctx := context.Background()
 
@@ -157,6 +157,85 @@ func TestPollOnlyOneActiveAtATime(t *testing.T) {
 	}
 }
 
+// Queuing a poll behind a future start date is the whole point of having start
+// dates: it must not disturb whatever is running, and it must take over by
+// itself when its time comes.
+func TestPollScheduledPollWaitsForItsStartDate(t *testing.T) {
+	conn := pollTestDB(t)
+	ctx := context.Background()
+
+	// Dated explicitly rather than left NULL so the two polls sit on a realistic
+	// timeline: one that has been up for a week, one queued for next week.
+	lastWeek := time.Now().Add(-7 * 24 * time.Hour)
+	running, err := CreatePoll(ctx, conn, "Running now", PollStatusActive, &lastWeek, nil, []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("create running poll: %v", err)
+	}
+
+	nextWeek := time.Now().Add(7 * 24 * time.Hour)
+	queued, err := CreatePoll(ctx, conn, "Next week", PollStatusActive, &nextWeek, nil, []string{"c", "d"})
+	if err != nil {
+		t.Fatalf("create scheduled poll: %v", err)
+	}
+
+	live, err := GetActivePoll(ctx, conn)
+	if err != nil {
+		t.Fatalf("get live poll: %v", err)
+	}
+	if live.ID != running {
+		t.Fatalf("live poll = %d, want the already-running %d", live.ID, running)
+	}
+
+	stillRunning, err := GetPollByID(ctx, conn, running)
+	if err != nil {
+		t.Fatalf("get running poll: %v", err)
+	}
+	if stillRunning.Status != PollStatusActive {
+		t.Fatalf("running poll status = %q, want %q -- scheduling closed it", stillRunning.Status, PollStatusActive)
+	}
+
+	scheduled, err := GetPollByID(ctx, conn, queued)
+	if err != nil {
+		t.Fatalf("get scheduled poll: %v", err)
+	}
+	if got := scheduled.State(time.Now(), running); got != PollStateScheduled {
+		t.Fatalf("scheduled poll state = %q, want %q", got, PollStateScheduled)
+	}
+	if scheduled.AcceptsVotes(time.Now()) {
+		t.Fatalf("scheduled poll accepts votes before its start date")
+	}
+
+	// Simulate the start date arriving. Nothing sweeps polls, so the takeover
+	// has to fall out of the read path on its own.
+	if _, err := conn.ExecContext(ctx,
+		"UPDATE "+PollsTableName+" SET starts_at = ? WHERE id = ?",
+		time.Now().Add(-time.Minute), queued); err != nil {
+		t.Fatalf("advance start date: %v", err)
+	}
+
+	live, err = GetActivePoll(ctx, conn)
+	if err != nil {
+		t.Fatalf("get live poll after start: %v", err)
+	}
+	if live.ID != queued {
+		t.Fatalf("live poll = %d, want the newly started %d", live.ID, queued)
+	}
+	if got := stillRunning.State(time.Now(), queued); got != PollStateSuperseded {
+		t.Fatalf("displaced poll state = %q, want %q", got, PollStateSuperseded)
+	}
+
+	// And when the poll that took over ends, the one it displaced must stay
+	// displaced rather than popping back onto the site.
+	if _, err := conn.ExecContext(ctx,
+		"UPDATE "+PollsTableName+" SET ends_at = ? WHERE id = ?",
+		time.Now().Add(-time.Second), queued); err != nil {
+		t.Fatalf("expire taken-over poll: %v", err)
+	}
+	if _, err := GetActivePoll(ctx, conn); err != ErrNoActivePoll {
+		t.Fatalf("live poll after the queue drained = %v, want ErrNoActivePoll", err)
+	}
+}
+
 func TestPollVoting(t *testing.T) {
 	conn := pollTestDB(t)
 	ctx := context.Background()
@@ -194,15 +273,29 @@ func TestPollExpiredWindowRejectsVotes(t *testing.T) {
 	ctx := context.Background()
 
 	// Active status but an end date in the past: the window check is what must
-	// stop the vote, since nothing sweeps expired polls into "closed".
+	// stop the vote, since nothing sweeps expired polls into "closed". The poll
+	// drops off the site entirely, so the vote fails on there being nothing to
+	// vote on rather than on the poll itself being shut.
 	start := time.Now().Add(-48 * time.Hour)
 	end := time.Now().Add(-24 * time.Hour)
-	if _, err := CreatePoll(ctx, conn, "Expired", PollStatusActive, &start, &end, []string{"yes", "no"}); err != nil {
+	id, err := CreatePoll(ctx, conn, "Expired", PollStatusActive, &start, &end, []string{"yes", "no"})
+	if err != nil {
 		t.Fatalf("create expired poll: %v", err)
 	}
 
-	if _, err := VoteOnActivePoll(ctx, conn, "yes"); err != ErrPollNotOpen {
-		t.Fatalf("vote on expired poll err = %v, want ErrPollNotOpen", err)
+	if _, err := VoteOnActivePoll(ctx, conn, "yes"); err != ErrNoActivePoll {
+		t.Fatalf("vote on expired poll err = %v, want ErrNoActivePoll", err)
+	}
+
+	expired, err := GetPollByID(ctx, conn, id)
+	if err != nil {
+		t.Fatalf("get expired poll: %v", err)
+	}
+	if expired.AcceptsVotes(time.Now()) {
+		t.Fatalf("expired poll still accepts votes")
+	}
+	if got := expired.State(time.Now(), 0); got != PollStateEnded {
+		t.Fatalf("expired poll state = %q, want %q", got, PollStateEnded)
 	}
 }
 

--- a/server/internal/handlers/poll_handlers.go
+++ b/server/internal/handlers/poll_handlers.go
@@ -339,7 +339,7 @@ func GetPolls(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusInternalServerError, "Failed to fetch polls")
 			return
 		}
-		writeJSON(w, http.StatusOK, models.PollListResponse{Polls: pollViews(polls)})
+		writeJSON(w, http.StatusOK, models.PollListResponse{Polls: pollViews(polls, livePollID(r, conn))})
 	})
 }
 
@@ -361,7 +361,7 @@ func GetPollsManage(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusInternalServerError, "Failed to fetch polls")
 			return
 		}
-		writeJSON(w, http.StatusOK, models.PollListResponse{Polls: pollViews(polls)})
+		writeJSON(w, http.StatusOK, models.PollListResponse{Polls: pollViews(polls, livePollID(r, conn))})
 	})
 }
 
@@ -395,12 +395,12 @@ func GetPollByID(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusNotFound, "poll not found")
 			return
 		}
-		writeJSON(w, http.StatusOK, models.PollResponse{Poll: pollView(*poll)})
+		writeJSON(w, http.StatusOK, models.PollResponse{Poll: pollView(*poll, livePollID(r, conn))})
 	})
 }
 
 // @Summary Create a poll
-// @Description Creating a poll with status "active" closes whichever poll was previously active.
+// @Description Creating a poll with status "active" publishes it when its start date arrives; if that date has already passed (or none was given) it goes live at once and closes the poll that was running.
 // @Tags poll
 // @Accept json
 // @Produce json
@@ -474,7 +474,7 @@ func PostPollRecord(conn *sql.DB) http.Handler {
 			return
 		}
 		activity.LogRequest(r, "poll_updated", fmt.Sprintf("Created poll: %s", question))
-		writeJSON(w, http.StatusCreated, models.PollResponse{Poll: pollView(*poll)})
+		writeJSON(w, http.StatusCreated, models.PollResponse{Poll: pollView(*poll, livePollID(r, conn))})
 	})
 }
 
@@ -538,6 +538,12 @@ func PatchPollRecord(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusBadRequest, "invalid ends_at")
 			return
 		}
+		// Only checkable when the same request supplies both; a PATCH that moves
+		// one date against a stored one is caught by the editor before it is sent.
+		if startsAt != nil && endsAt != nil && endsAt.Before(*startsAt) {
+			writeError(w, http.StatusBadRequest, "ends_at must be after starts_at")
+			return
+		}
 
 		if err := db.UpdatePoll(r.Context(), conn, id, question, status, startsAt, endsAt, clearStarts, clearEnds); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -553,12 +559,15 @@ func PatchPollRecord(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusInternalServerError, "Failed to load poll")
 			return
 		}
-		// The legacy cms_settings title tracks the active poll only.
-		if poll.Status == db.PollStatusActive {
+		// The legacy cms_settings title tracks whatever is on the site. A poll
+		// queued behind a start date must not claim it early, or a rollback to
+		// the previous binary would show a question readers cannot vote on.
+		liveID := livePollID(r, conn)
+		if poll.ID == liveID {
 			_ = db.SetPollTitle(r.Context(), conn, poll.Question)
 		}
 		activity.LogRequest(r, "poll_updated", fmt.Sprintf("Updated poll #%d: %s", id, poll.Question))
-		writeJSON(w, http.StatusOK, models.PollResponse{Poll: pollView(*poll)})
+		writeJSON(w, http.StatusOK, models.PollResponse{Poll: pollView(*poll, liveID)})
 	})
 }
 
@@ -711,15 +720,27 @@ func DeletePollRecordOption(conn *sql.DB) http.Handler {
 // helpers
 // ---------------------------------------------------------------------------
 
-func pollViews(polls []db.Poll) []models.PollView {
+// livePollID resolves which poll is on the site right now so views can be
+// labelled with their derived state. A lookup failure is not worth failing the
+// request over: 0 simply means "nothing is live", and every other field still
+// renders.
+func livePollID(r *http.Request, conn *sql.DB) int64 {
+	id, err := db.LivePollID(r.Context(), conn)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+func pollViews(polls []db.Poll, liveID int64) []models.PollView {
 	views := make([]models.PollView, 0, len(polls))
 	for _, p := range polls {
-		views = append(views, pollView(p))
+		views = append(views, pollView(p, liveID))
 	}
 	return views
 }
 
-func pollView(p db.Poll) models.PollView {
+func pollView(p db.Poll, liveID int64) models.PollView {
 	total := p.TotalVotes()
 	options := make([]models.PollOptionView, 0, len(p.Options))
 	for _, opt := range p.Options {

--- a/server/internal/models/api_responses.go
+++ b/server/internal/models/api_responses.go
@@ -403,10 +403,16 @@ type PollOptionView struct {
 // PollView is a full poll: the question, when it ran, and its results.
 // StartsAt/EndsAt are RFC3339 strings, or empty when unset -- an absent EndsAt
 // is what the public archive renders as "No Expiry".
+//
+// Status is what an editor set. State is what that means right now once the
+// date window is taken into account (draft/scheduled/live/ended/superseded/
+// closed) -- clients should display State and never re-derive it, so the
+// editor and the public site can never disagree about what is running.
 type PollView struct {
 	ID         int64            `json:"id"`
 	Question   string           `json:"question"`
 	Status     string           `json:"status"`
+	State      string           `json:"state"`
 	StartsAt   string           `json:"starts_at,omitempty"`
 	EndsAt     string           `json:"ends_at,omitempty"`
 	TotalVotes int64            `json:"total_votes"`


### PR DESCRIPTION
## The problem

Poll start and end dates decided nothing. Status was the only real switch:

- Setting a poll **active with a future start date** closed whatever was running *immediately*, and the public API began serving it right away — while `AcceptsVotes` refused every vote until the start time. Readers got a dead widget and the live poll was gone.
- A poll **past its end date** kept showing an `ACTIVE` badge in the editor while silently rejecting votes.

So "set a start date and it goes live then" is exactly what the UI implied and exactly what didn't happen.

## What changed

**Status now means "in rotation"; the date window decides what readers see.**

- `LivePollID` returns the most recently started active poll, unless it has ended. A poll queued for next week is invisible until next week, then takes over on its own.
- The end date is checked in Go rather than in the `WHERE` clause deliberately — as a SQL filter it would hand the slot back to the poll underneath, resurrecting something an editor had already replaced.
- Publishing closes only what is *currently on the site* (`closeRunningPollsTx`); queued polls survive. This is what stops scheduling from wiping the queue.
- `UpdatePoll` resolves the dates the row will have *after* a partial PATCH before deciding whether it displaces anything.
- New computed `state` on `PollView` (`draft | scheduled | live | ended | superseded | closed`), so the editor and the public site can't disagree about what is running.
- Fixed alongside: a scheduled poll used to claim the legacy `cms_settings` title before going live.

**Editor UI**

- The "publish immediately" checkbox plus two loose date fields become one choice: **Save as draft / Publish now / Schedule**. Date fields appear only when they mean something.
- Consequences stated before you commit — publishing now warns which poll it closes; scheduling says the current one keeps running until then.
- Badges show state, not status. Each card gets a sentence: "On the site now — closes in 3 days, August 4…", "Goes live in 2 days…", "Taken off the site by a later poll".
- Date window validated client-side instead of returning a bare 400.

**Date picker theming**

New shared `DateTimeField` matching the app's `Input`: same height, radius, border and focus ring; explicit light `color-scheme` so the browser stops painting internals from the OS preference; muted placeholder instead of near-black `mm/dd/yyyy`; the grey native glyph replaced with a themed `CalendarClock` button calling `showPicker()`. The indicator is removed rather than covered, so clicking a segment to type still works.

## Testing

`go build`/`go vet` clean; frontend `tsc`, `eslint`, `vite build` clean. Database integration tests run against a real MariaDB:

```
CMS_TEST_DSN='...@tcp(127.0.0.1:3306)/poll_test?parseTime=true&multiStatements=true' go test ./internal/...
```

- New `TestPollScheduledPollWaitsForItsStartDate` covers queue → takeover → no resurrection.
- `TestPollExpiredWindowRejectsVotes` now expects `ErrNoActivePoll`: an expired poll drops off the site rather than being served as shut.
- Swagger regenerated.

## Notes for review

- Not rendered in a browser — the date field's appearance is reasoned from the CSS, not seen.
- A poll displaced by a takeover keeps `status = active` in the DB (shown as "Replaced"). Cleaning that up needs a sweeper or scheduled job; out of scope here.
- Public API response shapes are unchanged apart from the additive `state` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)