### PR TITLE
fix(taxonomy): align section navigation with the live site

### DIFF
--- a/scripts/generate_wordpress_sql.py
+++ b/scripts/generate_wordpress_sql.py
@@ -13,6 +13,13 @@ from pathlib import Path
 
 # Seed ROWS only. The table definition comes from the canonical schema file --
 # see canonical_schema() and server/internal/database/schema/README.md.
+#
+# Rows 1-35 were hand-written and had drifted from the live site: ids 36+ are the
+# sections and subsections WordPress actually publishes
+# (cms.thetriangle.org/wp-json/triangle/v2/section/<slug>) that this list was
+# missing, which is why nav rows like Puzzles and Satire never appeared on a
+# CMS-backed section page. Slugs stay in the CMS's cleaned-up form
+# ("music", not WordPress's "music-entertainment"); only the set is aligned.
 TAXONOMY_ROWS_SQL = """INSERT INTO site_taxonomy (id, kind, slug, canonical_title, parent_slug, article_count) VALUES
   (1, 'section', 'news', 'News', NULL, 0),
   (2, 'section', 'sports', 'Sports', NULL, 0),
@@ -22,9 +29,9 @@ TAXONOMY_ROWS_SQL = """INSERT INTO site_taxonomy (id, kind, slug, canonical_titl
   (6, 'section', 'comics-puzzles', 'Comics & Puzzles', NULL, 0),
   (7, 'section', 'special-editions', 'Special Editions', NULL, 0),
   (8, 'subsection', 'academic-transformation', 'Academic Transformation', 'news', 0),
-  (9, 'subsection', 'politics', 'Politics', 'news', 0),
+  (9, 'subsection', 'politics', 'Politics', 'opinion', 0),
   (10, 'subsection', 'transit', 'Transit', 'news', 0),
-  (11, 'subsection', 'crime-policy-violations', 'Crime & Policy Violations', 'news', 0),
+  (11, 'subsection', 'public-safety', 'Public Safety', 'news', 0),
   (12, 'subsection', 'mens-basketball', 'Men''s Basketball', 'sports', 0),
   (13, 'subsection', 'womens-basketball', 'Women''s Basketball', 'sports', 0),
   (14, 'subsection', 'big-5', 'Big 5', 'sports', 0),
@@ -48,7 +55,24 @@ TAXONOMY_ROWS_SQL = """INSERT INTO site_taxonomy (id, kind, slug, canonical_titl
   (32, 'subsection', 'sudoku', 'Sudoku', 'comics-puzzles', 0),
   (33, 'subsection', 'welcome-week', 'Welcome Week', 'special-editions', 0),
   (34, 'subsection', 'the-rectangle', 'The Rectangle', 'special-editions', 0),
-  (35, 'subsection', '100-year-anniversary', '100 Year Anniversary', 'special-editions', 0);
+  (35, 'subsection', '100-year-anniversary', '100 Year Anniversary', 'special-editions', 0),
+  (36, 'subsection', 'comics', 'Comics', 'comics-puzzles', 0),
+  (37, 'section', 'graduation', 'Graduation', NULL, 0),
+  (38, 'subsection', 'campus', 'Campus', 'news', 0),
+  (39, 'subsection', 'city', 'City', 'news', 0),
+  (40, 'subsection', 'national', 'National', 'news', 0),
+  (41, 'subsection', 'world', 'World', 'news', 0),
+  (42, 'subsection', 'lifestyle', 'Lifestyle', 'opinion', 0),
+  (43, 'subsection', 'nil', 'NIL', 'sports', 0),
+  (44, 'subsection', 'squash', 'Squash', 'sports', 0),
+  (45, 'subsection', 'performing-arts', 'Performing Arts', 'entertainment', 0),
+  (46, 'subsection', 'the-drawing-board', 'The Drawing Board', 'entertainment', 0),
+  (47, 'subsection', 'puzzles', 'Puzzles', 'comics-puzzles', 0),
+  (48, 'subsection', 'satire', 'Satire', 'comics-puzzles', 0),
+  (49, 'subsection', 'from-the-playbook', 'From the Playbook', 'columns', 0),
+  (50, 'subsection', 'jack-of-all-takes', 'Jack of All Takes', 'columns', 0),
+  (51, 'subsection', 'the-green-angle', 'The Green Angle', 'columns', 0),
+  (52, 'subsection', 'the-overall-score', 'The Overall Score', 'columns', 0);
 """
 
 PLACEHOLDER_EMBEDDINGS_SQL = """DROP TABLE IF EXISTS article_embeddings;

--- a/server/internal/database/footer_settings.go
+++ b/server/internal/database/footer_settings.go
@@ -46,7 +46,7 @@ func defaultFooterColumns() []models.FooterColumn {
 			link("Academic Transformation", "/academic-transformation"),
 			link("Politics", "/politics"),
 			link("Transit", "/transit"),
-			link("Crime & Policy Violations", "/crime-policy-violations"),
+			link("Public Safety", "/public-safety"),
 		}},
 		{Entries: []models.FooterEntry{
 			heading("Sports", "/sports"),

--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -33,7 +33,7 @@ func CategoryMatchPatterns(slug string) []string {
 		return nil
 	}
 
-	patterns := make([]string, 0, 3)
+	patterns := make([]string, 0, 4)
 	add := func(value string) {
 		for _, existing := range patterns {
 			if existing == value {
@@ -45,10 +45,47 @@ func CategoryMatchPatterns(slug string) []string {
 
 	add("%" + normalized + "%")
 	if strings.Contains(normalized, "-") {
-		add("%" + strings.ReplaceAll(normalized, "-", " ") + "%")
+		spaced := strings.ReplaceAll(normalized, "-", " ")
+		add("%" + spaced + "%")
 		add("%" + strings.ReplaceAll(normalized, "-", " & ") + "%")
+		if possessive := possessiveVariant(spaced); possessive != "" {
+			add("%" + possessive + "%")
+		}
 	}
 	return patterns
+}
+
+// possessiveStems are the words a slug can only have lost an apostrophe from.
+// "mens" is not a plural of anything, so it can only be "men's"; "comics" is a
+// plural, so "comic's" would be a guess. Restricting the rewrite to these keeps
+// it from inventing patterns.
+var possessiveStems = map[string]string{
+	"mens":      "men's",
+	"womens":    "women's",
+	"childrens": "children's",
+	"peoples":   "people's",
+}
+
+// possessiveVariant restores the apostrophe a slug had to drop, so
+// "mens-basketball" can still find the category "Men's Basketball". Returns ""
+// when the phrase has no possessive to restore.
+//
+// Without this the four apostrophe subsections -- both basketballs, both
+// soccers -- matched nothing at all, so their pages were empty and their counts
+// read 0 while the categories they name were on hundreds of articles.
+func possessiveVariant(phrase string) string {
+	words := strings.Split(phrase, " ")
+	changed := false
+	for i, word := range words {
+		if replacement, ok := possessiveStems[word]; ok {
+			words[i] = replacement
+			changed = true
+		}
+	}
+	if !changed {
+		return ""
+	}
+	return strings.Join(words, " ")
 }
 
 // taxonomyMatchSlugs maps every section/subsection slug to the slugs whose

--- a/server/internal/database/taxonomy_test.go
+++ b/server/internal/database/taxonomy_test.go
@@ -20,6 +20,31 @@ func TestCategoryMatchPatternsExpandsDashedSlugs(t *testing.T) {
 	}
 }
 
+func TestCategoryMatchPatternsRestoresPossessiveApostrophe(t *testing.T) {
+	// The category text is "Men's Basketball"; no slug can carry the
+	// apostrophe, so without this pattern the subsection matched nothing.
+	got := CategoryMatchPatterns("mens-basketball")
+	want := []string{"%mens-basketball%", "%mens basketball%", "%mens & basketball%", "%men's basketball%"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d patterns %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pattern %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestCategoryMatchPatternsLeavesPluralsAlone(t *testing.T) {
+	// "philly-sports" is a plural, not a possessive: guessing "philly sport's"
+	// would add a pattern that matches nothing.
+	for _, pattern := range CategoryMatchPatterns("philly-sports") {
+		if strings.Contains(pattern, "'") {
+			t.Fatalf("unexpected possessive pattern %q", pattern)
+		}
+	}
+}
+
 func TestCategoryMatchPatternsSingleWordSlug(t *testing.T) {
 	got := CategoryMatchPatterns("comics")
 	if len(got) != 1 || got[0] != "%comics%" {

--- a/server/internal/handlers/article_params.go
+++ b/server/internal/handlers/article_params.go
@@ -13,9 +13,12 @@ import (
 var allowedSubsectionsBySection = map[string]map[string]struct{}{
 	"news": {
 		"academic-transformation": {},
-		"politics":                {},
 		"transit":                 {},
-		"crime-policy-violations": {},
+		"public-safety":           {},
+		"campus":                  {},
+		"city":                    {},
+		"national":                {},
+		"world":                   {},
 	},
 	"sports": {
 		"mens-basketball":   {},
@@ -25,14 +28,22 @@ var allowedSubsectionsBySection = map[string]map[string]struct{}{
 		"field-hockey":      {},
 		"mens-soccer":       {},
 		"womens-soccer":     {},
+		"nil":               {},
+		"squash":            {},
 	},
 	"opinion": {
 		"science-tech":    {},
 		"from-the-editor": {},
+		"politics":        {},
+		"lifestyle":       {},
 	},
 	"columns": {
 		"the-love-triangle":    {},
 		"tri-this-sweet-treat": {},
+		"from-the-playbook":    {},
+		"jack-of-all-takes":    {},
+		"the-green-angle":      {},
+		"the-overall-score":    {},
 	},
 	"entertainment": {
 		"movies":              {},
@@ -42,12 +53,18 @@ var allowedSubsectionsBySection = map[string]map[string]struct{}{
 		"books":               {},
 		"gaming":              {},
 		"listicles":           {},
+		"performing-arts":     {},
+		"the-drawing-board":   {},
 	},
 	"comics-puzzles": {
 		"political-cartoons": {},
 		"crossword":          {},
 		"sudoku":             {},
+		"comics":             {},
+		"puzzles":            {},
+		"satire":             {},
 	},
+	"graduation": {},
 }
 
 func normalizeAndValidateArticleParams(ctx context.Context, conn *sql.DB, params ArticleParams) (ArticleParams, error) {


### PR DESCRIPTION
Dev section pages were missing subsections that thetriangle.org shows. Comics & Puzzles listed four where the live site lists six, `graduation` was missing as a section, and Columns listed two subsections that do not exist upstream.

The nav is built from `site_taxonomy` ([handlers.go:159](../blob/main/server/internal/handlers/handlers.go#L159)), which is seeded from a hand-written list in `scripts/generate_wordpress_sql.py` that had never been reconciled with WordPress.

## What changed

- **Seed** — 35 rows to 52, sourced from `cms.thetriangle.org/wp-json/triangle/v2/section/<slug>`. Slugs stay in the CMS's cleaned-up form (`music`, not WordPress's `music-entertainment`); only the set is aligned. Also adds `comics`, which existed in the live DB but not in the seed, so it would have disappeared on the next reseed.
- **Two existing rows moved.** `politics` is an Opinion subsection upstream, not News. `crime-policy-violations` matched zero articles because the category text is `Public Safety`; renamed to `public-safety`, which resolves 109 articles.
- **Apostrophe matching** — `CategoryMatchPatterns` now emits `%men's basketball%` for `mens-basketball`. Both basketballs and both soccers matched nothing at all before, so their pages were empty and counts read 0 despite hundreds of tagged articles. Limited to stems that can only be possessives, so `philly-sports` is not turned into `philly sport's`.
- **Three copies of the same list** — the seed, the no-DB fallback map in `article_params.go`, and the default footer menu had each drifted separately; all three now agree.

## Verification

The taxonomy rows are already applied to the dev database, and the CMS API on Delta returns them:

| subsection | articles |
| --- | --- |
| public-safety | 109 |
| performing-arts | 131 |
| squash | 86 |
| campus | 46 |
| satire | 33 |
| graduation (section) | 31 |
| puzzles | 7 |

The apostrophe fix is code, so `mens-basketball` and friends stay at 0 until this deploys. `CMS_REBUILD_TAXONOMY_COUNTS_ON_STARTUP=true` is set on Delta, so `article_count` for every new row refreshes on that deploy without anyone running the rebuild endpoint.

`go test ./...` passes; two tests added for the possessive patterns.

## Companion change

`Scalene` carries its own hardcoded footer fallback with the old `/crime-policy-violations` link. Committed on `CMS-Testing` as `d323275`.

## Not addressed

- New rows append by `id`, so nav order differs slightly from the live site (Comics & Puzzles reads ... Sudoku, Comics, Puzzles, Satire). Fixing it means renumbering.
- `sudoku` and `the-rectangle` still count 0 — no article carries those categories at all.
- `special-editions` and its three subsections have no upstream counterpart; left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)