### PR TITLE
feat(media): curate the public photo gallery

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -231,6 +231,31 @@ Progress is reported per entry *walked* rather than per file indexed, because th
 corpus is mostly derivatives that are skipped without a stat — counting only
 indexed files would look frozen for long stretches.
 
+### The public photo gallery
+
+`/v1/gallery`, which the public site's `/photo` page reads, serves only images an
+editor has marked (Media -> open an image -> "Show on the photo gallery", or the
+"Photo gallery" filter to review the current set). The library itself is every
+file on the mount — house ads, comic strips, crossword scans — so an unfiltered
+gallery is a dump of the upload directory rather than the photo desk's work.
+
+Reindexing never sets the flag. WordPress kept the same selection as the
+`include_in_gallery` attachment meta, so seed it once per cutover from the legacy
+database:
+
+```bash
+python ./scripts/backfill_gallery_flags.py \
+    --wp-dsn  'wordpress@tcp(10.248.42.122)/wordpress' \
+    --cms-dsn 'triangle_user@tcp(10.248.40.154)/triangle' --dry-run
+```
+
+Passwords come from `WP_DB_PASSWORD` / `CMS_DB_PASSWORD` or a prompt. Drop
+`--dry-run` to apply. By default the CMS ends up matching WordPress exactly,
+which also *clears* marks made in the CMS since the last run; once editors are
+curating in the CMS, use `--additive` so it only ever adds. Run it after the
+media reindex — it matches on file path, and images the library has not seen yet
+are reported and skipped.
+
 ### Disk
 
 Blue/green keeps two frontend and two backend images resident, plus whatever

--- a/frontend/src/pages/mediaView.tsx
+++ b/frontend/src/pages/mediaView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Copy, Check, ImageOff, Search, Trash2, Upload, X } from "lucide-react"
+import { Copy, Check, ImageOff, Images, Search, Trash2, Upload, X } from "lucide-react"
 import { useApiFetch } from "../hooks/useApiFetch"
 import { useCurrentUserRole } from "../hooks/useCurrentUserRole"
 
@@ -14,6 +14,7 @@ type MediaItem = {
   height?: number
   alt_text?: string
   caption?: string
+  in_gallery?: boolean
   created_at?: string
 }
 
@@ -64,6 +65,7 @@ function MediaView() {
 
   const [searchInput, setSearchInput] = useState("")
   const [search, setSearch] = useState("")
+  const [galleryOnly, setGalleryOnly] = useState(false)
   const [selected, setSelected] = useState<MediaItem | null>(null)
   const [uploadStatus, setUploadStatus] = useState<string | null>(null)
 
@@ -81,12 +83,13 @@ function MediaView() {
         offset: String(offset),
       })
       if (search) params.set("search", search)
+      if (galleryOnly) params.set("in_gallery", "true")
 
       const response = await apiFetch(`/v1/media?${params.toString()}`, { signal })
       if (!response.ok) throw new Error(await errorMessage(response, `Request failed (${response.status})`))
       return (await response.json()) as MediaResponse
     },
