### PR TITLE
fix(polls): send the poll state the editor renders

### DIFF
--- a/frontend/src/pages/pollView.tsx
+++ b/frontend/src/pages/pollView.tsx
@@ -41,13 +41,26 @@ type PollListResponse = {
   polls?: Poll[]
 }
 
-const STATE_META: Record<PollState, { label: string; className: string }> = {
+type StateMeta = { label: string; className: string }
+
+const UNKNOWN_STATE_META: StateMeta = {
+  label: "Unknown",
+  className: "bg-muted text-muted-foreground border-border",
+}
+
+const STATE_META: Record<PollState, StateMeta> = {
   live: { label: "Live", className: "bg-emerald-500/10 text-emerald-600 border-emerald-500/30" },
   scheduled: { label: "Scheduled", className: "bg-blue-500/10 text-blue-600 border-blue-500/30" },
   draft: { label: "Draft", className: "bg-amber-500/10 text-amber-600 border-amber-500/30" },
   ended: { label: "Ended", className: "bg-muted text-muted-foreground border-border" },
   superseded: { label: "Replaced", className: "bg-muted text-muted-foreground border-border" },
   closed: { label: "Closed", className: "bg-muted text-muted-foreground border-border" },
+}
+
+// A state the client does not recognise is a server that has moved ahead of it,
+// not a reason to take the page down: an unlabelled badge beats a blank screen.
+function stateMeta(state: PollState): StateMeta {
+  return STATE_META[state] ?? UNKNOWN_STATE_META
 }
 
 // The API speaks RFC3339; <input type="datetime-local"> speaks "YYYY-MM-DDTHH:mm"
@@ -124,6 +137,8 @@ function scheduleSummary(poll: Poll): string {
       return "Taken off the site by a later poll"
     case "closed":
       return poll.starts_at ? `Closed — ran from ${formatRunDate(poll.starts_at)}` : "Closed"
+    default:
+      return poll.status === "active" ? "Published" : "Not published"
   }
 }
 
@@ -608,9 +623,9 @@ export default function PollView() {
                       <div className="flex items-center gap-2 flex-wrap">
                         <h2 className="font-semibold text-foreground">{poll.question}</h2>
                         <span
-                          className={`text-[11px] uppercase tracking-wide px-2 py-0.5 rounded-full border ${STATE_META[poll.state].className}`}
+                          className={`text-[11px] uppercase tracking-wide px-2 py-0.5 rounded-full border ${stateMeta(poll.state).className}`}
                         >
-                          {STATE_META[poll.state].label}
+                          {stateMeta(poll.state).label}
                         </span>
                       </div>
                       <p className="text-xs text-muted-foreground mt-1">{scheduleSummary(poll)}</p>

--- a/server/internal/handlers/poll_handlers.go
+++ b/server/internal/handlers/poll_handlers.go
@@ -762,6 +762,7 @@ func pollView(p db.Poll, liveID int64) models.PollView {
 		ID:         p.ID,
 		Question:   p.Question,
 		Status:     p.Status,
+		State:      p.State(time.Now(), liveID),
 		TotalVotes: total,
 		Options:    options,
 	}

--- a/server/internal/handlers/poll_handlers_test.go
+++ b/server/internal/handlers/poll_handlers_test.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	db "server/internal/database"
+)
+
+// The editor renders state and nothing else -- an empty one takes the page down
+// rather than degrading -- so every view has to carry one.
+func TestPollView_AlwaysCarriesState(t *testing.T) {
+	past := time.Now().Add(-24 * time.Hour)
+	future := time.Now().Add(24 * time.Hour)
+
+	cases := []struct {
+		name   string
+		poll   db.Poll
+		liveID int64
+		want   string
+	}{
+		{
+			name:   "live poll",
+			poll:   db.Poll{ID: 1, Status: db.PollStatusActive, StartsAt: &past},
+			liveID: 1,
+			want:   db.PollStateLive,
+		},
+		{
+			name:   "active poll queued behind its start date",
+			poll:   db.Poll{ID: 2, Status: db.PollStatusActive, StartsAt: &future},
+			liveID: 1,
+			want:   db.PollStateScheduled,
+		},
+		{
+			name: "draft",
+			poll: db.Poll{ID: 3, Status: db.PollStatusDraft},
+			want: db.PollStateDraft,
+		},
+		{
+			name: "closed",
+			poll: db.Poll{ID: 4, Status: db.PollStatusClosed},
+			want: db.PollStateClosed,
+		},
+		{
+			name:   "active poll past its end date",
+			poll:   db.Poll{ID: 5, Status: db.PollStatusActive, StartsAt: &past, EndsAt: &past},
+			liveID: 1,
+			want:   db.PollStateEnded,
+		},
+		{
+			name:   "nothing live at all",
+			poll:   db.Poll{ID: 6, Status: db.PollStatusActive, StartsAt: &past},
+			liveID: 0,
+			want:   db.PollStateSuperseded,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			view := pollView(tc.poll, tc.liveID)
+			if view.State == "" {
+				t.Fatal("poll view has no state; the editor cannot render this")
+			}
+			if view.State != tc.want {
+				t.Fatalf("state = %q, want %q", view.State, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What is broken

`delta` is serving a blank page right now, on every route, for anyone whose session touched the polls page. Merged in #135.

`pollView()` builds every field of the poll response except `State`, so `/v1/polls/manage` answers `"state": ""` for every poll. The editor renders state and only state — `STATE_META[poll.state].className` dereferences `undefined`, throws during render, and with no error boundary above the router it unmounts the entire app. The root URL going blank is the same dead session, not a second bug.

The `liveID` needed to compute state was already threaded through all five call sites and `Poll.State()` already existed. Only the assignment was missing.

## The fix

- `server/internal/handlers/poll_handlers.go` — `State: p.State(time.Now(), liveID)`. This is the actual fix; everything else is hardening.
- `frontend/src/pages/pollView.tsx` — unrecognised state gets an "Unknown" badge and a plain status sentence instead of throwing. A server ahead of the client is a stale deploy, not a reason to serve nothing.
- `server/internal/handlers/poll_handlers_test.go` — table test over all six states asserting `view.State != ""`.

## Why it shipped

Polls had no handler-level tests. The database tests added in #135 covered `LivePollID` and `Poll.State` thoroughly and both were correct — nothing checked the handler put the result in the response. The TS `state: PollState` type was a claim about the API that nothing verified, which is why `tsc` was clean.

## Testing

- `go build ./...` clean, `go test ./...` green including the new test.
- `tsc --noEmit` clean.
- Not verified: the seven poll integration tests skip without `CMS_TEST_DSN`, so the scheduling logic from #135 still has no executed coverage in CI. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)