### PR TITLE
fix(articles): stop hiding drafts from the CMS listing

### DIFF
--- a/frontend/src/pages/articleView.tsx
+++ b/frontend/src/pages/articleView.tsx
@@ -22,6 +22,7 @@ type ApiArticle = {
   slug: string
   status: string
   published_date?: string
+  creation_date?: string
   featured_image?: string
   authors?: Array<{
     name?: string
@@ -275,7 +276,8 @@ function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: Article
             .filter((name) => name.length > 0)
             .join(", "),
           status: mapApiStatus(item.status, activeTab),
-          date: formatArticleDate(item.published_date),
+          // Drafts have no published_date, so fall back to when the row was created.
+          date: formatArticleDate(item.published_date ?? item.creation_date),
           slug: item.slug,
           featuredImage: item.featured_image,
         }))

--- a/frontend/src/pages/editArticleView.tsx
+++ b/frontend/src/pages/editArticleView.tsx
@@ -444,13 +444,20 @@ function EditArticleView() {
       ).trim())
       .filter((category) => category.length > 0)
 
+    // Rows with neither an author nor a category are filtered out of the listing
+    // as import artifacts. Drafts are exempt from that filter for editors, so
+    // this only has to block on the way to published — where the row would
+    // otherwise vanish from both the CMS list and the public site.
+    if (effectiveStatus === "published" && !selectedAuthorId && categories.length === 0) {
+      setError("Add at least one author or category so the article shows up in the list.")
+      setIsSaving(false)
+      return
+    }
+
     try {
       if (isNew) {
         if (!title.trim()) {
           throw new Error("A title is required.")
-        }
-        if (!selectedAuthorId && categories.length === 0) {
-          throw new Error("Add at least one author or category so the article shows up in the list.")
         }
         const createPayload = {
           title: title.trim(),

--- a/server/internal/database/http_models.go
+++ b/server/internal/database/http_models.go
@@ -38,10 +38,10 @@ var ArticleColumns = []string{
 	"id", "title", "slug", "description", "text", "excerpt", "tags", "categories",
 	"pub_date", "mod_date", "priority", "breaking_news",
 	"comment_status", "photo_url",
-	"focus_keyword", "meta_description", "seo_title",
+	"focus_keyword", "meta_description", "seo_title", "creation_date",
 }
 
-const articleSelectColumnsQualified = "a.`id`, a.`title`, a.`slug`, a.`description`, a.`text`, a.`excerpt`, a.`tags`, a.`categories`, a.`pub_date`, a.`mod_date`, a.`priority`, a.`breaking_news`, a.`comment_status`, a.`photo_url`, a.`focus_keyword`, a.`meta_description`, a.`seo_title`"
+const articleSelectColumnsQualified = "a.`id`, a.`title`, a.`slug`, a.`description`, a.`text`, a.`excerpt`, a.`tags`, a.`categories`, a.`pub_date`, a.`mod_date`, a.`priority`, a.`breaking_news`, a.`comment_status`, a.`photo_url`, a.`focus_keyword`, a.`meta_description`, a.`seo_title`, a.`creation_date`"
 
 // Image/photo URLs are canonicalized upstream in the WordPress ETL (see
 // wordpress-etl Utils/MediaURL) so `photo_url` and inline body images are stored
@@ -144,12 +144,13 @@ func ScanArticle(rows *sql.Rows) (models.Article, error) {
 		focusKeyword    sql.NullString
 		metaDescription sql.NullString
 		seoTitle        sql.NullString
+		creationDate    sql.NullTime
 	)
 	err := rows.Scan(
 		&a.ID, &a.Title, &slug, &description, &text, &excerpt, &tags, &categories,
 		&pubDate, &ignoredMod, &priority, &ignoredBreak,
 		&commentStatus, &photoURL,
-		&focusKeyword, &metaDescription, &seoTitle,
+		&focusKeyword, &metaDescription, &seoTitle, &creationDate,
 	)
 	if err != nil {
 		return models.Article{}, err
@@ -176,6 +177,10 @@ func ScanArticle(rows *sql.Rows) (models.Article, error) {
 	}
 	a.Tags = parseStringListField(tags)
 	a.Categories = parseStringListField(categories)
+	if creationDate.Valid {
+		t := creationDate.Time
+		a.CreatedAt = &t
+	}
 	if pubDate.Valid {
 		t := pubDate.Time
 		a.PublishedAt = &t
@@ -355,7 +360,7 @@ func SearchArticles(ctx context.Context, conn *sql.DB, term string, limit, offse
 	}
 
 	like := "%" + trimmedTerm + "%"
-	query := "SELECT `id`, `title`, `slug`, `description`, `text`, `excerpt`, `tags`, `categories`, `pub_date`, `mod_date`, `priority`, `breaking_news`, `comment_status`, `photo_url`, `focus_keyword`, `meta_description`, `seo_title` FROM `articles` " +
+	query := "SELECT `id`, `title`, `slug`, `description`, `text`, `excerpt`, `tags`, `categories`, `pub_date`, `mod_date`, `priority`, `breaking_news`, `comment_status`, `photo_url`, `focus_keyword`, `meta_description`, `seo_title`, `creation_date` FROM `articles` " +
 		// Search is public, so it stays pinned to live content: published and not
 		// soft-deleted. Archived rows were previously reachable here.
 		"WHERE `pub_date` IS NOT NULL AND `archived_at` IS NULL AND (`title` LIKE ? OR `tags` LIKE ? OR `text` LIKE ?) " +
@@ -604,6 +609,9 @@ func ArticleInputToDBFields(body models.ArticleInput) []any {
 		strings.TrimSpace(body.FocusKeyword),
 		strings.TrimSpace(body.MetaDescription),
 		strings.TrimSpace(body.SEOTitle),
+		// Stamp creation_date so a draft has a date of its own: it is what the
+		// CMS listing sorts unpublished rows by (pub_date is NULL until publish).
+		time.Now().UTC().Format("2006-01-02 15:04:05"),
 	}
 }
 

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -357,6 +357,7 @@ func articleListItems(articles []models.Article, excerptWords int) []models.Arti
 			IsFeatured:    article.IsFeatured,
 		}
 		item.PublishedDate = article.PublishedAt
+		item.CreationDate = article.CreatedAt
 		items = append(items, item)
 	}
 	return items
@@ -1104,16 +1105,46 @@ type ArticleParams struct {
 func queryArticles(r *http.Request, conn *sql.DB, params ArticleParams, limit, offset int) (*sql.Rows, error) {
 	q := r.URL.Query()
 	conditions, args := articleQueryFilters(r, params)
-	query := "SELECT `id`, `title`, `slug`, `description`, `text`, `excerpt`, `tags`, `categories`, `pub_date`, `mod_date`, `priority`, `breaking_news`, `comment_status`, `photo_url`, `focus_keyword`, `meta_description`, `seo_title` FROM `articles`"
+	query := "SELECT `id`, `title`, `slug`, `description`, `text`, `excerpt`, `tags`, `categories`, `pub_date`, `mod_date`, `priority`, `breaking_news`, `comment_status`, `photo_url`, `focus_keyword`, `meta_description`, `seo_title`, `creation_date` FROM `articles`"
 	if len(conditions) > 0 {
 		query += " WHERE " + strings.Join(conditions, " AND ")
 	}
-	if q.Get("sort_by") == "" {
+	sortBy := q.Get("sort_by")
+	if sortBy == "" {
 		query += " ORDER BY `id` DESC"
 	}
-	query = db.BuildOrderLimit(query, q.Get("sort_by"), q.Get("sort_direction"), db.ArticleSortByColumn, limit, offset)
+	if clause := articleOrderByClause(r, sortBy, q.Get("sort_direction")); clause != "" {
+		// Editor date sort is handled here; hand BuildOrderLimit an empty sort_by
+		// so it only appends LIMIT/OFFSET and can't emit a second ORDER BY.
+		query += clause
+		sortBy = ""
+	}
+	query = db.BuildOrderLimit(query, sortBy, q.Get("sort_direction"), db.ArticleSortByColumn, limit, offset)
 
 	return conn.QueryContext(r.Context(), query, args...)
+}
+
+// articleOrderByClause returns the editor-only ORDER BY for date sorts, or ""
+// to let BuildOrderLimit handle it. Sorting the CMS listing on `pub_date` puts
+// drafts (NULL pub_date) at the very end, so a new draft lands on the last page
+// of a 9k-article list instead of at the top. Editors sort on the date the row
+// actually has — published date, else creation date — which interleaves drafts
+// with published articles.
+func articleOrderByClause(r *http.Request, sortBy, sortDir string) string {
+	if _, isEditor := middleware.UserFromContext(r.Context()); !isEditor {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(sortBy)) {
+	case string(models.ArticleSortByPublishedAt), string(models.ArticleSortByCreatedAt):
+	default:
+		return ""
+	}
+
+	dir := "ASC"
+	if strings.EqualFold(strings.TrimSpace(sortDir), string(models.SortDirectionDescending)) {
+		dir = "DESC"
+	}
+	return " ORDER BY COALESCE(`pub_date`, `creation_date`) " + dir + ", `id` " + dir
 }
 
 func countArticles(r *http.Request, conn *sql.DB, params ArticleParams) (int, error) {
@@ -1135,7 +1166,17 @@ func articleQueryFilters(r *http.Request, params ArticleParams) ([]string, []any
 	var conditions []string
 	var args []any
 
-	conditions = append(conditions, "((TRIM(COALESCE(`authors`, '')) <> '' AND TRIM(`authors`) <> '[]') OR (TRIM(COALESCE(`categories`, '')) <> '' AND TRIM(`categories`) <> '[]'))")
+	_, isEditor := middleware.UserFromContext(r.Context())
+
+	// Exclude media/import artifacts that have neither authors nor categories.
+	// A brand-new CMS draft looks exactly like one of those until an author or a
+	// category is attached, so editors keep unpublished rows regardless — without
+	// the exemption a draft is invisible in the CMS listing until it is filed.
+	artifactFilter := "((TRIM(COALESCE(`authors`, '')) <> '' AND TRIM(`authors`) <> '[]') OR (TRIM(COALESCE(`categories`, '')) <> '' AND TRIM(`categories`) <> '[]'))"
+	if isEditor {
+		artifactFilter = "(" + artifactFilter + " OR `pub_date` IS NULL)"
+	}
+	conditions = append(conditions, artifactFilter)
 
 	// /v1/articles is public, so an anonymous caller is pinned to the published,
 	// non-archived view and the `archived`/`status` query params are ignored for
@@ -1143,7 +1184,6 @@ func articleQueryFilters(r *http.Request, params ArticleParams) ([]string, []any
 	// (?status=draft) or soft-deleted articles (?archived=true) — the listing is
 	// excerpt-only, but unpublished headlines still must not leak. Editors are
 	// identified by OptionalAuth on the route and keep the full filter set.
-	_, isEditor := middleware.UserFromContext(r.Context())
 	if !isEditor {
 		conditions = append(conditions, "`pub_date` IS NOT NULL", "`archived_at` IS NULL")
 	} else if _, archivedProvided := q["archived"]; archivedProvided {
@@ -1182,7 +1222,11 @@ func articleQueryFilters(r *http.Request, params ArticleParams) ([]string, []any
 		}
 	}
 
-	if strings.EqualFold(strings.TrimSpace(q.Get("sort_by")), string(models.ArticleSortByPublishedAt)) &&
+	// Oldest-first on pub_date would otherwise lead with the NULL block. Editors
+	// sort on COALESCE(pub_date, creation_date) (see articleOrderByClause), so
+	// their drafts are already placed by date and must not be filtered out here.
+	if !isEditor &&
+		strings.EqualFold(strings.TrimSpace(q.Get("sort_by")), string(models.ArticleSortByPublishedAt)) &&
 		strings.EqualFold(strings.TrimSpace(q.Get("sort_direction")), string(models.SortDirectionAscending)) {
 		conditions = append(conditions, "`pub_date` IS NOT NULL")
 	}
@@ -1882,7 +1926,7 @@ func PostArticles(conn *sql.DB) http.HandlerFunc {
 		}
 		fields := db.ArticleInputToDBFields(body)
 		result, err := db.Insert(r.Context(), conn, "articles",
-			[]string{"title", "slug", "description", "text", "excerpt", "categories", "pub_date", "mod_date", "priority", "breaking_news", "comment_status", "photo_url", "tags", "metadata", "focus_keyword", "meta_description", "seo_title"},
+			[]string{"title", "slug", "description", "text", "excerpt", "categories", "pub_date", "mod_date", "priority", "breaking_news", "comment_status", "photo_url", "tags", "metadata", "focus_keyword", "meta_description", "seo_title", "creation_date"},
 			fields...,
 		)
 		if err != nil {

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -306,3 +306,80 @@ func TestArticleDetailCondition_EditorSeesEverything(t *testing.T) {
 		t.Fatalf("editor lookup must not be narrowed, got %q", got)
 	}
 }
+
+// A draft created in the CMS has neither authors nor categories until an editor
+// fills them in, which is exactly the shape of the import-artifact filter. The
+// editor listing must not drop it.
+func TestArticleQueryFilters_EditorSeesUnfiledDrafts(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles", nil)
+	req = req.WithContext(middleware.ContextWithUser(req.Context(), &models.User{ID: 1, Role: models.RoleAdmin}))
+
+	conditions, _ := articleQueryFilters(req, ArticleParams{})
+	joined := strings.Join(conditions, " AND ")
+
+	if !strings.Contains(joined, "OR `pub_date` IS NULL)") {
+		t.Fatalf("editor listing must exempt drafts from the artifact filter, got %q", joined)
+	}
+}
+
+func TestArticleQueryFilters_AnonymousKeepsArtifactFilter(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles", nil)
+
+	conditions, _ := articleQueryFilters(req, ArticleParams{})
+	joined := strings.Join(conditions, " AND ")
+
+	if strings.Contains(joined, "OR `pub_date` IS NULL") {
+		t.Fatalf("anonymous listing must not widen the artifact filter, got %q", joined)
+	}
+	if !strings.Contains(joined, "TRIM(COALESCE(`authors`, ''))") {
+		t.Fatalf("anonymous listing must keep the artifact filter, got %q", joined)
+	}
+}
+
+// Oldest-first used to append `pub_date` IS NOT NULL for everyone, which hid
+// every draft — and made the Draft status filter return nothing at all.
+func TestArticleQueryFilters_EditorAscendingDateSortKeepsDrafts(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles?sort_by=published_date&sort_direction=asc&status=draft", nil)
+	req = req.WithContext(middleware.ContextWithUser(req.Context(), &models.User{ID: 1, Role: models.RoleAdmin}))
+
+	conditions, _ := articleQueryFilters(req, ArticleParams{})
+	joined := strings.Join(conditions, " AND ")
+
+	if strings.Contains(joined, "`pub_date` IS NOT NULL") {
+		t.Fatalf("editor oldest-first sort must not exclude drafts, got %q", joined)
+	}
+}
+
+func TestArticleQueryFilters_AnonymousAscendingDateSortSkipsNullPubDates(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles?sort_by=published_date&sort_direction=asc", nil)
+
+	conditions, _ := articleQueryFilters(req, ArticleParams{})
+	joined := strings.Join(conditions, " AND ")
+
+	if !strings.Contains(joined, "`pub_date` IS NOT NULL") {
+		t.Fatalf("anonymous oldest-first sort must stay published-only, got %q", joined)
+	}
+}
+
+// Sorting straight on `pub_date` parks every draft after the last published
+// article, so a new draft lands on the final page of the listing.
+func TestArticleOrderByClause(t *testing.T) {
+	editorReq := func(query string) *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/v1/articles"+query, nil)
+		return req.WithContext(middleware.ContextWithUser(req.Context(), &models.User{ID: 1, Role: models.RoleAdmin}))
+	}
+
+	got := articleOrderByClause(editorReq("?sort_by=published_date&sort_direction=desc"), "published_date", "desc")
+	if got != " ORDER BY COALESCE(`pub_date`, `creation_date`) DESC, `id` DESC" {
+		t.Fatalf("editor newest-first clause = %q", got)
+	}
+
+	if got := articleOrderByClause(editorReq("?sort_by=title&sort_direction=asc"), "title", "asc"); got != "" {
+		t.Fatalf("non-date sort must fall through to BuildOrderLimit, got %q", got)
+	}
+
+	anonReq := httptest.NewRequest(http.MethodGet, "/v1/articles?sort_by=published_date", nil)
+	if got := articleOrderByClause(anonReq, "published_date", "desc"); got != "" {
+		t.Fatalf("anonymous sort must be unchanged, got %q", got)
+	}
+}

--- a/server/internal/models/api_responses.go
+++ b/server/internal/models/api_responses.go
@@ -47,6 +47,9 @@ type ArticleListItem struct {
 	FeaturedImage string            `json:"featured_image"`
 	IsFeatured    bool              `json:"is_featured"`
 	PublishedDate *time.Time        `json:"published_date,omitempty"`
+	// Drafts have no published_date; the CMS listing falls back to this so an
+	// unpublished row still shows a date.
+	CreationDate *time.Time `json:"creation_date,omitempty"`
 }
 
 type Pagination struct {


### PR DESCRIPTION
Drafts were missing from the article list, its search box, and the Draft status filter. Four separate defects in the shared `/v1/articles` query path, all of which had to be fixed for a draft to be reliably visible.

## What was wrong

**1. The import-artifact filter ate new drafts.** Every listing query required `authors` or `categories` to be non-empty, to skip WordPress media/import rows. A draft has neither until an editor files it. Editors now get `(artifact filter OR pub_date IS NULL)`; anonymous callers keep the filter exactly as before.

**2. "Oldest first" excluded every draft.** Ascending sort on `published_date` appended `pub_date IS NOT NULL` for *all* callers. Combined with the Draft chip, the list was guaranteed empty. Now anonymous-only.

**3. Drafts sank to the last page.** The list sorts on `pub_date`, and MariaDB puts NULLs last in DESC, so a new draft landed at the end of ~9k articles. Editors now sort on `COALESCE(pub_date, creation_date)` via the new `articleOrderByClause`, interleaving drafts with published articles by real date.

**4. Drafts had no date at all.** `POST /v1/articles` never wrote `creation_date`, so a CMS-created row had every date column NULL — which would have defeated fix 3. Insert now stamps it, `creation_date` is threaded through the article read path (`ArticleColumns`, both hardcoded SELECTs, `ScanArticle`, `ArticleListItem`), and the Date column falls back to it instead of showing `-`.

Also relaxed the editor's "add at least one author or category" guard — it was a workaround for defect 1 and blocked saving a rough draft. It now fires only when publishing, and covers the PATCH path too, so publishing an unfiled draft can't make it vanish from both the CMS list and the public site.

No schema change: `creation_date` already exists on `articles`.

## Testing

5 new cases in `handlers_test.go` covering the editor/anonymous split on both filters and the order-by clause. Full Go suite, `go vet`, and `tsc --noEmit` pass.

Verified at the query-construction level only — worth confirming against the seeded DB that unfiled drafts now appear and that no import artifacts leaked into the editor list.

## Not included

`PUT`/`PATCH` still write `mod_date = NULL` on every update, wiping the modified timestamp. Pre-existing and unrelated to this bug, but it's why "last edited" isn't available as a sort key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)