-    [apiFetch, search],
+    [apiFetch, search, galleryOnly],
   )
 
   useEffect(() => {
@@ -191,7 +194,7 @@ function MediaView() {
     }
   }
 
-  const handleSaveDetails = async (item: MediaItem, altText: string, caption: string) => {
+  const handleSaveDetails = async (item: MediaItem, altText: string, caption: string, inGallery: boolean) => {
     setError(null)
     setNotice(null)
 
@@ -199,15 +202,23 @@ function MediaView() {
       const response = await apiFetch(`/v1/media/${String(item.id)}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ alt_text: altText, caption }),
+        body: JSON.stringify({ alt_text: altText, caption, in_gallery: inGallery }),
       })
       if (!response.ok) {
         setError(await errorMessage(response, `Save failed (${response.status})`))
         return
       }
       const updated = (await response.json()) as MediaItem
-      setMediaItems((current) => current.map((candidate) => (candidate.id === updated.id ? updated : candidate)))
-      setSelected(updated)
+      // Taking an image out of the gallery while filtered to it drops the tile,
+      // rather than leaving a row on screen that no longer matches the filter.
+      const droppedByFilter = galleryOnly && !updated.in_gallery
+      setMediaItems((current) =>
+        droppedByFilter
+          ? current.filter((candidate) => candidate.id !== updated.id)
+          : current.map((candidate) => (candidate.id === updated.id ? updated : candidate)),
+      )
+      if (droppedByFilter) setTotalCount((current) => Math.max(0, current - 1))
+      setSelected(droppedByFilter ? null : updated)
       setNotice("Details saved.")
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to save details.")
@@ -222,7 +233,8 @@ function MediaView() {
           <h1 className="text-2xl font-bold text-foreground">Media</h1>
           {!isLoading && !error && (
             <p className="text-sm text-muted-foreground">
-              {totalCount} item{totalCount === 1 ? "" : "s"}
+              {totalCount} {galleryOnly ? "gallery image" : "item"}
+              {totalCount === 1 ? "" : "s"}
               {search ? ` matching "${search}"` : ""}
             </p>
           )}
@@ -251,17 +263,33 @@ function MediaView() {
         )}
       </div>
 
-      {/* Search */}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-        <input
-          aria-label="Search media"
-          className="w-full pl-9 pr-4 py-2 rounded-lg border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition"
-          onChange={(e) => setSearchInput(e.target.value)}
-          placeholder="Search by file name, alt text, or caption..."
-          type="search"
-          value={searchInput}
-        />
+      {/* Search, and the curated-gallery filter */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[16rem]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+          <input
+            aria-label="Search media"
+            className="w-full pl-9 pr-4 py-2 rounded-lg border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition"
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search by file name, alt text, or caption..."
+            type="search"
+            value={searchInput}
+          />
+        </div>
+        <button
+          aria-pressed={galleryOnly}
+          className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
+            galleryOnly
+              ? "border-primary bg-primary/10 text-primary"
+              : "border-border text-muted-foreground hover:bg-muted"
+          }`}
+          onClick={() => setGalleryOnly((current) => !current)}
+          title="Show only the images published on the public photo gallery"
+          type="button"
+        >
+          <Images className="w-4 h-4" aria-hidden="true" />
+          Photo gallery
+        </button>
       </div>
 
       {notice && (
@@ -287,8 +315,14 @@ function MediaView() {
       ) : mediaItems.length === 0 ? (
         <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
           <ImageOff className="w-10 h-10" />
-          <p className="text-sm">{search ? `No results for "${search}"` : "No media items yet."}</p>
-          {!search && isAdmin && (
+          <p className="text-sm">
+            {search
+              ? `No results for "${search}"`
+              : galleryOnly
+                ? "Nothing is on the public photo gallery yet. Open an image and tick “Show on the photo gallery”."
+                : "No media items yet."}
+          </p>
+          {!search && !galleryOnly && isAdmin && (
             <p className="text-xs">
               Upload a file, or run Reindex Media in Settings to pull in already-migrated images.
             </p>
@@ -316,6 +350,15 @@ function MediaView() {
                     loading="lazy"
                   />
                   <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors" />
+                  {item.in_gallery && (
+                    <span
+                      className="absolute bottom-1.5 left-1.5 inline-flex items-center gap-1 rounded-md bg-black/60 px-1.5 py-0.5 text-[10px] font-medium text-white"
+                      title="On the public photo gallery"
+                    >
+                      <Images className="w-3 h-3" aria-hidden="true" />
+                      Gallery
+                    </span>
+                  )}
                 </button>
                 {isAdmin && (
                   <button
@@ -375,12 +418,13 @@ type MediaDetailPanelProps = {
   item: MediaItem
   canEdit: boolean
   onClose: () => void
-  onSave: (item: MediaItem, altText: string, caption: string) => Promise<void>
+  onSave: (item: MediaItem, altText: string, caption: string, inGallery: boolean) => Promise<void>
 }
 
 function MediaDetailPanel({ item, canEdit, onClose, onSave }: MediaDetailPanelProps) {
   const [altText, setAltText] = useState(item.alt_text ?? "")
   const [caption, setCaption] = useState(item.caption ?? "")
+  const [inGallery, setInGallery] = useState(item.in_gallery ?? false)
   const [isSaving, setIsSaving] = useState(false)
   const [copied, setCopied] = useState(false)
 
@@ -404,7 +448,7 @@ function MediaDetailPanel({ item, canEdit, onClose, onSave }: MediaDetailPanelPr
 
   const save = async () => {
     setIsSaving(true)
-    await onSave(item, altText, caption)
+    await onSave(item, altText, caption, inGallery)
     setIsSaving(false)
   }
 
@@ -475,6 +519,24 @@ function MediaDetailPanel({ item, canEdit, onClose, onSave }: MediaDetailPanelPr
             rows={3}
             value={caption}
           />
+        </label>
+
+        {/* The library is every file on the media server, house ads and comics
+            included, so the public gallery is opt-in per image. */}
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            checked={inGallery}
+            className="mt-0.5 accent-primary disabled:opacity-60"
+            disabled={!canEdit}
+            onChange={(e) => setInGallery(e.target.checked)}
+            type="checkbox"
+          />
+          <span className="flex flex-col">
+            <span className="text-foreground">Show on the photo gallery</span>
+            <span className="text-xs text-muted-foreground">
+              Readers see this on thetriangle.org/photo once you save.
+            </span>
+          </span>
         </label>
 
         {canEdit && (

--- a/frontend/src/pages/mediaView.tsx
+++ b/frontend/src/pages/mediaView.tsx
@@ -18,6 +18,14 @@ type MediaItem = {
   created_at?: string
 }
 
+// Only the fields the current user is allowed to change are sent, so an editor
+// saving a gallery choice cannot rewrite alt text they were never shown.
+type MediaPatch = {
+  alt_text?: string
+  caption?: string
+  in_gallery?: boolean
+}
+
 type MediaResponse = {
   media?: MediaItem[]
   pagination?: {
@@ -194,7 +202,7 @@ function MediaView() {
     }
   }
 
-  const handleSaveDetails = async (item: MediaItem, altText: string, caption: string, inGallery: boolean) => {
+  const handleSaveDetails = async (item: MediaItem, patch: MediaPatch) => {
     setError(null)
     setNotice(null)
 
@@ -202,7 +210,7 @@ function MediaView() {
       const response = await apiFetch(`/v1/media/${String(item.id)}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ alt_text: altText, caption, in_gallery: inGallery }),
+        body: JSON.stringify(patch),
       })
       if (!response.ok) {
         setError(await errorMessage(response, `Save failed (${response.status})`))
@@ -418,7 +426,7 @@ type MediaDetailPanelProps = {
   item: MediaItem
   canEdit: boolean
   onClose: () => void
-  onSave: (item: MediaItem, altText: string, caption: string, inGallery: boolean) => Promise<void>
+  onSave: (item: MediaItem, patch: MediaPatch) => Promise<void>
 }
 
 function MediaDetailPanel({ item, canEdit, onClose, onSave }: MediaDetailPanelProps) {
@@ -448,7 +456,7 @@ function MediaDetailPanel({ item, canEdit, onClose, onSave }: MediaDetailPanelPr
 
   const save = async () => {
     setIsSaving(true)
-    await onSave(item, altText, caption, inGallery)
+    await onSave(item, canEdit ? { alt_text: altText, caption, in_gallery: inGallery } : { in_gallery: inGallery })
     setIsSaving(false)
   }
 
@@ -522,12 +530,13 @@ function MediaDetailPanel({ item, canEdit, onClose, onSave }: MediaDetailPanelPr
         </label>
 
         {/* The library is every file on the media server, house ads and comics
-            included, so the public gallery is opt-in per image. */}
+            included, so the public gallery is opt-in per image. Curating it is
+            photo-desk work rather than administration, so it is open to
+            editors even where the metadata fields above are not. */}
         <label className="flex items-start gap-2 text-sm">
           <input
             checked={inGallery}
-            className="mt-0.5 accent-primary disabled:opacity-60"
-            disabled={!canEdit}
+            className="mt-0.5 accent-primary"
             onChange={(e) => setInGallery(e.target.checked)}
             type="checkbox"
           />
@@ -539,16 +548,14 @@ function MediaDetailPanel({ item, canEdit, onClose, onSave }: MediaDetailPanelPr
           </span>
         </label>
 
-        {canEdit && (
-          <button
-            className="self-start px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors"
-            disabled={isSaving}
-            onClick={() => void save()}
-            type="button"
-          >
-            {isSaving ? "Saving..." : "Save details"}
-          </button>
-        )}
+        <button
+          className="self-start px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          disabled={isSaving}
+          onClick={() => void save()}
+          type="button"
+        >
+          {isSaving ? "Saving..." : canEdit ? "Save details" : "Save gallery choice"}
+        </button>
       </aside>
     </div>
   )

--- a/scripts/backfill_gallery_flags.py
+++ b/scripts/backfill_gallery_flags.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Copy WordPress's hand-picked photo-gallery selection into the CMS.
+
+The public /photo page is curated, not "every image we have". In WordPress that
+selection lives on each attachment as the post meta `include_in_gallery`, which
+the legacy `triangle/v1/gallery` endpoint filtered on; in the CMS it is the
+`media.in_gallery` column. Nothing in the ETL carries it: CMS media rows come
+from walking the CephFS uploads tree, which knows only what is on disk. Without
+this backfill the gallery starts empty after a cutover.
+
+  python ./scripts/backfill_gallery_flags.py \
+      --wp-dsn wordpress@tcp(10.248.42.122)/wordpress \
+      --cms-dsn triangle_user@tcp(10.248.40.154)/triangle --dry-run
+
+Passwords come from WP_DB_PASSWORD and CMS_DB_PASSWORD (or a prompt), never from
+argv. Re-runnable: it sets the flag on what WordPress has marked and, unless
+--additive, clears it on everything else, so the CMS ends up matching WordPress
+exactly. Marks made in the CMS since the last run are therefore lost unless you
+pass --additive -- which is the right choice once editors have started curating
+in the CMS and WordPress is only the historical seed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# WordPress stores `_wp_attached_file` relative to the uploads directory
+# ("2026/01/photo.jpg"); the CMS stores paths relative to MEDIA_ROOT, which
+# keeps WordPress's own layout underneath this prefix.
+UPLOADS_PREFIX = "wp-content/uploads/"
+
+GALLERY_META_KEY = "include_in_gallery"
+
+# WordPress writes booleans as "1"/"0", but a meta row touched by other plugins
+# can hold "true" or "yes". Anything else (including "0" and the empty string)
+# means not in the gallery.
+TRUTHY_META = ("1", "true", "yes", "on")
+
+DSN_RE = re.compile(
+    r"^(?P<user>[^:@/]+)(?::(?P<password>[^@]*))?@tcp\((?P<host>[^:)]+)(?::(?P<port>\d+))?\)/(?P<database>[^?]+)"
+)
+
+
+class Fail(Exception):
+    """A preflight or verification failure with a human-readable reason."""
+
+
+def info(msg: str) -> None:
+    print(f"  {msg}")
+
+
+def step(msg: str) -> None:
+    print(f"\n==> {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"  WARNING: {msg}", file=sys.stderr)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Copy WordPress's include_in_gallery selection into the CMS media library."
+    )
+    parser.add_argument(
+        "--wp-dsn",
+        required=True,
+        help="legacy WordPress database: user:password@tcp(host:port)/database (password optional)",
+    )
+    parser.add_argument(
+        "--cms-dsn",
+        required=True,
+        help="CMS database: user:password@tcp(host:port)/database (password optional)",
+    )
+    parser.add_argument(
+        "--wp-prefix",
+        default="wp_",
+        help="WordPress table prefix (default: wp_)",
+    )
+    parser.add_argument(
+        "--additive",
+        action="store_true",
+        help="only set flags; leave images already marked in the CMS alone",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would change without writing anything",
+    )
+    return parser.parse_args()
+
+
+def resolve_dsn(dsn: str, label: str, password_env: str) -> dict:
+    match = DSN_RE.match(dsn.strip())
+    if not match:
+        raise Fail(f"--{label}-dsn must look like user:password@tcp(host:port)/database")
+
+    parts = match.groupdict()
+    target = {
+        "user": parts["user"],
+        "host": parts["host"],
+        "port": int(parts["port"] or 3306),
+        "database": parts["database"],
+        "password": parts["password"] or os.getenv(password_env) or "",
+    }
+    if not target["password"]:
+        if not sys.stdin.isatty():
+            raise Fail(f"no password for {label}: set {password_env}, or run interactively.")
+        target["password"] = getpass.getpass(f"Password for {target['user']}@{target['host']} ({label}): ")
+    return target
+
+
+def mysql_client() -> str:
+    for candidate in ("mariadb", "mysql"):
+        if shutil.which(candidate):
+            return candidate
+    raise Fail("neither `mariadb` nor `mysql` is on PATH; install a MariaDB client.")
+
+
+class Client:
+    """Runs SQL against one target without ever putting the password in argv."""
+
+    def __init__(self, target: dict):
+        self.target = target
+        self.binary = mysql_client()
+        # An option file keeps the password out of `ps` and shell history. 0600,
+        # in a private temp dir, removed on exit.
+        self._dir = tempfile.mkdtemp(prefix="triangle-gallery-")
+        self.defaults = Path(self._dir) / "my.cnf"
+        self.defaults.write_text(
+            "[client]\n"
+            f"host={target['host']}\n"
+            f"port={target['port']}\n"
+            f"user={target['user']}\n"
+            f"password={target['password']}\n",
+            encoding="utf-8",
+        )
+        self.defaults.chmod(0o600)
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    def _run(self, sql: str, *, tab_separated: bool) -> subprocess.CompletedProcess:
+        cmd = [self.binary, f"--defaults-file={self.defaults}", self.target["database"]]
+        if tab_separated:
+            cmd += ["-N", "-B"]
+        cmd += ["-e", sql]
+        return subprocess.run(cmd, capture_output=True, text=True)
+
+    def rows(self, sql: str) -> list[list[str]]:
+        done = self._run(sql, tab_separated=True)
+        if done.returncode != 0:
+            raise Fail(f"query failed on {self.target['database']}: {done.stderr.strip()}")
+        return [line.split("\t") for line in done.stdout.splitlines() if line]
+
+    def scalar(self, sql: str) -> str:
+        rows = self.rows(sql)
+        return rows[0][0] if rows and rows[0] else ""
+
+    def execute(self, sql: str) -> None:
+        done = self._run(sql, tab_separated=False)
+        if done.returncode != 0:
+            raise Fail(f"statement failed on {self.target['database']}: {done.stderr.strip()}")
+
+
+def quote(value: str) -> str:
+    """Single-quoted SQL literal. Paths are file names, but they come from a
+    database, so they get escaped rather than trusted."""
+    return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'"
+
+
+def selected_paths(wp: Client, prefix: str) -> list[str]:
+    """Uploads-relative file paths WordPress has marked for the gallery."""
+    truthy = ", ".join(quote(value) for value in TRUTHY_META)
+    rows = wp.rows(
+        "SELECT DISTINCT attached.meta_value "
+        f"FROM {prefix}postmeta AS flag "
+        f"JOIN {prefix}postmeta AS attached "
+        "  ON attached.post_id = flag.post_id AND attached.meta_key = '_wp_attached_file' "
+        f"JOIN {prefix}posts AS post "
+        "  ON post.ID = flag.post_id AND post.post_type = 'attachment' "
+        f"WHERE flag.meta_key = {quote(GALLERY_META_KEY)} "
+        f"  AND LOWER(flag.meta_value) IN ({truthy}) "
+        "ORDER BY attached.meta_value"
+    )
+    return [row[0].strip() for row in rows if row and row[0].strip()]
+
+
+def main() -> int:
+    args = parse_args()
+    wp_client: Client | None = None
+    cms_client: Client | None = None
+
+    try:
+        wp_target = resolve_dsn(args.wp_dsn, "wp", "WP_DB_PASSWORD")
+        cms_target = resolve_dsn(args.cms_dsn, "cms", "CMS_DB_PASSWORD")
+        wp_client = Client(wp_target)
+        cms_client = Client(cms_target)
+
+        step("Reading the WordPress selection")
+        paths = selected_paths(wp_client, args.wp_prefix)
+        if not paths:
+            raise Fail(
+                f"no attachments carry {GALLERY_META_KEY}; check --wp-prefix "
+                f"(currently {args.wp_prefix!r}) and that this is the live WordPress database."
+            )
+        info(f"{len(paths)} attachment(s) marked for the gallery in WordPress")
+
+        # The CMS knows nothing about WordPress attachment ids, so the file path
+        # is the join key. An unmatched path means the file never made it onto
+        # the media mount, or the library has not been reindexed since it did.
+        cms_paths = [UPLOADS_PREFIX + path.lstrip("/") for path in paths]
+        literals = ", ".join(quote(path) for path in cms_paths)
+
+        step("Matching against the CMS media library")
+        matched = {row[0] for row in cms_client.rows(f"SELECT `path` FROM `media` WHERE `path` IN ({literals})")}
+        missing = [path for path in cms_paths if path not in matched]
+        info(f"{len(matched)} of {len(cms_paths)} found in the library")
+        if missing:
+            warn(f"{len(missing)} marked image(s) are not in the library and will be skipped:")
+            for path in missing[:10]:
+                info(f"  {path}")
+            if len(missing) > 10:
+                info(f"  ... and {len(missing) - 10} more")
+            info("Run Reindex Media in Settings if these files are on the media mount.")
+
+        already = int(cms_client.scalar("SELECT COUNT(*) FROM `media` WHERE `in_gallery` = 1") or 0)
+        to_clear = 0 if args.additive else int(
+            cms_client.scalar(
+                f"SELECT COUNT(*) FROM `media` WHERE `in_gallery` = 1 AND `path` NOT IN ({literals})"
+            )
+            or 0
+        )
+
+        step("Applying")
+        info(f"{already} image(s) currently in the CMS gallery")
+        info(f"{len(matched)} to be marked; {to_clear} to be unmarked")
+        if args.dry_run:
+            info("--dry-run: nothing written.")
+            return 0
+
+        if not args.additive:
+            cms_client.execute(f"UPDATE `media` SET `in_gallery` = 0 WHERE `path` NOT IN ({literals})")
+        cms_client.execute(f"UPDATE `media` SET `in_gallery` = 1 WHERE `path` IN ({literals})")
+
+        total = int(cms_client.scalar("SELECT COUNT(*) FROM `media` WHERE `in_gallery` = 1") or 0)
+        info(f"{total} image(s) now on the public photo gallery")
+        return 0
+
+    except Fail as err:
+        print(f"\nERROR: {err}", file=sys.stderr)
+        return 1
+    finally:
+        if wp_client:
+            wp_client.cleanup()
+        if cms_client:
+            cms_client.cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -4396,6 +4396,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/models.AuthorOverview"
                     }
                 },
+                "breaking_news": {
+                    "type": "boolean"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4472,6 +4475,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/models.AuthorSummary"
                     }
                 },
+                "breaking_news": {
+                    "type": "boolean"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4528,6 +4534,9 @@ const docTemplate = `{
                         "type": "integer"
                     }
                 },
+                "breaking_news": {
+                    "type": "boolean"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4578,6 +4587,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/models.AuthorSummary"
                     }
                 },
+                "breaking_news": {
+                    "type": "boolean"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4585,6 +4597,10 @@ const docTemplate = `{
                     }
                 },
                 "comment_status": {
+                    "type": "string"
+                },
+                "creation_date": {
+                    "description": "Drafts have no published_date; the CMS listing falls back to this so an\nunpublished row still shows a date.",
                     "type": "string"
                 },
                 "excerpt": {
@@ -4621,6 +4637,9 @@ const docTemplate = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "breaking_news": {
+                    "type": "boolean"
                 },
                 "categories": {
                     "type": "array",
@@ -5304,6 +5323,10 @@ const docTemplate = `{
                 "id": {
                     "type": "integer"
                 },
+                "in_gallery": {
+                    "description": "InGallery is the editor's \"show this on the public photo gallery\" flag.\nIt is off by default: the library is every file on the media mount, house\nads and comics included, and the gallery is a curated selection of it.",
+                    "type": "boolean"
+                },
                 "mime_type": {
                     "type": "string"
                 },
@@ -5423,6 +5446,9 @@ const docTemplate = `{
                 },
                 "file_name": {
                     "type": "string"
+                },
+                "in_gallery": {
+                    "type": "boolean"
                 }
             }
         },

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -4393,6 +4393,9 @@
                         "$ref": "#/definitions/models.AuthorOverview"
                     }
                 },
+                "breaking_news": {
+                    "type": "boolean"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4469,6 +4472,9 @@
                         "$ref": "#/definitions/models.AuthorSummary"
                     }
                 },
+                "breaking_news": {
+                    "type": "boolean"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4525,6 +4531,9 @@
                         "type": "integer"
                     }
                 },
+                "breaking_news": {
+                    "type": "boolean"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4575,6 +4584,9 @@
                         "$ref": "#/definitions/models.AuthorSummary"
                     }
                 },
+                "breaking_news": {
+                    "type": "boolean"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4582,6 +4594,10 @@
                     }
                 },
                 "comment_status": {
+                    "type": "string"
+                },
+                "creation_date": {
+                    "description": "Drafts have no published_date; the CMS listing falls back to this so an\nunpublished row still shows a date.",
                     "type": "string"
                 },
                 "excerpt": {
@@ -4618,6 +4634,9 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "breaking_news": {
+                    "type": "boolean"
                 },
                 "categories": {
                     "type": "array",
@@ -5301,6 +5320,10 @@
                 "id": {
                     "type": "integer"
                 },
+                "in_gallery": {
+                    "description": "InGallery is the editor's \"show this on the public photo gallery\" flag.\nIt is off by default: the library is every file on the media mount, house\nads and comics included, and the gallery is a curated selection of it.",
+                    "type": "boolean"
+                },
                 "mime_type": {
                     "type": "string"
                 },
@@ -5420,6 +5443,9 @@
                 },
                 "file_name": {
                     "type": "string"
+                },
+                "in_gallery": {
+                    "type": "boolean"
                 }
             }
         },

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -95,6 +95,8 @@ definitions:
         items:
           $ref: '#/definitions/models.AuthorOverview'
         type: array
+      breaking_news:
+        type: boolean
       categories:
         items:
           type: string
@@ -145,6 +147,8 @@ definitions:
         items:
           $ref: '#/definitions/models.AuthorSummary'
         type: array
+      breaking_news:
+        type: boolean
       categories:
         items:
           $ref: '#/definitions/models.CategorySummary'
@@ -182,6 +186,8 @@ definitions:
         items:
           type: integer
         type: array
+      breaking_news:
+        type: boolean
       categories:
         items:
           type: string
@@ -215,11 +221,18 @@ definitions:
         items:
           $ref: '#/definitions/models.AuthorSummary'
         type: array
+      breaking_news:
+        type: boolean
       categories:
         items:
           $ref: '#/definitions/models.CategorySummary'
         type: array
       comment_status:
+        type: string
+      creation_date:
+        description: |-
+          Drafts have no published_date; the CMS listing falls back to this so an
+          unpublished row still shows a date.
         type: string
       excerpt:
         type: string
@@ -244,6 +257,8 @@ definitions:
         items:
           type: integer
         type: array
+      breaking_news:
+        type: boolean
       categories:
         items:
           type: string
@@ -687,6 +702,12 @@ definitions:
         type: integer
       id:
         type: integer
+      in_gallery:
+        description: |-
+          InGallery is the editor's "show this on the public photo gallery" flag.
+          It is off by default: the library is every file on the media mount, house
+          ads and comics included, and the gallery is a curated selection of it.
+        type: boolean
       mime_type:
         type: string
       path:
@@ -765,6 +786,8 @@ definitions:
         type: string
       file_name:
         type: string
+      in_gallery:
+        type: boolean
     type: object
   models.MediaResponse:
     properties:

--- a/server/internal/database/media.go
+++ b/server/internal/database/media.go
@@ -28,7 +28,7 @@ var MediaSortByColumn = map[string]string{
 
 var MediaColumns = []string{
 	"id", "path", "file_name", "mime_type", "size_bytes",
-	"width", "height", "alt_text", "caption", "created_at", "updated_at",
+	"width", "height", "alt_text", "caption", "in_gallery", "created_at", "updated_at",
 }
 
 // mediaMimeByExt is the extension -> MIME mapping used when indexing existing
@@ -63,11 +63,13 @@ func EnsureMediaTable(ctx context.Context, conn *sql.DB) error {
 			height INT NULL,
 			alt_text LONGTEXT,
 			caption LONGTEXT,
+			in_gallery TINYINT(1) NOT NULL DEFAULT 0,
 			created_at DATETIME,
 			updated_at DATETIME,
 			UNIQUE KEY uniq_media_path (path),
 			INDEX idx_media_created_at (created_at),
-			INDEX idx_media_file_name (file_name)
+			INDEX idx_media_file_name (file_name),
+			INDEX idx_media_in_gallery (in_gallery, created_at)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
 	`); err != nil {
 		return err
@@ -83,8 +85,10 @@ func EnsureMediaTable(ctx context.Context, conn *sql.DB) error {
 		ADD COLUMN IF NOT EXISTS height INT NULL,
 		ADD COLUMN IF NOT EXISTS alt_text LONGTEXT,
 		ADD COLUMN IF NOT EXISTS caption LONGTEXT,
+		ADD COLUMN IF NOT EXISTS in_gallery TINYINT(1) NOT NULL DEFAULT 0,
 		ADD COLUMN IF NOT EXISTS created_at DATETIME,
-		ADD COLUMN IF NOT EXISTS updated_at DATETIME
+		ADD COLUMN IF NOT EXISTS updated_at DATETIME,
+		ADD INDEX IF NOT EXISTS idx_media_in_gallery (in_gallery, created_at)
 	`)
 	return err
 }
@@ -111,6 +115,7 @@ func ScanMedia(rows *sql.Rows) (models.Media, error) {
 		&height,
 		&altText,
 		&caption,
+		&item.InGallery,
 		&createdAt,
 		&updatedAt,
 	)
@@ -166,6 +171,11 @@ func mediaConditions(params models.MediaListParams) ([]string, []any) {
 			conditions = append(conditions, "`mime_type` = ?")
 			args = append(args, mimeType)
 		}
+	}
+
+	if params.InGallery != nil {
+		conditions = append(conditions, "`in_gallery` = ?")
+		args = append(args, *params.InGallery)
 	}
 
 	return conditions, args
@@ -270,8 +280,8 @@ func InsertMedia(ctx context.Context, conn *sql.DB, relPath, mimeType string, si
 // present on the patch are written; a patch with none set is a no-op error so
 // the handler can answer 400 rather than silently succeeding.
 func UpdateMediaMeta(ctx context.Context, conn *sql.DB, id int64, patch models.MediaPatch) (models.Media, error) {
-	setClauses := make([]string, 0, 4)
-	args := make([]any, 0, 5)
+	setClauses := make([]string, 0, 5)
+	args := make([]any, 0, 6)
 
 	if patch.FileName != nil {
 		setClauses = append(setClauses, "`file_name` = ?")
@@ -284,6 +294,10 @@ func UpdateMediaMeta(ctx context.Context, conn *sql.DB, id int64, patch models.M
 	if patch.Caption != nil {
 		setClauses = append(setClauses, "`caption` = ?")
 		args = append(args, *patch.Caption)
+	}
+	if patch.InGallery != nil {
+		setClauses = append(setClauses, "`in_gallery` = ?")
+		args = append(args, *patch.InGallery)
 	}
 	if len(setClauses) == 0 {
 		return models.Media{}, ErrNoMediaFields

--- a/server/internal/handlers/media.go
+++ b/server/internal/handlers/media.go
@@ -697,7 +697,7 @@ func withMediaURL(item models.Media) models.Media {
 func mediaListParams(r *http.Request) models.MediaListParams {
 	q := r.URL.Query()
 	_, limit, offset := listParams(r, 50)
-	return models.MediaListParams{
+	params := models.MediaListParams{
 		Limit:         limit,
 		Offset:        offset,
 		Query:         strings.TrimSpace(q.Get("search")),
@@ -705,6 +705,13 @@ func mediaListParams(r *http.Request) models.MediaListParams {
 		SortBy:        models.MediaSortBy(q.Get("sort_by")),
 		SortDirection: models.SortDirection(q.Get("sort_direction")),
 	}
+	// Absent means "the whole library"; "?in_gallery=0" is a real filter for the
+	// everything-but-the-gallery view, so presence is what counts here.
+	if _, provided := q["in_gallery"]; provided {
+		inGallery := boolParam(r, "in_gallery")
+		params.InGallery = &inGallery
+	}
+	return params
 }
 
 // boolParam reads a flag-style query parameter, where a bare "?keep_file" counts
@@ -814,6 +821,11 @@ func GetMediaGallery(conn *sql.DB) http.Handler {
 // not accept the free-text search parameter, which would otherwise turn the
 // endpoint into a lookup tool over editors' file names and captions.
 //
+// It is also narrowed to images an editor has marked for the gallery. The
+// library is every file on the media mount, house ads, comic strips and
+// crossword scans included; serving all of it made /photo a dump of the upload
+// directory rather than the photo desk's work.
+//
 // @Summary List gallery images for the public site
 // @Tags media
 // @Produce json
@@ -825,11 +837,13 @@ func GetMediaGallery(conn *sql.DB) http.Handler {
 func GetPublicGallery(conn *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, limit, offset := listParams(r, 50)
+		curated := true
 		items, _, err := db.ListMedia(r.Context(), conn, models.MediaListParams{
-			Limit:    limit,
-			Offset:   offset,
-			MimeType: "image/",
-			SortBy:   models.MediaSortBy(r.URL.Query().Get("sort_by")),
+			Limit:     limit,
+			Offset:    offset,
+			MimeType:  "image/",
+			InGallery: &curated,
+			SortBy:    models.MediaSortBy(r.URL.Query().Get("sort_by")),
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())

--- a/server/internal/handlers/media_integration_test.go
+++ b/server/internal/handlers/media_integration_test.go
@@ -181,6 +181,90 @@ func TestMediaHTTP_UploadListPatchDelete(t *testing.T) {
 	}
 }
 
+// The public gallery is a curated selection, not the upload directory. Serving
+// everything put house ads, comic strips and crossword scans on /photo.
+func TestMediaHTTP_PublicGalleryOnlyServesCuratedImages(t *testing.T) {
+	conn := mediaHTTPTestDB(t)
+	root := t.TempDir()
+	t.Setenv("MEDIA_ROOT", root)
+	t.Setenv("MEDIA_BASE_URL", "https://media.example.org")
+
+	upload := func(name string) models.MediaUploadResponse {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		PostMedia(conn).ServeHTTP(rec, uploadRequest(t, name, pngBytes(t, 4, 4)))
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("upload %s status = %d, body = %s", name, rec.Code, rec.Body.String())
+		}
+		var created models.MediaUploadResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+			t.Fatalf("decode upload %s: %v", name, err)
+		}
+		return created
+	}
+
+	photo := upload("basketball.png")
+	upload("house-ad.png")
+
+	// Nothing is in the gallery until an editor says so, including brand-new
+	// uploads -- the default has to be off or the /photo page fills itself.
+	emptyRec := httptest.NewRecorder()
+	GetPublicGallery(conn).ServeHTTP(emptyRec, httptest.NewRequest(http.MethodGet, "/v1/gallery", nil))
+	var empty models.MediaGalleryResponse
+	if err := json.Unmarshal(emptyRec.Body.Bytes(), &empty); err != nil {
+		t.Fatalf("decode gallery: %v", err)
+	}
+	if len(empty.Media) != 0 {
+		t.Fatalf("gallery = %+v, want nothing before anything is marked", empty.Media)
+	}
+
+	markRec := httptest.NewRecorder()
+	PatchMediaItem(conn).ServeHTTP(markRec,
+		mediaIDRequest(t, http.MethodPatch, "/v1/media/1", photo.ID, `{"in_gallery":true}`))
+	if markRec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d, body = %s", markRec.Code, markRec.Body.String())
+	}
+	var marked models.Media
+	if err := json.Unmarshal(markRec.Body.Bytes(), &marked); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if !marked.InGallery {
+		t.Fatal("in_gallery did not persist")
+	}
+
+	galleryRec := httptest.NewRecorder()
+	GetPublicGallery(conn).ServeHTTP(galleryRec, httptest.NewRequest(http.MethodGet, "/v1/gallery", nil))
+	var gallery models.MediaGalleryResponse
+	if err := json.Unmarshal(galleryRec.Body.Bytes(), &gallery); err != nil {
+		t.Fatalf("decode gallery: %v", err)
+	}
+	if len(gallery.Media) != 1 || gallery.Media[0].ID != photo.ID {
+		t.Fatalf("gallery = %+v, want only the marked photo", gallery.Media)
+	}
+
+	// The editor-facing listing still sees the whole library, and can narrow to
+	// the curated set on demand.
+	listRec := httptest.NewRecorder()
+	GetMedia(conn).ServeHTTP(listRec, httptest.NewRequest(http.MethodGet, "/v1/media", nil))
+	var listed models.MediaResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if listed.Pagination.TotalCount != 2 {
+		t.Fatalf("library total = %d, want both assets", listed.Pagination.TotalCount)
+	}
+
+	filteredRec := httptest.NewRecorder()
+	GetMedia(conn).ServeHTTP(filteredRec, httptest.NewRequest(http.MethodGet, "/v1/media?in_gallery=true", nil))
+	var filtered models.MediaResponse
+	if err := json.Unmarshal(filteredRec.Body.Bytes(), &filtered); err != nil {
+		t.Fatalf("decode filtered list: %v", err)
+	}
+	if filtered.Pagination.TotalCount != 1 || len(filtered.Media) != 1 || filtered.Media[0].ID != photo.ID {
+		t.Fatalf("in_gallery=true list = %+v, want only the marked photo", filtered)
+	}
+}
+
 func TestMediaHTTP_DeleteKeepFileLeavesTheFile(t *testing.T) {
 	conn := mediaHTTPTestDB(t)
 	root := t.TempDir()

--- a/server/internal/models/types.go
+++ b/server/internal/models/types.go
@@ -191,16 +191,20 @@ type ArticleListParams struct {
 // location on the media filesystem and is the row's stable identity; URL is that
 // path rendered through MEDIA_BASE_URL for display and is not stored.
 type Media struct {
-	ID        int64      `json:"id"`
-	Path      string     `json:"path"`
-	FileName  string     `json:"file_name"`
-	URL       string     `json:"url"`
-	MimeType  string     `json:"mime_type"`
-	SizeBytes int64      `json:"size_bytes"`
-	Width     *int       `json:"width,omitempty"`
-	Height    *int       `json:"height,omitempty"`
-	AltText   string     `json:"alt_text,omitempty"`
-	Caption   string     `json:"caption,omitempty"`
+	ID        int64  `json:"id"`
+	Path      string `json:"path"`
+	FileName  string `json:"file_name"`
+	URL       string `json:"url"`
+	MimeType  string `json:"mime_type"`
+	SizeBytes int64  `json:"size_bytes"`
+	Width     *int   `json:"width,omitempty"`
+	Height    *int   `json:"height,omitempty"`
+	AltText   string `json:"alt_text,omitempty"`
+	Caption   string `json:"caption,omitempty"`
+	// InGallery is the editor's "show this on the public photo gallery" flag.
+	// It is off by default: the library is every file on the media mount, house
+	// ads and comics included, and the gallery is a curated selection of it.
+	InGallery bool       `json:"in_gallery"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
@@ -226,16 +230,20 @@ type MediaInput struct {
 }
 
 type MediaPatch struct {
-	FileName *string `json:"file_name,omitempty"`
-	AltText  *string `json:"alt_text,omitempty"`
-	Caption  *string `json:"caption,omitempty"`
+	FileName  *string `json:"file_name,omitempty"`
+	AltText   *string `json:"alt_text,omitempty"`
+	Caption   *string `json:"caption,omitempty"`
+	InGallery *bool   `json:"in_gallery,omitempty"`
 }
 
 type MediaListParams struct {
-	Limit         int
-	Offset        int
-	Query         string
-	MimeType      string
+	Limit    int
+	Offset   int
+	Query    string
+	MimeType string
+	// InGallery filters on the curation flag when set; nil lists the whole
+	// library, which is what the editor-facing browser wants.
+	InGallery     *bool
 	SortBy        MediaSortBy
 	SortDirection SortDirection
 }


### PR DESCRIPTION
## The bug

dev's `/photo` does not look like production's. It leads with the classifieds house ad, the "join our team" banner, the Tripod podcast ad, a comic strip, a crossword and a sudoku.

`/v1/gallery` served **every** `image/*` row, and the library is every file on the media mount — `IndexMediaRoot` walks the CephFS uploads tree, so anything ever uploaded to WordPress is a gallery candidate.

Production is curated. WordPress stores the selection per attachment as post meta:

```
GET /wp-json/wp/v2/media/66738  → meta: { include_in_gallery: true }   # in the prod gallery
GET /wp-json/wp/v2/media/69707  → meta: { include_in_gallery: false }  # newest upload, not in it
```

`triangle/v1/gallery` filtered on it and returned 25 images, none of them the newest uploads. Nothing carries that flag into the CMS, so there was no filter to apply.

## The change

- **`media.in_gallery`**, `TINYINT(1) NOT NULL DEFAULT 0`, added through the existing `EnsureMediaTable` ALTER block, with an `(in_gallery, created_at)` index. Off by default — reindexing never marks anything, so the gallery cannot fill itself.
- **`GET /v1/gallery`** filters on it. The editor-facing `GET /v1/media` still lists the whole library and now accepts `?in_gallery=true|false`.
- **`PATCH /v1/media/{id}`** accepts `in_gallery`.
- **Media library UI**: a "Show on the photo gallery" checkbox in the detail panel, a "Gallery" badge on marked tiles, and a "Photo gallery" filter toggle to review the current set. Unmarking while filtered drops the tile rather than leaving a row that no longer matches.
- **Editors can curate, not just admins.** Choosing which photos run on `/photo` is photo-desk work; `PATCH /v1/media/{id}` was already open to editors, so this only ungates the field in the UI. Alt text and caption stay admin-only as before, and the PATCH body now carries just the fields the current user was shown, so an editor saving a gallery choice cannot rewrite metadata it never rendered.
- **`scripts/backfill_gallery_flags.py`** copies WordPress's selection into the CMS, joining `wp_postmeta.include_in_gallery` to `_wp_attached_file` and matching `media.path`. Passwords via `WP_DB_PASSWORD` / `CMS_DB_PASSWORD` or a prompt (never argv), `--dry-run`, and `--additive` for once editors curate in the CMS rather than WordPress. Images not yet in the library are reported and skipped.
- `deploy/README.md` documents the flag and the backfill, next to the reindex section.

Scalene needs no change — `/photo` renders whatever `/v1/gallery` returns.

## Cutover note

The backfill is **not** a one-off: run it after each media reindex, before the site goes live, or `/photo` comes up empty. Default behaviour makes the CMS match WordPress exactly and clears marks made in the CMS since the last run; `--additive` only ever adds.

## Testing

- New integration test `TestMediaHTTP_PublicGalleryOnlyServesCuratedImages`: nothing is in the gallery until marked (including fresh uploads), the flag round-trips through PATCH, the public endpoint returns only marked images, and the editor listing still sees the whole library.
- Full `go test ./...` against a real MariaDB (`CMS_TEST_DSN` set) — green.
- Backfill script exercised end-to-end against fixture `wp_posts`/`wp_postmeta` and `media` tables: dry-run, apply, and `--additive`, including the not-in-library warning path. Not yet run against the real WordPress database — give it a `--dry-run` there first; expect ~25 matches.
- `tsc --noEmit`, `eslint`, `npm run build` clean.

Swagger output is regenerated; it also picks up unrelated `breaking_news` drift that had accumulated in the committed docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)