### PR TITLE
fix(nginx): stop caching 404s for 30 days on legacy media

### DIFF
--- a/deploy/nginx/triangle-cms.conf
+++ b/deploy/nginx/triangle-cms.conf
@@ -75,7 +75,16 @@ server {
         # Filenames encode the exact size, so files are immutable. Set this only
         # via add_header -- `expires` would emit a second, weaker Cache-Control
         # and CDNs disagree about which duplicate wins.
-        add_header Cache-Control "public, max-age=2592000, immutable" always;
+        #
+        # Deliberately NOT `always`: that flag also stamps 30-day-immutable onto
+        # 404s, and Cloudflare then pins "this file does not exist" at the edge
+        # for a month. Any file added to the corpus after something first
+        # requested it stays invisible until the TTL expires or someone purges --
+        # a migrated image that is provably on disk and served fine by this nginx
+        # still 404s publicly, which reads as a failed copy rather than a cache
+        # hit. Without the flag add_header applies only to 2xx/3xx, so misses
+        # fall back to Cloudflare's short default 404 TTL and self-heal.
+        add_header Cache-Control "public, max-age=2592000, immutable";
     }
 
     # Never serve dotfiles (keep ACME http-01 working if it is ever added here).


### PR DESCRIPTION
## Problem

The `/wp-content/` block sets its cache header with `add_header ... always`. That flag applies the header to **error responses too**, so every 404 from the media tree went out with:

```
Cache-Control: public, max-age=2592000, immutable
```

Cloudflare took that at face value and pinned *"this file does not exist"* at the edge for 30 days.

The consequence: any file added to the corpus **after** something first requested it stays invisible for a month — on disk, served correctly by nginx, still 404 to every visitor. It reads as a failed copy rather than a cache hit, which is what makes it expensive to diagnose.

## How it surfaced

Found while migrating `wp-content/uploads/newsletter/` to CephFS. The files landed and the origin served them, but the edge kept replaying a 404 cached minutes before the copy finished:

| Request | Result |
|---|---|
| `…/nl-header-1-1200x0.png` | `404`, `cf-cache-status: HIT`, `age: 35385` |
| `…/nl-header-1-1200x0.png?v=1` | `200 image/png`, 90,191 bytes, `cf-cache-status: MISS` |

Same path, same origin — the only difference is a cache key Cloudflare hadn't poisoned. Origin `curl` on Delta returned `200` throughout.

## Fix

Drop `always` from the `Cache-Control` `add_header` **only**. Without the flag it applies to 2xx/3xx, so misses fall back to Cloudflare's short default 404 TTL and a later-added file self-heals.

`X-Content-Type-Options` and `Content-Security-Policy` keep `always` deliberately — those must apply to error responses.

Immutable caching for real images is unchanged.

## Scope

- Does **not** purge anything already cached; existing poisoned entries age out on their own (~Aug 30 for the newsletter paths).
- Host-level config, so merging does not deploy it. Needs `sudo cp` + `nginx -t` + `systemctl reload nginx` on Delta.
- Related workaround shipped separately in Scalene (`CMS-Testing`, 400337c): the `/proxy/` route now retries once past an edge-cached 404. That rescues already-poisoned paths; this PR fixes the mechanism.

## Verification after deploy

```bash
curl -sI http://localhost/wp-content/uploads/newsletter/does-not-exist-xyz.png | grep -i cache-control
```

Expected: **no `Cache-Control` line** on the 404, while a real image still returns `public, max-age=2592000, immutable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)