### PR TITLE
fix(dashboard): drop the misleading weekly article delta

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -41,7 +41,6 @@ interface ApiStats {
   draftArticles: number | null
   totalAuthors: number | null
   totalSections: number | null
-  weeklyDelta: number
   loading: boolean
 }
 
@@ -91,11 +90,9 @@ export default function DashboardPage() {
   const [isSavingDraft, setIsSavingDraft] = useState(false)
   const [draftError, setDraftError] = useState<string | null>(null)
   const [apiHealth, setApiHealth] = useState<"ok" | "error" | "checking">("checking")
-  const [stats, setStats] = useState<ApiStats>({ totalArticles: null, publishedArticles: null, draftArticles: null, totalAuthors: null, totalSections: null, weeklyDelta: 0, loading: true })
+  const [stats, setStats] = useState<ApiStats>({ totalArticles: null, publishedArticles: null, draftArticles: null, totalAuthors: null, totalSections: null, loading: true })
 
   useEffect(() => {
-    let cancelled = false
-
     apiFetch("/v1/articles?limit=10")
       .then((r) => r.json())
       .then((d) => {
@@ -178,60 +175,7 @@ export default function DashboardPage() {
     apiFetch("/v1/articles?limit=1")
       .then((r) => (r.ok ? setApiHealth("ok") : setApiHealth("error")))
       .catch(() => setApiHealth("error"))
-
-    ;(async () => {
-      const now = Date.now()
-      const oneWeekAgo = now - 7 * 24 * 60 * 60 * 1000
-      const twoWeeksAgo = now - 14 * 24 * 60 * 60 * 1000
-      const pageSize = 100
-      let offset = 0
-      let thisWeek = 0
-      let prevWeek = 0
-
-      try {
-        for (;;) {
-          const resp = await apiFetch(`/v1/articles?status=published&sort_by=published_date&sort_direction=desc&limit=${pageSize}&offset=${offset}`)
-          const data = await resp.json()
-          const articles = Array.isArray(data?.articles) ? data.articles : []
-          if (articles.length === 0) break
-
-          let reachedOlderThanWindow = false
-          for (const article of articles) {
-            const publishedDate = article?.published_date
-            if (!publishedDate) continue
-            const t = new Date(publishedDate).getTime()
-            if (Number.isNaN(t)) continue
-            if (t >= oneWeekAgo) {
-              thisWeek += 1
-              continue
-            }
-            if (t >= twoWeeksAgo) {
-              prevWeek += 1
-              continue
-            }
-            reachedOlderThanWindow = true
-          }
-
-          if (reachedOlderThanWindow || articles.length < pageSize) break
-          offset += pageSize
-        }
-
-        if (!cancelled) {
-          setStats((s) => ({ ...s, weeklyDelta: thisWeek - prevWeek }))
-        }
-      } catch {
-        if (!cancelled) {
-          setStats((s) => ({ ...s, weeklyDelta: 0 }))
-        }
-      }
-    })()
-
-    return () => {
-      cancelled = true
-    }
   }, [apiFetch])
-
-  const weeklyDelta = stats.weeklyDelta
   const displayName = String(user?.name ?? user?.email ?? "Editor")
 
   const createQuickDraft = async () => {
@@ -358,9 +302,8 @@ export default function DashboardPage() {
             icon: FileText,
             color: "text-primary",
             bg: "bg-primary/10",
-            delta: `${weeklyDelta >= 0 ? "+" : ""}${weeklyDelta} this week`,
-            up: weeklyDelta >= 0,
-            neutral: weeklyDelta === 0,
+            delta: "",
+            up: true,
           },
           {
             label: "Published",
@@ -430,7 +373,7 @@ export default function DashboardPage() {
                 </div>
                 <p className="text-2xl font-extrabold tracking-tight">{card.value}</p>
                 {card.delta ? (
-                  <p className={`text-xs mt-1 flex items-center gap-0.5 font-medium ${card.neutral ? "text-muted-foreground" : card.up ? "text-success" : "text-destructive"}`}>
+                  <p className={`text-xs mt-1 flex items-center gap-0.5 font-medium ${card.up ? "text-success" : "text-destructive"}`}>
                     {DeltaIcon ? <DeltaIcon className="w-3 h-3" /> : card.up ? <ArrowUpRight className="w-3 h-3" /> : <ArrowDownRight className="w-3 h-3" />}
                     {card.delta}
                   </p>


### PR DESCRIPTION
## What

Removes the `-30 this week` delta from the dashboard stat strip.


## Why

The line rendered under **Total Articles**, but was computed entirely from `status=published` articles — so it was on the wrong card, and `-30` next to a 10,057 total read as the corpus shrinking. What it actually meant was "30 fewer articles published in the last 7 days than in the 7 days before that."

Beyond the labeling, the metric measured the wrong thing for this CMS. Article `published_date` values come from the WordPress ETL reseed, so the figure mostly tracked *when we last reseeded* rather than staff output. A metric that reports its own plumbing is worse than no metric, and nothing on the dashboard routed off it the way Drafts → "need review" does.

It was also the most expensive thing on the page: every dashboard load fired a serial paged walk of `/v1/articles`, 100 rows at a time, parsed client-side, to produce one integer. Everything else in the strip is a single count. The loop broke on the first page containing a >14-day-old article, so it silently depended on `sort_by=published_date&sort_direction=desc` behaving exactly as assumed, and future-dated posts landed in the "this week" bucket because the bound was only `t >= oneWeekAgo`.

## Changes

- Deleted the paged fetch loop; `weeklyDelta` is gone from `ApiStats`.
- Published card returns to a bare count; Total Articles shows just the total.
- Dropped the now-dead `card.neutral` styling branch — the two remaining deltas (Drafts, API Status) are never neutral.
- Dropped the effect's `cancelled` flag, whose only consumer was that loop.

Net −57 lines, and a pile of requests per dashboard load.

## Notes

- If we ever want publishing cadence, it belongs as a sparkline backed by a server-side `GROUP BY week` query, not a ±N on a stat tile.
- Pre-existing and untouched: the remaining `.then` handlers in that effect set state without an unmount guard. Removing `cancelled` doesn't change that — none of them ever checked it. Happy to tighten separately if wanted.

## Testing

`npx tsc --noEmit` and `npx eslint src/pages/DashboardPage.tsx` both exit 0. Change is display-only; no API or server code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
