### PR TITLE
fix(taxonomy): match sections by their subsections, and count what we list

### DIFF
--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"strings"
 )
 
@@ -20,51 +19,122 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 	return err
 }
 
-func parseTaxonomyCountCategories(value sql.NullString) []string {
-	if !value.Valid || strings.TrimSpace(value.String) == "" {
+// CategoryMatchPatterns returns the LOWER(`categories`) LIKE patterns that
+// identify articles filed under a taxonomy slug.
+//
+// WordPress category text does not match our slugs literally, so a slug stands
+// in for several spellings: "comics-puzzles" has to find "Comics & Puzzles".
+// This is the single definition of "is this article in this section" -- both the
+// article listing and the count rebuild call it, because when they disagreed a
+// section could list 2545 articles while reporting 8.
+func CategoryMatchPatterns(slug string) []string {
+	normalized := strings.ToLower(strings.TrimSpace(slug))
+	if normalized == "" {
 		return nil
 	}
-	var parsed []string
-	if err := json.Unmarshal([]byte(value.String), &parsed); err != nil {
-		return strings.Split(value.String, ",")
+
+	patterns := make([]string, 0, 3)
+	add := func(value string) {
+		for _, existing := range patterns {
+			if existing == value {
+				return
+			}
+		}
+		patterns = append(patterns, value)
 	}
-	return parsed
+
+	add("%" + normalized + "%")
+	if strings.Contains(normalized, "-") {
+		add("%" + strings.ReplaceAll(normalized, "-", " ") + "%")
+		add("%" + strings.ReplaceAll(normalized, "-", " & ") + "%")
+	}
+	return patterns
 }
 
-func RebuildTaxonomyArticleCounts(ctx context.Context, conn *sql.DB) error {
+// taxonomyMatchSlugs maps every section/subsection slug to the slugs whose
+// articles belong to it: a subsection matches only itself, a section matches
+// itself plus all of its children.
+//
+// The children matter because a section can be a pure container. Nothing is
+// filed under the category "Special Editions" -- its articles live under
+// "Welcome Week" and "100 Year Anniversary" -- so matching the section slug
+// alone reports zero for a section that visibly has content.
+func taxonomyMatchSlugs(ctx context.Context, conn *sql.DB) (map[string][]string, error) {
 	rows, err := conn.QueryContext(ctx, `
-		SELECT categories
-		FROM articles
-		WHERE TRIM(COALESCE(categories, '')) <> ''
-		  AND archived_at IS NULL
+		SELECT slug, kind, COALESCE(parent_slug, '')
+		FROM site_taxonomy
+		WHERE kind IN ('section', 'subsection')
 	`)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer rows.Close()
 
-	counts := make(map[string]int64)
+	matches := make(map[string][]string)
+	children := make(map[string][]string)
 	for rows.Next() {
-		var rawCategories sql.NullString
-		if err := rows.Scan(&rawCategories); err != nil {
-			return err
+		var slug, kind, parent string
+		if err := rows.Scan(&slug, &kind, &parent); err != nil {
+			return nil, err
 		}
-
-		seen := make(map[string]struct{})
-		for _, category := range parseTaxonomyCountCategories(rawCategories) {
-			slug := CanonicalizeSlug(category)
-			if slug == "" {
-				continue
-			}
-			if _, ok := seen[slug]; ok {
-				continue
-			}
-			seen[slug] = struct{}{}
-			counts[slug] += 1
+		if strings.TrimSpace(slug) == "" {
+			continue
+		}
+		matches[slug] = []string{slug}
+		if kind == "subsection" && strings.TrimSpace(parent) != "" {
+			children[parent] = append(children[parent], slug)
 		}
 	}
 	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	for parent, kids := range children {
+		if _, ok := matches[parent]; !ok {
+			continue
+		}
+		matches[parent] = append(matches[parent], kids...)
+	}
+	return matches, nil
+}
+
+// TaxonomyCountCondition builds the WHERE fragment matching articles in any of
+// the given slugs, along with its arguments.
+func TaxonomyCountCondition(slugs []string) (string, []any) {
+	var clauses []string
+	var args []any
+	for _, slug := range slugs {
+		for _, pattern := range CategoryMatchPatterns(slug) {
+			clauses = append(clauses, "LOWER(`categories`) LIKE ?")
+			args = append(args, pattern)
+		}
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return "(" + strings.Join(clauses, " OR ") + ")", args
+}
+
+func RebuildTaxonomyArticleCounts(ctx context.Context, conn *sql.DB) error {
+	matchSlugs, err := taxonomyMatchSlugs(ctx, conn)
+	if err != nil {
 		return err
+	}
+
+	// Counted over the same population the public listing shows, so
+	// article_count equals the total a reader actually pages through.
+	counts := make(map[string]int64, len(matchSlugs))
+	for slug, slugs := range matchSlugs {
+		condition, args := TaxonomyCountCondition(slugs)
+		if condition == "" {
+			continue
+		}
+		var count int64
+		query := "SELECT COUNT(*) FROM `articles` WHERE `archived_at` IS NULL AND `pub_date` IS NOT NULL AND " + condition
+		if err := conn.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+			return err
+		}
+		counts[slug] = count
 	}
 
 	tx, err := conn.BeginTx(ctx, nil)

--- a/server/internal/database/taxonomy_test.go
+++ b/server/internal/database/taxonomy_test.go
@@ -1,0 +1,71 @@
+package database
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCategoryMatchPatternsExpandsDashedSlugs(t *testing.T) {
+	// A dashed slug has to find the WordPress spelling, which uses spaces and
+	// often an ampersand: "comics-puzzles" must match "Comics & Puzzles".
+	got := CategoryMatchPatterns("comics-puzzles")
+	want := []string{"%comics-puzzles%", "%comics puzzles%", "%comics & puzzles%"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d patterns %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pattern %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestCategoryMatchPatternsSingleWordSlug(t *testing.T) {
+	got := CategoryMatchPatterns("comics")
+	if len(got) != 1 || got[0] != "%comics%" {
+		t.Fatalf("got %v, want [%%comics%%]", got)
+	}
+}
+
+func TestCategoryMatchPatternsEmpty(t *testing.T) {
+	if got := CategoryMatchPatterns("   "); got != nil {
+		t.Fatalf("got %v, want nil for a blank slug", got)
+	}
+}
+
+func TestTaxonomyCountConditionORsEverySlug(t *testing.T) {
+	// A section matches its own slug OR any child's, so a container section
+	// with no category of its own still resolves to its subsections' articles.
+	condition, args := TaxonomyCountCondition([]string{"special-editions", "welcome-week"})
+	if condition == "" {
+		t.Fatal("expected a condition")
+	}
+	if strings.Contains(condition, " AND ") {
+		t.Errorf("condition must OR its slugs, not AND them: %s", condition)
+	}
+	// 3 patterns per dashed slug, two slugs.
+	if got := strings.Count(condition, "LIKE ?"); got != 6 {
+		t.Errorf("got %d placeholders, want 6: %s", got, condition)
+	}
+	if len(args) != 6 {
+		t.Errorf("got %d args, want 6: %v", len(args), args)
+	}
+	for _, want := range []string{"%welcome week%", "%special editions%"} {
+		found := false
+		for _, arg := range args {
+			if arg == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing pattern %q in %v", want, args)
+		}
+	}
+}
+
+func TestTaxonomyCountConditionEmpty(t *testing.T) {
+	condition, args := TaxonomyCountCondition(nil)
+	if condition != "" || args != nil {
+		t.Fatalf("got (%q, %v), want empty", condition, args)
+	}
+}

--- a/server/internal/handlers/article_params.go
+++ b/server/internal/handlers/article_params.go
@@ -69,6 +69,14 @@ func normalizeAndValidateArticleParams(ctx context.Context, conn *sql.DB, params
 		}
 	}
 
+	if params.Section != "" {
+		matchSlugs, err := sectionMatchSlugs(ctx, conn, params.Section)
+		if err != nil {
+			return ArticleParams{}, err
+		}
+		params.SectionMatchSlugs = matchSlugs
+	}
+
 	if params.Subsection != "" {
 		parentSection, ok, err := parentSectionForSubsection(ctx, conn, params.Subsection)
 		if err != nil {
@@ -106,6 +114,45 @@ func taxonomySectionExists(ctx context.Context, conn *sql.DB, section string) (b
 		return false, nil
 	}
 	return err == nil, err
+}
+
+// sectionMatchSlugs returns the section plus every subsection filed under it,
+// which together define what "articles in this section" means. Falls back to
+// the section alone when there is no database handle, matching the behaviour of
+// the other taxonomy lookups here.
+func sectionMatchSlugs(ctx context.Context, conn *sql.DB, section string) ([]string, error) {
+	trimmed := strings.TrimSpace(section)
+	if trimmed == "" {
+		return nil, nil
+	}
+	if conn == nil {
+		slugs := []string{trimmed}
+		for subsection := range allowedSubsectionsBySection[trimmed] {
+			slugs = append(slugs, subsection)
+		}
+		return slugs, nil
+	}
+
+	rows, err := conn.QueryContext(ctx,
+		"SELECT slug FROM site_taxonomy WHERE kind = ? AND parent_slug = ?",
+		string(models.TaxonomyTypeSubsection), trimmed,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	slugs := []string{trimmed}
+	for rows.Next() {
+		var slug string
+		if err := rows.Scan(&slug); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(slug) != "" {
+			slugs = append(slugs, slug)
+		}
+	}
+	return slugs, rows.Err()
 }
 
 func parentSectionForSubsection(ctx context.Context, conn *sql.DB, subsection string) (string, bool, error) {

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -1100,6 +1100,10 @@ type ArticleParams struct {
 	AuthorSlug string
 	Section    string
 	Subsection string
+	// SectionMatchSlugs is the section plus its subsections, resolved during
+	// validation because the filter builder has no database handle. A section
+	// with no matching category of its own is still populated by its children.
+	SectionMatchSlugs []string
 }
 
 func queryArticles(r *http.Request, conn *sql.DB, params ArticleParams, limit, offset int) (*sql.Rows, error) {
@@ -1205,12 +1209,14 @@ func articleQueryFilters(r *http.Request, params ArticleParams) ([]string, []any
 		args = append(args, params.AuthorSlug)
 	}
 
-	if params.Section != "" {
-		appendCategorySlugCondition(&conditions, &args, params.Section)
-	}
-
+	// A subsection stands on its own: ANDing it with its parent returns the
+	// intersection, which is empty whenever the parent slug is not itself a
+	// real category. That is how /special-editions/welcome-week served 0
+	// articles while 30 were filed under "Welcome Week".
 	if params.Subsection != "" {
 		appendCategorySlugCondition(&conditions, &args, params.Subsection)
+	} else if params.Section != "" {
+		appendCategorySlugCondition(&conditions, &args, params.SectionMatchSlugs...)
 	}
 
 	if status := strings.TrimSpace(q.Get("status")); status != "" && isEditor {
@@ -1261,35 +1267,16 @@ func articleQueryFilters(r *http.Request, params ArticleParams) ([]string, []any
 	return conditions, args
 }
 
-func appendCategorySlugCondition(conditions *[]string, args *[]any, slug string) {
-	normalized := strings.ToLower(strings.TrimSpace(slug))
-	if normalized == "" {
+// appendCategorySlugCondition narrows to articles filed under any of the given
+// slugs. Patterns come from db.CategoryMatchPatterns so the listing and the
+// taxonomy counts can never drift apart.
+func appendCategorySlugCondition(conditions *[]string, args *[]any, slugs ...string) {
+	condition, condArgs := db.TaxonomyCountCondition(slugs)
+	if condition == "" {
 		return
 	}
-
-	patterns := make([]string, 0, 3)
-	addPattern := func(value string) {
-		for _, existing := range patterns {
-			if existing == value {
-				return
-			}
-		}
-		patterns = append(patterns, value)
-	}
-
-	addPattern("%" + normalized + "%")
-	if strings.Contains(normalized, "-") {
-		addPattern("%" + strings.ReplaceAll(normalized, "-", " ") + "%")
-		addPattern("%" + strings.ReplaceAll(normalized, "-", " & ") + "%")
-	}
-
-	clauseParts := make([]string, 0, len(patterns))
-	for _, pattern := range patterns {
-		clauseParts = append(clauseParts, "LOWER(`categories`) LIKE ?")
-		*args = append(*args, pattern)
-	}
-
-	*conditions = append(*conditions, "("+strings.Join(clauseParts, " OR ")+")")
+	*conditions = append(*conditions, condition)
+	*args = append(*args, condArgs...)
 }
 
 func appendArticleTypeCondition(conditions *[]string, args *[]any, rawType string, negate ...bool) {
@@ -2411,7 +2398,14 @@ func GetHomepage(conn *sql.DB) http.HandlerFunc {
 				key   string
 				limit int
 			}) error {
-				params := ArticleParams{"", section.slug, ""}
+				// Resolved rather than literal so a homepage block for a
+				// container section (one with no category of its own) still
+				// shows its subsections' articles.
+				matchSlugs, err := sectionMatchSlugs(r.Context(), conn, section.slug)
+				if err != nil {
+					return err
+				}
+				params := ArticleParams{Section: section.slug, SectionMatchSlugs: matchSlugs}
 				limit := section.limit
 				rows, err := queryArticles(r, conn, params, limit+1, offset)
 				if err != nil {


### PR DESCRIPTION
## The bug

Two section-page problems that turned out to share one root: section membership had **three different definitions** in the codebase.

**1. Container sections listed nothing.** Article filtering did a `LIKE` on the section slug alone, and `AND`ed a subsection with its parent. Both assume the section slug appears in the WordPress category text — untrue for a section that is only a container. Nothing is filed under the category `Special Editions`; its articles live under `Welcome Week` and `100 Year Anniversary`. So:

- `/v1/sections/special-editions/articles` → **0** articles
- `/v1/sections/special-editions/articles?subsection_slug=welcome-week` → **0**, the intersection of a real category with one that does not exist, while 30 articles sat under Welcome Week

`news/politics` and `entertainment/music` only worked by luck: those parent slugs happen to occur in category text.

**2. Counts disagreed with listings.** `RebuildTaxonomyArticleCounts` used a third definition — exact equality on `CanonicalizeSlug(category)`. `Arts & Entertainment` canonicalizes to `arts-entertainment`, which never equalled the `entertainment` slug, so the section **listed 2545 articles while reporting 8**.

## The fix

One matcher, `db.CategoryMatchPatterns`, used by both the listing and the count rebuild so they cannot drift apart.

- A **section** matches itself **OR** any of its subsections.
- A **subsection** matches only itself, instead of being `AND`ed with its parent. A subsection can only narrow a section, so intersecting the two could never add anything.
- **Counts** are derived from the same matcher over the same published, non-archived population, so `article_count` is the total a reader actually pages through.

The homepage section blocks resolve their match slugs too, so a homepage block for a container section shows its subsections' articles.

## Effect on the current corpus

| | before | after |
|---|---|---|
| `special-editions` listing | 0 | **60** |
| `welcome-week` subsection | 0 | **30** |
| `entertainment` count | 8 | **2602** (= its listing) |
| `comics` | 221 | **293** |

## Testing

`go build`, `go vet` and the full `go test ./...` suite pass. New unit tests cover the pattern expansion (`comics-puzzles` → `Comics & Puzzles`), the OR-not-AND behaviour, and the empty cases. The SQL the new code generates was also run against the live corpus to produce the numbers above.

Note the count rebuild now issues one `COUNT(*)` per taxonomy row (35 today) at startup instead of a single scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)