### PR TITLE
Complete comments moderation flow

### DIFF
--- a/frontend/src/pages/commentsView.tsx
+++ b/frontend/src/pages/commentsView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { Check, ChevronFirst, ChevronLast, ChevronLeft, ChevronRight, ExternalLink, MessageSquare, Search, Trash2, X } from "lucide-react"
+import { Check, ChevronFirst, ChevronLast, ChevronLeft, ChevronRight, ExternalLink, MessageSquare, RotateCcw, Search, Trash2, X } from "lucide-react"
 import { Link } from "react-router-dom"
 import { publicSiteUrl } from "../auth/urls"
 import { useApiFetch } from "../hooks/useApiFetch"
@@ -155,6 +155,7 @@ export default function CommentsView() {
   const [error, setError] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
   const [busyCommentId, setBusyCommentId] = useState<number | null>(null)
+  const [selectedCommentIds, setSelectedCommentIds] = useState<Set<number>>(() => new Set())
 
   const loadComments = useCallback(async () => {
     setIsLoading(true)
@@ -178,6 +179,7 @@ export default function CommentsView() {
       const body = await response.json() as CommentsResponse
       const nextComments = body.comments ?? []
       setComments(nextComments)
+      setSelectedCommentIds(new Set())
       setTotalCount(body.pagination?.total_count ?? body.pagination?.totalCount ?? nextComments.length)
       setCounts({
         all: body.counts?.all ?? nextComments.length,
@@ -210,6 +212,30 @@ export default function CommentsView() {
 
   const totalPages = Math.max(1, Math.ceil(Math.max(totalCount, comments.length) / PAGE_SIZE))
   const siteUrl = useMemo(() => publicSiteUrl(), [])
+  const selectedCount = selectedCommentIds.size
+  const visibleCommentIds = useMemo(() => comments.map((comment) => comment.id), [comments])
+  const allVisibleSelected = visibleCommentIds.length > 0 && visibleCommentIds.every((id) => selectedCommentIds.has(id))
+
+  const toggleCommentSelection = (commentId: number) => {
+    setSelectedCommentIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(commentId)) {
+        next.delete(commentId)
+      } else {
+        next.add(commentId)
+      }
+      return next
+    })
+  }
+
+  const toggleVisibleSelection = () => {
+    setSelectedCommentIds((prev) => {
+      if (allVisibleSelected) {
+        return new Set([...prev].filter((id) => !visibleCommentIds.includes(id)))
+      }
+      return new Set([...prev, ...visibleCommentIds])
+    })
+  }
 
   const updateStatus = async (comment: Comment, status: CommentStatus) => {
     if (busyCommentId !== null) return
@@ -232,9 +258,32 @@ export default function CommentsView() {
     }
   }
 
+  const updateSelectedStatus = async (status: CommentStatus) => {
+    if (busyCommentId !== null || selectedCommentIds.size === 0) return
+    const ids = [...selectedCommentIds]
+    setBusyCommentId(-1)
+    setActionError(null)
+    try {
+      const responses = await Promise.all(ids.map((id) => apiFetch(`/v1/comments/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      })))
+      const failed = responses.find((response) => !response.ok)
+      if (failed) {
+        throw new Error(await readErrorMessage(failed, `Bulk update failed (${failed.status})`))
+      }
+      await loadComments()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Unable to update selected comments.")
+    } finally {
+      setBusyCommentId(null)
+    }
+  }
+
   const deleteComment = async (comment: Comment) => {
     if (busyCommentId !== null) return
-    const shouldDelete = window.confirm(`Delete comment from ${comment.author_name || "Anonymous"}?`)
+    const shouldDelete = window.confirm(`Delete trashed comment from ${comment.author_name || "Anonymous"} forever?`)
     if (!shouldDelete) return
 
     setBusyCommentId(comment.id)
@@ -247,6 +296,28 @@ export default function CommentsView() {
       await loadComments()
     } catch (err) {
       setActionError(err instanceof Error ? err.message : "Unable to delete comment.")
+    } finally {
+      setBusyCommentId(null)
+    }
+  }
+
+  const deleteSelectedComments = async () => {
+    if (busyCommentId !== null || selectedCommentIds.size === 0) return
+    const shouldDelete = window.confirm(`Delete ${selectedCommentIds.size} trashed comment${selectedCommentIds.size === 1 ? "" : "s"} forever?`)
+    if (!shouldDelete) return
+
+    const ids = [...selectedCommentIds]
+    setBusyCommentId(-1)
+    setActionError(null)
+    try {
+      const responses = await Promise.all(ids.map((id) => apiFetch(`/v1/comments/${id}`, { method: "DELETE" })))
+      const failed = responses.find((response) => !response.ok)
+      if (failed) {
+        throw new Error(await readErrorMessage(failed, `Bulk delete failed (${failed.status})`))
+      }
+      await loadComments()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Unable to delete selected comments.")
     } finally {
       setBusyCommentId(null)
     }
@@ -298,6 +369,67 @@ export default function CommentsView() {
         </div>
       </div>
 
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card px-3 py-2">
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+          <input
+            checked={allVisibleSelected}
+            className="h-4 w-4 rounded border-border"
+            disabled={comments.length === 0 || isLoading}
+            onChange={toggleVisibleSelection}
+            type="checkbox"
+          />
+          <span>{selectedCount ? `${selectedCount.toLocaleString()} selected` : "Select visible"}</span>
+        </label>
+        <div className="h-5 w-px bg-border" />
+        <button
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:text-emerald-700 hover:bg-emerald-50 disabled:opacity-40 dark:hover:bg-emerald-900/20"
+          disabled={selectedCount === 0 || busyCommentId !== null}
+          onClick={() => void updateSelectedStatus("approved")}
+          type="button"
+        >
+          <Check className="h-4 w-4" />
+          Approve
+        </button>
+        <button
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground hover:bg-muted disabled:opacity-40"
+          disabled={selectedCount === 0 || busyCommentId !== null}
+          onClick={() => void updateSelectedStatus("pending")}
+          type="button"
+        >
+          <RotateCcw className="h-4 w-4" />
+          Pending
+        </button>
+        <button
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:text-red-700 hover:bg-red-50 disabled:opacity-40 dark:hover:bg-red-900/20"
+          disabled={selectedCount === 0 || busyCommentId !== null}
+          onClick={() => void updateSelectedStatus("spam")}
+          type="button"
+        >
+          <X className="h-4 w-4" />
+          Spam
+        </button>
+        <button
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:text-destructive hover:bg-destructive/10 disabled:opacity-40"
+          disabled={selectedCount === 0 || busyCommentId !== null}
+          onClick={() => void updateSelectedStatus("trash")}
+          type="button"
+        >
+          <Trash2 className="h-4 w-4" />
+          Trash
+        </button>
+        {statusFilter === "trash" ? (
+          <button
+            className="inline-flex items-center gap-1.5 rounded-lg border border-destructive/30 px-2.5 py-1.5 text-sm text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-40"
+            disabled={selectedCount === 0 || busyCommentId !== null}
+            onClick={() => void deleteSelectedComments()}
+            type="button"
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete forever
+          </button>
+        ) : null}
+      </div>
+
       {error ? (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
           {error}
@@ -320,7 +452,7 @@ export default function CommentsView() {
         ) : (
           <div className="divide-y divide-border">
             {comments.map((comment) => {
-              const isBusy = busyCommentId === comment.id
+              const actionsDisabled = busyCommentId !== null
               const hasMappedArticle = comment.article_slug && comment.article_id > 0
               const articlePath = hasMappedArticle ? `/articles/${encodeURIComponent(comment.article_slug)}/edit` : ""
               const publicPath = comment.article_slug ? `${siteUrl}/article/${comment.article_slug}` : ""
@@ -328,6 +460,14 @@ export default function CommentsView() {
               return (
                 <article key={comment.id} className="grid gap-4 p-4 md:grid-cols-[minmax(0,1fr)_auto] hover:bg-muted/30 transition-colors">
                   <div className="flex gap-3 min-w-0">
+                    <input
+                      aria-label={`Select comment from ${comment.author_name || "Anonymous"}`}
+                      checked={selectedCommentIds.has(comment.id)}
+                      className="mt-3 h-4 w-4 rounded border-border shrink-0"
+                      disabled={actionsDisabled}
+                      onChange={() => toggleCommentSelection(comment.id)}
+                      type="checkbox"
+                    />
                     <div className="w-10 h-10 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-bold shrink-0">
                       {initials(comment.author_name)}
                     </div>
@@ -366,7 +506,7 @@ export default function CommentsView() {
                     {comment.status !== "approved" ? (
                       <button
                         className="p-1.5 rounded-lg text-muted-foreground hover:text-emerald-700 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors disabled:opacity-40"
-                        disabled={isBusy}
+                        disabled={actionsDisabled}
                         onClick={() => void updateStatus(comment, "approved")}
                         title="Approve"
                         type="button"
@@ -374,10 +514,21 @@ export default function CommentsView() {
                         <Check className="w-4 h-4" />
                       </button>
                     ) : null}
+                    {comment.status !== "pending" ? (
+                      <button
+                        className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-40"
+                        disabled={actionsDisabled}
+                        onClick={() => void updateStatus(comment, "pending")}
+                        title={comment.status === "trash" ? "Restore to pending" : "Set pending"}
+                        type="button"
+                      >
+                        <RotateCcw className="w-4 h-4" />
+                      </button>
+                    ) : null}
                     {comment.status !== "spam" ? (
                       <button
                         className="p-1.5 rounded-lg text-muted-foreground hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-40"
-                        disabled={isBusy}
+                        disabled={actionsDisabled}
                         onClick={() => void updateStatus(comment, "spam")}
                         title="Mark as spam"
                         type="button"
@@ -385,15 +536,27 @@ export default function CommentsView() {
                         <X className="w-4 h-4" />
                       </button>
                     ) : null}
-                    <button
-                      className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40"
-                      disabled={isBusy}
-                      onClick={() => void deleteComment(comment)}
-                      title="Delete"
-                      type="button"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
+                    {comment.status !== "trash" ? (
+                      <button
+                        className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40"
+                        disabled={actionsDisabled}
+                        onClick={() => void updateStatus(comment, "trash")}
+                        title="Move to trash"
+                        type="button"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    ) : (
+                      <button
+                        className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40"
+                        disabled={actionsDisabled}
+                        onClick={() => void deleteComment(comment)}
+                        title="Delete forever"
+                        type="button"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    )}
                   </div>
                 </article>
               )

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -537,6 +537,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -534,6 +534,12 @@
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -1423,6 +1423,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/models.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
         "404":
           description: Not Found
           schema:

--- a/server/internal/database/comments.go
+++ b/server/internal/database/comments.go
@@ -172,7 +172,7 @@ func GetArticleCommentTargetBySlug(ctx context.Context, conn *sql.DB, slug strin
 	return 0, "", false, fmt.Errorf("get article for comments: %w", err)
 }
 
-func CommentExistsForArticle(ctx context.Context, conn *sql.DB, articleID, commentID int64) (bool, error) {
+func CommentCanAcceptReply(ctx context.Context, conn *sql.DB, articleID, commentID int64) (bool, error) {
 	if commentID <= 0 {
 		return true, nil
 	}
@@ -182,6 +182,8 @@ func CommentExistsForArticle(ctx context.Context, conn *sql.DB, articleID, comme
 		SELECT 1
 		FROM comments
 		WHERE id = ? AND article_id = ?
+		  AND status = 'approved'
+		  AND (`+"`type`"+` IS NULL OR `+"`type`"+` = '' OR `+"`type`"+` = 'comment')
 		LIMIT 1
 	`, commentID, articleID).Scan(&exists)
 	if err == nil {
@@ -190,7 +192,7 @@ func CommentExistsForArticle(ctx context.Context, conn *sql.DB, articleID, comme
 	if err == sql.ErrNoRows {
 		return false, nil
 	}
-	return false, fmt.Errorf("check comment parent exists: %w", err)
+	return false, fmt.Errorf("check comment parent can accept reply: %w", err)
 }
 
 func CreateComment(ctx context.Context, conn *sql.DB, params CreateCommentParams) (Comment, error) {

--- a/server/internal/handlers/comments_integration_test.go
+++ b/server/internal/handlers/comments_integration_test.go
@@ -1,0 +1,218 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	db "server/internal/database"
+	"server/internal/models"
+)
+
+// CMS_TEST_DSN='user:pw@tcp(127.0.0.1:3306)/comments_test?parseTime=true&multiStatements=true' go test ./internal/handlers/ -run CommentHTTP -v
+func commentHTTPTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("CMS_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CMS_TEST_DSN not set; skipping comment handler integration test")
+	}
+
+	conn, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	if err := conn.Ping(); err != nil {
+		t.Fatalf("ping test database: %v", err)
+	}
+
+	ctx := context.Background()
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 60)", "cms_comments_integration_test").Scan(&acquired); err != nil {
+		t.Fatalf("acquire test lock: %v", err)
+	}
+	if !acquired.Valid || acquired.Int64 != 1 {
+		t.Fatal("timed out waiting for the comments test lock")
+	}
+	t.Cleanup(func() {
+		_, _ = conn.ExecContext(context.Background(), "SELECT RELEASE_LOCK(?)", "cms_comments_integration_test")
+		conn.Close()
+	})
+
+	if _, err := conn.ExecContext(ctx, "DROP TABLE IF EXISTS comments"); err != nil {
+		t.Fatalf("drop comments table: %v", err)
+	}
+	if err := db.EnsureCommentsTable(ctx, conn); err != nil {
+		t.Fatalf("ensure comments table: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, "DROP TABLE IF EXISTS articles"); err != nil {
+		t.Fatalf("drop articles table: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, `
+		CREATE TABLE articles (
+			id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			slug VARCHAR(255) NOT NULL UNIQUE,
+			comment_status VARCHAR(32)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+	`); err != nil {
+		t.Fatalf("create articles table: %v", err)
+	}
+
+	return conn
+}
+
+func seedCommentArticle(t *testing.T, conn *sql.DB, slug, commentStatus string) int64 {
+	t.Helper()
+
+	result, err := conn.ExecContext(context.Background(), "INSERT INTO articles (slug, comment_status) VALUES (?, ?)", slug, commentStatus)
+	if err != nil {
+		t.Fatalf("seed article: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("read article id: %v", err)
+	}
+	return id
+}
+
+func postArticleCommentRequest(slug string, parentID int64) *http.Request {
+	body := `{"parent_id":` + strconv.FormatInt(parentID, 10) + `,"author_name":"Reader","author_email":"reader@example.org","content":"A useful comment."}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/articles/"+slug+"/comments", strings.NewReader(body))
+	req.SetPathValue("slug", slug)
+	return req
+}
+
+func TestCommentHTTP_PostRejectsClosedArticle(t *testing.T) {
+	conn := commentHTTPTestDB(t)
+	seedCommentArticle(t, conn, "closed-story", "closed")
+
+	rec := httptest.NewRecorder()
+	PostArticleComment(conn, nil).ServeHTTP(rec, postArticleCommentRequest("closed-story", 0))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("post status = %d, want 403; body = %s", rec.Code, rec.Body.String())
+	}
+
+	var count int
+	if err := conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM comments").Scan(&count); err != nil {
+		t.Fatalf("count comments: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("closed article created %d comments, want 0", count)
+	}
+}
+
+func TestCommentHTTP_PostOpenArticleCreatesPendingCommentWithoutSpamChecker(t *testing.T) {
+	conn := commentHTTPTestDB(t)
+	articleID := seedCommentArticle(t, conn, "open-story", "open")
+
+	rec := httptest.NewRecorder()
+	PostArticleComment(conn, nil).ServeHTTP(rec, postArticleCommentRequest("open-story", 0))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("post status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+
+	var comment models.CommentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &comment); err != nil {
+		t.Fatalf("decode comment response: %v", err)
+	}
+	if comment.ArticleID != articleID {
+		t.Fatalf("article_id = %d, want %d", comment.ArticleID, articleID)
+	}
+	if comment.Status != "pending" {
+		t.Fatalf("status = %q, want pending", comment.Status)
+	}
+	if strings.TrimSpace(comment.Content) == "" {
+		t.Fatal("comment content was not returned")
+	}
+
+	var storedArticleID, storedParentID int64
+	var storedStatus string
+	if err := conn.QueryRowContext(context.Background(), "SELECT article_id, parent_id, `status` FROM comments WHERE id = ?", comment.ID).Scan(&storedArticleID, &storedParentID, &storedStatus); err != nil {
+		t.Fatalf("read stored comment: %v", err)
+	}
+	if storedArticleID != articleID || storedParentID != 0 || storedStatus != "pending" {
+		t.Fatalf("stored comment = article_id %d parent_id %d status %q, want article_id %d parent_id 0 status pending", storedArticleID, storedParentID, storedStatus, articleID)
+	}
+}
+
+func TestCommentHTTP_PostAllowsReplyToApprovedTopLevelComment(t *testing.T) {
+	conn := commentHTTPTestDB(t)
+	articleID := seedCommentArticle(t, conn, "reply-story", "open")
+	parent, err := db.CreateComment(context.Background(), conn, db.CreateCommentParams{
+		ArticleID:  articleID,
+		AuthorName: "Parent",
+		Content:    "Top-level comment",
+		Status:     "approved",
+		Type:       "comment",
+	})
+	if err != nil {
+		t.Fatalf("seed parent comment: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	PostArticleComment(conn, nil).ServeHTTP(rec, postArticleCommentRequest("reply-story", parent.ID))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("post status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+
+	var comment models.CommentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &comment); err != nil {
+		t.Fatalf("decode comment response: %v", err)
+	}
+	if comment.ParentID != parent.ID {
+		t.Fatalf("parent_id = %d, want %d", comment.ParentID, parent.ID)
+	}
+}
+
+func TestCommentHTTP_PostAllowsReplyToReply(t *testing.T) {
+	conn := commentHTTPTestDB(t)
+	articleID := seedCommentArticle(t, conn, "nested-story", "open")
+	parent, err := db.CreateComment(context.Background(), conn, db.CreateCommentParams{
+		ArticleID:  articleID,
+		AuthorName: "Parent",
+		Content:    "Top-level comment",
+		Status:     "approved",
+		Type:       "comment",
+	})
+	if err != nil {
+		t.Fatalf("seed parent comment: %v", err)
+	}
+	reply, err := db.CreateComment(context.Background(), conn, db.CreateCommentParams{
+		ArticleID:  articleID,
+		ParentID:   parent.ID,
+		AuthorName: "Reply",
+		Content:    "First-level reply",
+		Status:     "approved",
+		Type:       "comment",
+	})
+	if err != nil {
+		t.Fatalf("seed reply comment: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	PostArticleComment(conn, nil).ServeHTTP(rec, postArticleCommentRequest("nested-story", reply.ID))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("post status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+
+	var comment models.CommentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &comment); err != nil {
+		t.Fatalf("decode comment response: %v", err)
+	}
+	if comment.ParentID != reply.ID {
+		t.Fatalf("parent_id = %d, want %d", comment.ParentID, reply.ID)
+	}
+}

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -1612,6 +1612,7 @@ func GetArticleComments(conn *sql.DB) http.HandlerFunc {
 // @Success 201 {object} models.CommentResponse
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 404 {object} models.ErrorResponse
+// @Failure 403 {object} models.ErrorResponse
 // @Failure 413 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /v1/articles/{slug}/comments [post]
@@ -1667,7 +1668,7 @@ func PostArticleComment(conn *sql.DB, spamChecker akismet.Checker) http.HandlerF
 			return
 		}
 
-		articleID, _, exists, err := db.GetArticleCommentTargetBySlug(r.Context(), conn, slug)
+		articleID, commentStatus, exists, err := db.GetArticleCommentTargetBySlug(r.Context(), conn, slug)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
@@ -1676,20 +1677,25 @@ func PostArticleComment(conn *sql.DB, spamChecker akismet.Checker) http.HandlerF
 			writeError(w, http.StatusNotFound, "article not found")
 			return
 		}
+		if articleCommentsClosed(commentStatus) {
+			writeError(w, http.StatusForbidden, "comments are closed for this article")
+			return
+		}
 
-		parentExists, err := db.CommentExistsForArticle(r.Context(), conn, articleID, body.ParentID)
+		parentCanAcceptReply, err := db.CommentCanAcceptReply(r.Context(), conn, articleID, body.ParentID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		if !parentExists {
+		if !parentCanAcceptReply {
 			writeError(w, http.StatusBadRequest, "parent comment not found")
 			return
 		}
 
 		now := time.Now().UTC()
-		status := "approved"
+		status := "pending"
 		if spamChecker != nil {
+			status = "approved"
 			isSpam, err := spamChecker.CheckComment(r.Context(), akismet.Comment{
 				UserIP:      clientIP(r),
 				UserAgent:   r.UserAgent(),
@@ -1740,6 +1746,10 @@ func PostArticleComment(conn *sql.DB, spamChecker akismet.Checker) http.HandlerF
 			Type:         comment.Type,
 		})
 	}
+}
+
+func articleCommentsClosed(commentStatus string) bool {
+	return strings.EqualFold(strings.TrimSpace(commentStatus), "closed")
 }
 
 func articlePermalink(r *http.Request, slug string) string {

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -66,6 +66,27 @@ func TestPatchComment_InvalidStatus(t *testing.T) {
 	}
 }
 
+func TestArticleCommentsClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   bool
+	}{
+		{name: "closed", status: "closed", want: true},
+		{name: "case and space tolerant", status: " Closed ", want: true},
+		{name: "open", status: "open", want: false},
+		{name: "empty means open", status: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := articleCommentsClosed(tt.status); got != tt.want {
+				t.Fatalf("articleCommentsClosed(%q) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAppendCategorySlugCondition(t *testing.T) {
 	var conditions []string
 	var args []any


### PR DESCRIPTION
## Summary

- Enforce closed article comment settings on public comment submission.
- Default new public comments to pending when Akismet is not configured.
- Allow nested replies to approved reader comments while keeping parent validation scoped to the same article.
- Expand the CMS comments queue with selection, bulk moderation, restore-to-pending, soft trash, and permanent delete from trash.
- Add comment submission integration coverage behind CMS_TEST_DSN and update Swagger for the new 403 response.

## Validation

- go test ./...
- go test ./internal/handlers -run CommentHTTP -v (DB-backed cases skipped locally because CMS_TEST_DSN is not set)
- npm run build in frontend
- npm run lint in frontend

Related public-site changes were committed and pushed separately to Scalene CMS-Testing (dcf17c6).