### PR TITLE
feat(settings): collapse settings sections and rework the footer editor

### DIFF
--- a/frontend/src/components/FooterMenuEditor.tsx
+++ b/frontend/src/components/FooterMenuEditor.tsx
@@ -1,6 +1,18 @@
-import { ArrowDown, ArrowUp, Plus, Trash2 } from "lucide-react"
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  ExternalLink,
+  Link2,
+  Minus,
+  Plus,
+  Trash2,
+  Type,
+} from "lucide-react"
 import { useEffect, useState } from "react"
 import { useApiFetch } from "../hooks/useApiFetch"
+import SettingsSection from "./SettingsSection"
 
 type FooterEntryKind = "link" | "heading" | "spacer"
 
@@ -16,6 +28,16 @@ type FooterColumn = {
 }
 
 const emptyEntry: FooterEntry = { kind: "link", label: "", href: "", new_tab: false }
+
+const kindOptions: { kind: FooterEntryKind; label: string; icon: typeof Type }[] = [
+  { kind: "heading", label: "Heading", icon: Type },
+  { kind: "link", label: "Link", icon: Link2 },
+  { kind: "spacer", label: "Spacer", icon: Minus },
+]
+
+const inputClass =
+  "w-full px-2.5 py-1.5 rounded-md border border-border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+const iconButtonClass = "p-1 rounded-md hover:bg-muted disabled:opacity-30 disabled:hover:bg-transparent"
 
 function normalizeEntry(raw: unknown): FooterEntry {
   const entry = (raw ?? {}) as Partial<FooterEntry>
@@ -42,6 +64,10 @@ function normalizeColumns(raw: unknown): FooterColumn[] {
  * Editor for the public site's footer menu. The footer is one ordered document
  * rather than a set of independent records, so the whole menu is loaded, edited
  * locally, and saved in a single PATCH.
+ *
+ * Columns are laid out side by side so the editor reads like the footer it
+ * produces; per-entry controls stay hidden until the entry is hovered or
+ * focused, which keeps a six-column menu from becoming a wall of buttons.
  */
 export default function FooterMenuEditor() {
   const apiFetch = useApiFetch()
@@ -105,6 +131,11 @@ export default function FooterMenuEditor() {
     setColumns(next)
   }
 
+  function addEntry(columnIndex: number, kind: FooterEntryKind) {
+    const column = columns[columnIndex]
+    updateColumn(columnIndex, { entries: [...column.entries, { ...emptyEntry, kind }] })
+  }
+
   async function save() {
     setSaving(true)
     setMessage(null)
@@ -132,146 +163,207 @@ export default function FooterMenuEditor() {
   const dirty = JSON.stringify(columns) !== saved
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-4">
-      <h2 className="text-lg font-semibold text-foreground">Footer Menu</h2>
-      <p className="text-sm text-muted-foreground">
-        Link columns shown in the public site footer. Headings are the bold entries; a spacer starts a
-        new group inside the same column. Saving an empty menu restores the built-in default.
-      </p>
-
+    <SettingsSection
+      title="Footer Menu"
+      storageKey="footer"
+      dirty={dirty}
+      summary={
+        loading
+          ? "Loading…"
+          : `${columns.length} column${columns.length === 1 ? "" : "s"}`
+      }
+      description="Link columns shown in the public site footer, laid out left to right as they appear on the site. Headings are the bold entries; a spacer starts a new group inside the same column. Saving an empty menu restores the built-in default."
+    >
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : columns.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border p-8 flex flex-col items-center gap-3 text-center">
+          <p className="text-sm text-muted-foreground max-w-sm">
+            The footer menu is empty. Add a column to build it, or save as-is to restore the built-in
+            default footer.
+          </p>
+          <button
+            type="button"
+            onClick={() => setColumns([{ entries: [{ ...emptyEntry, kind: "heading" }] }])}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-sm hover:bg-muted"
+          >
+            <Plus className="w-4 h-4" aria-hidden="true" />
+            Add column
+          </button>
+        </div>
       ) : (
-        <div className="flex flex-col gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
           {columns.map((column, columnIndex) => (
-            <div key={columnIndex} className="rounded-lg border border-border p-4 flex flex-col gap-3">
-              <div className="flex items-center justify-between">
+            <div
+              key={columnIndex}
+              className="rounded-lg border border-border bg-background/40 flex flex-col divide-y divide-border"
+            >
+              <div className="flex items-center justify-between gap-2 px-3 py-2">
                 <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
                   Column {columnIndex + 1}
                 </span>
-                <div className="flex items-center gap-1">
+                <div className="flex items-center gap-0.5">
                   <button
                     type="button"
                     aria-label={`Move column ${columnIndex + 1} earlier`}
+                    title="Move earlier"
                     onClick={() => moveColumn(columnIndex, -1)}
                     disabled={columnIndex === 0}
-                    className="p-1.5 rounded-md hover:bg-muted disabled:opacity-40"
+                    className={iconButtonClass}
                   >
-                    <ArrowUp className="w-4 h-4" aria-hidden="true" />
+                    <ArrowLeft className="w-4 h-4" aria-hidden="true" />
                   </button>
                   <button
                     type="button"
                     aria-label={`Move column ${columnIndex + 1} later`}
+                    title="Move later"
                     onClick={() => moveColumn(columnIndex, 1)}
                     disabled={columnIndex === columns.length - 1}
-                    className="p-1.5 rounded-md hover:bg-muted disabled:opacity-40"
+                    className={iconButtonClass}
                   >
-                    <ArrowDown className="w-4 h-4" aria-hidden="true" />
+                    <ArrowRight className="w-4 h-4" aria-hidden="true" />
                   </button>
                   <button
                     type="button"
                     aria-label={`Remove column ${columnIndex + 1}`}
+                    title="Remove column"
                     onClick={() => setColumns(columns.filter((_, i) => i !== columnIndex))}
-                    className="p-1.5 rounded-md text-destructive hover:bg-destructive/10"
+                    className="p-1 rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
                   >
                     <Trash2 className="w-4 h-4" aria-hidden="true" />
                   </button>
                 </div>
               </div>
 
-              {column.entries.map((entry, entryIndex) => (
-                <div key={entryIndex} className="flex flex-wrap items-center gap-2">
-                  <select
-                    aria-label="Entry type"
-                    value={entry.kind}
-                    onChange={(e) => updateEntry(columnIndex, entryIndex, { kind: e.target.value as FooterEntryKind })}
-                    className="px-2 py-2 rounded-lg border border-border bg-background text-sm"
-                  >
-                    <option value="heading">Heading</option>
-                    <option value="link">Link</option>
-                    <option value="spacer">Spacer</option>
-                  </select>
+              <div className="flex flex-col divide-y divide-border/60">
+                {column.entries.map((entry, entryIndex) => (
+                  <div key={entryIndex} className="group/entry px-3 py-2 flex flex-col gap-1.5 hover:bg-muted/40">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="inline-flex rounded-md border border-border overflow-hidden shrink-0">
+                        {kindOptions.map(({ kind, label, icon: Icon }) => (
+                          <button
+                            key={kind}
+                            type="button"
+                            title={label}
+                            aria-label={label}
+                            aria-pressed={entry.kind === kind}
+                            onClick={() => updateEntry(columnIndex, entryIndex, { kind })}
+                            className={`px-1.5 py-1 ${
+                              entry.kind === kind
+                                ? "bg-muted text-foreground"
+                                : "text-muted-foreground/50 hover:bg-muted hover:text-foreground"
+                            }`}
+                          >
+                            <Icon className="w-3.5 h-3.5" aria-hidden="true" />
+                          </button>
+                        ))}
+                      </div>
 
-                  {entry.kind === "spacer" ? (
-                    <span className="text-sm text-muted-foreground flex-1">Blank line</span>
-                  ) : (
-                    <>
-                      <input
-                        aria-label="Label"
-                        value={entry.label}
-                        onChange={(e) => updateEntry(columnIndex, entryIndex, { label: e.target.value })}
-                        placeholder="Label"
-                        className="flex-1 min-w-[8rem] px-3 py-2 rounded-lg border border-border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
-                      />
-                      <input
-                        aria-label="Link target"
-                        value={entry.href}
-                        onChange={(e) => updateEntry(columnIndex, entryIndex, { href: e.target.value })}
-                        placeholder="/section or https://…"
-                        className="flex-[2] min-w-[12rem] px-3 py-2 rounded-lg border border-border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
-                      />
-                      <label className="flex items-center gap-1.5 text-sm text-muted-foreground select-none">
+                      <div className="ml-auto flex items-center gap-0.5">
+                        {/* Stays visible while on, so "opens in a new tab" is legible without hovering. */}
+                        {entry.kind !== "spacer" && (
+                          <button
+                            type="button"
+                            title="Open in new tab"
+                            aria-label="Open in new tab"
+                            aria-pressed={entry.new_tab}
+                            onClick={() => updateEntry(columnIndex, entryIndex, { new_tab: !entry.new_tab })}
+                            className={`p-1 rounded-md ${
+                              entry.new_tab
+                                ? "bg-primary/10 text-primary"
+                                : "text-muted-foreground hover:bg-muted opacity-0 group-hover/entry:opacity-100 focus-visible:opacity-100 transition-opacity"
+                            }`}
+                          >
+                            <ExternalLink className="w-4 h-4" aria-hidden="true" />
+                          </button>
+                        )}
+                      </div>
+
+                      <div className="flex items-center gap-0.5 opacity-0 group-hover/entry:opacity-100 focus-within:opacity-100 transition-opacity">
+                        <button
+                          type="button"
+                          aria-label="Move entry up"
+                          title="Move up"
+                          onClick={() => moveEntry(columnIndex, entryIndex, -1)}
+                          disabled={entryIndex === 0}
+                          className={iconButtonClass}
+                        >
+                          <ArrowUp className="w-4 h-4" aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Move entry down"
+                          title="Move down"
+                          onClick={() => moveEntry(columnIndex, entryIndex, 1)}
+                          disabled={entryIndex === column.entries.length - 1}
+                          className={iconButtonClass}
+                        >
+                          <ArrowDown className="w-4 h-4" aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Remove entry"
+                          title="Remove entry"
+                          onClick={() =>
+                            updateColumn(columnIndex, {
+                              entries: column.entries.filter((_, i) => i !== entryIndex),
+                            })
+                          }
+                          className="p-1 rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                        >
+                          <Trash2 className="w-4 h-4" aria-hidden="true" />
+                        </button>
+                      </div>
+                    </div>
+
+                    {entry.kind === "spacer" ? (
+                      <div className="flex items-center gap-2 py-0.5">
+                        <span className="flex-1 border-t border-dashed border-border" aria-hidden="true" />
+                        <span className="text-xs text-muted-foreground">Blank line</span>
+                        <span className="flex-1 border-t border-dashed border-border" aria-hidden="true" />
+                      </div>
+                    ) : (
+                      <>
                         <input
-                          type="checkbox"
-                          checked={entry.new_tab}
-                          onChange={(e) => updateEntry(columnIndex, entryIndex, { new_tab: e.target.checked })}
-                          className="h-4 w-4 rounded border-border text-primary focus:ring-2 focus:ring-primary/40"
+                          aria-label="Label"
+                          value={entry.label}
+                          onChange={(e) => updateEntry(columnIndex, entryIndex, { label: e.target.value })}
+                          placeholder="Label"
+                          className={`${inputClass} ${entry.kind === "heading" ? "font-semibold" : ""}`}
                         />
-                        New tab
-                      </label>
-                    </>
-                  )}
-
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      aria-label="Move entry up"
-                      onClick={() => moveEntry(columnIndex, entryIndex, -1)}
-                      disabled={entryIndex === 0}
-                      className="p-1.5 rounded-md hover:bg-muted disabled:opacity-40"
-                    >
-                      <ArrowUp className="w-4 h-4" aria-hidden="true" />
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="Move entry down"
-                      onClick={() => moveEntry(columnIndex, entryIndex, 1)}
-                      disabled={entryIndex === column.entries.length - 1}
-                      className="p-1.5 rounded-md hover:bg-muted disabled:opacity-40"
-                    >
-                      <ArrowDown className="w-4 h-4" aria-hidden="true" />
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="Remove entry"
-                      onClick={() =>
-                        updateColumn(columnIndex, {
-                          entries: column.entries.filter((_, i) => i !== entryIndex),
-                        })
-                      }
-                      className="p-1.5 rounded-md text-destructive hover:bg-destructive/10"
-                    >
-                      <Trash2 className="w-4 h-4" aria-hidden="true" />
-                    </button>
+                        <input
+                          aria-label="Link target"
+                          value={entry.href}
+                          onChange={(e) => updateEntry(columnIndex, entryIndex, { href: e.target.value })}
+                          placeholder="/section or https://…"
+                          className={`${inputClass} text-muted-foreground`}
+                        />
+                      </>
+                    )}
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
 
-              <button
-                type="button"
-                onClick={() => updateColumn(columnIndex, { entries: [...column.entries, { ...emptyEntry }] })}
-                className="self-start inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-sm hover:bg-muted"
-              >
-                <Plus className="w-4 h-4" aria-hidden="true" />
-                Add entry
-              </button>
+              <div className="px-3 py-2 flex flex-wrap items-center gap-1.5">
+                {kindOptions.map(({ kind, label, icon: Icon }) => (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => addEntry(columnIndex, kind)}
+                    className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-border text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                  >
+                    <Icon className="w-3.5 h-3.5" aria-hidden="true" />
+                    {label}
+                  </button>
+                ))}
+              </div>
             </div>
           ))}
 
           <button
             type="button"
             onClick={() => setColumns([...columns, { entries: [{ ...emptyEntry, kind: "heading" }] }])}
-            className="self-start inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-sm hover:bg-muted"
+            className="rounded-lg border border-dashed border-border px-3 py-6 flex items-center justify-center gap-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             <Plus className="w-4 h-4" aria-hidden="true" />
             Add column
@@ -288,8 +380,9 @@ export default function FooterMenuEditor() {
         >
           Save Footer
         </button>
+        {dirty && !saving && <span className="text-sm text-muted-foreground">Unsaved changes</span>}
         {message && <span className="text-sm text-muted-foreground">{message}</span>}
       </div>
-    </div>
+    </SettingsSection>
   )
 }

--- a/frontend/src/components/SettingsSection.tsx
+++ b/frontend/src/components/SettingsSection.tsx
@@ -1,0 +1,99 @@
+import { ChevronRight } from "lucide-react"
+import { useId, useState, type ReactNode } from "react"
+
+type SettingsSectionProps = {
+  title: string
+  /** Shown only while expanded, so a collapsed section stays one compact row. */
+  description?: ReactNode
+  /** Short right-aligned hint (e.g. "6 columns") that keeps the collapsed row informative. */
+  summary?: ReactNode
+  /** Flags unsaved edits in the header so collapsing can't hide them. */
+  dirty?: boolean
+  /** Distinguishes this section's remembered open state; must be stable. */
+  storageKey: string
+  defaultOpen?: boolean
+  children: ReactNode
+}
+
+const storagePrefix = "cms.settings.section."
+
+function readOpen(storageKey: string, fallback: boolean): boolean {
+  try {
+    const stored = localStorage.getItem(storagePrefix + storageKey)
+    return stored === null ? fallback : stored === "1"
+  } catch {
+    // Private-mode / disabled storage: fall back to the default rather than break the page.
+    return fallback
+  }
+}
+
+/**
+ * Collapsible card for one settings group. The settings page is a stack of
+ * independent groups, most of which are only touched occasionally, so each one
+ * collapses to a single row and remembers that choice across visits.
+ *
+ * The body is hidden with `hidden` rather than unmounted: sections own loaded
+ * state and in-progress edits, and remounting would refetch and discard them.
+ */
+export default function SettingsSection({
+  title,
+  description,
+  summary,
+  dirty = false,
+  storageKey,
+  defaultOpen = false,
+  children,
+}: SettingsSectionProps) {
+  const [open, setOpen] = useState(() => readOpen(storageKey, defaultOpen))
+  const bodyId = useId()
+
+  function toggle() {
+    setOpen((current) => {
+      const next = !current
+      try {
+        localStorage.setItem(storagePrefix + storageKey, next ? "1" : "0")
+      } catch {
+        // Remembering the state is a nicety; ignore storage failures.
+      }
+      return next
+    })
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-card">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        className="w-full flex items-center gap-3 px-6 py-4 text-left rounded-xl hover:bg-muted/30"
+      >
+        <ChevronRight
+          className={`w-4 h-4 shrink-0 text-muted-foreground transition-transform ${open ? "rotate-90" : ""}`}
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1">
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          {open && description && (
+            <p className="text-sm text-muted-foreground mt-0.5 max-w-3xl">{description}</p>
+          )}
+        </div>
+        {dirty && (
+          <span className="shrink-0 px-2 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-medium">
+            Unsaved
+          </span>
+        )}
+        {summary && <span className="shrink-0 text-xs text-muted-foreground">{summary}</span>}
+      </button>
+      {/* `flex` would override the `hidden` attribute's display:none, so the
+          class list has to carry the collapse itself. */}
+      <div
+        id={bodyId}
+        hidden={!open}
+        className={`border-t border-border px-6 py-5 flex-col gap-4 ${open ? "flex" : "hidden"}`}
+      >
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/settingsPage.tsx
+++ b/frontend/src/pages/settingsPage.tsx
@@ -2,6 +2,7 @@ import { ArrowDown, ArrowUp, ImageOff, ImagePlus, LogOut, Plus, RefreshCw, Trash
 import { useCallback, useEffect, useRef, useState } from "react"
 import FooterMenuEditor from "../components/FooterMenuEditor"
 import MediaPicker, { type MediaPickerItem } from "../components/MediaPicker"
+import SettingsSection from "../components/SettingsSection"
 import { useApiFetch } from "../hooks/useApiFetch"
 import { useCurrentUserRole } from "../hooks/useCurrentUserRole"
 import { useNavigate } from "react-router-dom"
@@ -355,6 +356,8 @@ export default function SettingsPage() {
   }
 
   const carouselDirty = JSON.stringify(carouselSlides) !== JSON.stringify(carouselSaved)
+  const siteTitleDirty = siteTitleDraft.trim() !== siteTitle
+  const breakingDirty = breakingEnabled !== breakingSaved.enabled || breakingText.trim() !== breakingSaved.text
 
   return (
     <div className="flex flex-col gap-6 p-6">
@@ -405,9 +408,13 @@ export default function SettingsPage() {
         </div>
       </div>
 
-      <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-4">
-        <h2 className="text-lg font-semibold text-foreground">Site</h2>
-        <p className="text-sm text-muted-foreground">Public site title used by the frontend.</p>
+      <SettingsSection
+        title="Site"
+        storageKey="site"
+        dirty={siteTitleDirty}
+        summary={siteTitle || "Not set"}
+        description="Public site title used by the frontend."
+      >
         <div className="flex flex-col gap-2 max-w-xl">
           <label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Site Title</label>
           <input
@@ -428,16 +435,16 @@ export default function SettingsPage() {
           </button>
           {siteTitleMessage && <span className="text-sm text-muted-foreground">{siteTitleMessage}</span>}
         </div>
-      </div>
+      </SettingsSection>
 
-      <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-4">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-semibold text-foreground">Homepage Carousel</h2>
-            <p className="text-sm text-muted-foreground">
-              Slides shown in Scalene's Splide carousel on the public homepage.
-            </p>
-          </div>
+      <SettingsSection
+        title="Homepage Carousel"
+        storageKey="carousel"
+        dirty={carouselDirty}
+        summary={`${carouselSlides.length} slide${carouselSlides.length === 1 ? "" : "s"}`}
+        description="Slides shown in Scalene's Splide carousel on the public homepage."
+      >
+        <div className="flex justify-end">
           <button
             type="button"
             onClick={() => setCarouselSlides((current) => [...current, emptyCarouselSlide()])}
@@ -606,13 +613,15 @@ export default function SettingsPage() {
           </button>
           {carouselMessage && <span className="text-sm text-muted-foreground">{carouselMessage}</span>}
         </div>
-      </div>
+      </SettingsSection>
 
-      <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-4">
-        <h2 className="text-lg font-semibold text-foreground">Breaking News Banner</h2>
-        <p className="text-sm text-muted-foreground">
-          Show a breaking-news banner across the top of the public homepage.
-        </p>
+      <SettingsSection
+        title="Breaking News Banner"
+        storageKey="breaking-news"
+        dirty={breakingDirty}
+        summary={breakingEnabled ? "Enabled" : "Off"}
+        description="Show a breaking-news banner across the top of the public homepage."
+      >
         <label className="flex items-center gap-3 cursor-pointer select-none">
           <input
             type="checkbox"
@@ -646,15 +655,16 @@ export default function SettingsPage() {
           </button>
           {breakingMessage && <span className="text-sm text-muted-foreground">{breakingMessage}</span>}
         </div>
-      </div>
+      </SettingsSection>
 
       {isAdmin && <FooterMenuEditor />}
 
-      <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-4">
-        <h2 className="text-lg font-semibold text-foreground">Taxonomy</h2>
-        <p className="text-sm text-muted-foreground">
-          Recalculate taxonomy article counts from current article category assignments.
-        </p>
+      <SettingsSection
+        title="Taxonomy"
+        storageKey="taxonomy"
+        description="Recalculate taxonomy article counts from current article category assignments."
+        summary={taxonomyRebuildRunning ? "Rebuilding…" : undefined}
+      >
         <div className="flex items-center gap-3">
           <button
             type="button"
@@ -666,15 +676,15 @@ export default function SettingsPage() {
           </button>
           {taxonomyRebuildMessage && <span className="text-sm text-muted-foreground">{taxonomyRebuildMessage}</span>}
         </div>
-      </div>
+      </SettingsSection>
 
       {isAdmin && (
-        <div className="rounded-xl border border-border bg-card p-6 flex flex-col gap-4">
-          <h2 className="text-lg font-semibold text-foreground">Media Library</h2>
-          <p className="text-sm text-muted-foreground">
-            Scan the media filesystem for files missing from the library. This walks every asset on the
-            media server and takes several minutes; existing entries are left untouched.
-          </p>
+        <SettingsSection
+          title="Media Library"
+          storageKey="media-library"
+          summary={mediaIndexRunning ? "Reindexing…" : undefined}
+          description="Scan the media filesystem for files missing from the library. This walks every asset on the media server and takes several minutes; existing entries are left untouched."
+        >
           <div className="flex items-center gap-3">
             <button
               type="button"
@@ -687,7 +697,7 @@ export default function SettingsPage() {
             </button>
             {mediaIndexMessage && <span className="text-sm text-muted-foreground">{mediaIndexMessage}</span>}
           </div>
-        </div>
+        </SettingsSection>
       )}
 
       {carouselPickerIndex !== null && (


### PR DESCRIPTION
## What

The settings screen had grown to six full-height cards stacked end to end — about **9,200px** of page. The footer menu was most of it: 6 columns × ~8 entries rendered as one long vertical list of ~48 identical wrapping form rows.

Collapsed, the page is now **~1,250px** and fits on one screen.

### Collapsible sections

New `SettingsSection` wraps every group (Site, Homepage Carousel, Breaking News, Footer Menu, Taxonomy, Media Library). The profile card is left alone — it's identity, not a setting.

- Collapsed by default, with open state remembered per section in `localStorage`.
- Collapsed rows stay informative via a right-aligned summary — `The Triangle`, `2 slides`, `Enabled`, `6 columns`, and `Reindexing…` / `Rebuilding…` while those jobs run. Descriptions render only when expanded.
- An **Unsaved** chip appears in the header when a section is dirty and stays visible while collapsed, so collapsing can't hide pending edits.
- Bodies are hidden with CSS rather than unmounted: sections own fetched state and in-progress edits that a remount would refetch and discard.

`Add Slide` moved from the carousel header into the body, since it can't nest inside the header's toggle button.

### Footer menu editor

Columns now lay out in a responsive grid mirroring the footer they produce, instead of stacking. Per entry, the label sits above the href; headings render semibold and spacers draw a dashed "Blank line" rule. A segmented heading/link/spacer picker replaces the per-row `<select>`, and move/delete controls are revealed on hover or focus. The new-tab toggle stays visible while enabled so it's legible at a glance.

## Testing

`tsc --noEmit` and `eslint` clean. Driven in a browser against the real default footer (6 columns / 48 entries) with the settings endpoints stubbed, since the page is behind OIDC:

- Expand/collapse, dirty chip appears on edit and persists while collapsed, edits survive a collapse/expand cycle, open state survives a reload.
- Footer save round-trips: moving an entry down and saving returned `About, Contact Us, Staff, Join The Triangle`.
- Tab order is Sign out plus the six headers — nothing reachable inside a collapsed body.
- No console errors.

Caught this way and fixed: the first version used the `hidden` attribute alone, which Tailwind's `flex` class overrode, leaving every section fully expanded under a collapsed chevron.

## Note

`tailwind.config.js` sets `darkMode: ["class"]`, but there is no `.dark` variable block in `src/index.css` and nothing toggles the class — dark mode is unused boilerplate, so this was designed light-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)