### PR TITLE
Multi-author bylines, parent-section inheritance, copy link, and a parent-section backfill

### DIFF
--- a/docs/ETL-REBUILD.md
+++ b/docs/ETL-REBUILD.md
@@ -1,0 +1,279 @@
+# Destructive ETL Rebuild — Primer
+
+How to rebuild the `triangle` database from scratch out of a fresh WordPress
+export. This is the "nuke and repave" path: `DROP DATABASE` → load six
+ETL-generated SQL files → restore the things the ETL does not produce.
+
+Last verified end-to-end **2026-08-01** (9780 articles onto DB1).
+
+---
+
+## 1. What this is, and when you actually need it
+
+The ETL (`wordpress-etl`) turns a WordPress WXR export into six SQL files under
+`logs/sql/`. Those files each carry their own `CREATE TABLE`, so loading them
+means dropping and recreating the database. There is no incremental mode and no
+migration tool.
+
+Reach for a full rebuild when:
+
+- article **content** must change wholesale — image URL canonicalization,
+  byline fixes, category/tag handling, un-dropping comics, etc. All of these are
+  baked into the data at ETL time, so an env-var change alone does nothing.
+- you are pulling a newer WordPress export.
+
+Do **not** rebuild for CMS-side schema changes. The Go backend applies those
+itself at startup via `EnsureArticlesSchema` (`server/internal/database/users.go`)
+with idempotent `ADD COLUMN IF NOT EXISTS`.
+
+## 2. What it destroys
+
+The ETL only owns six tables: `articles`, `authors`, `articles_authors`, `seo`,
+`article_embeddings`, `comments`.
+
+Everything else in the database is CMS-side and is **created empty at runtime**
+by the Go backend. `DROP DATABASE` therefore wipes real editorial state:
+
+| Lost | Consequence |
+| --- | --- |
+| `site_taxonomy` | **Every section page on the public site 404s.** Not "counts read 0" — Scalene resolves section routes from `/v1/taxonomy`, and an empty response means `/entertainment` etc. render the 404 page. Sections are config, not test data. |
+| `media.in_gallery` | `/photo` goes empty. The gallery is a hand-curated 25-image set; nothing re-seeds it. |
+| `cms_users`, `cms_sessions` | Everyone is logged out. Auto-promote recreates the first user on next login. |
+| `cms_settings` | Resets to defaults — breaking-news banner text is gone. |
+| `cms_activity`, `cms_poll_counts` | Gone. |
+
+Take a dump first, always. DB1 is still the only live copy — there is no DB2.
+
+```
+mariadb-dump --single-transaction --routines --events --databases triangle | gzip > pre-reset.sql.gz
+```
+
+Pull a copy off-host. You will need this dump again in step 6 to restore
+`site_taxonomy`.
+
+## 3. Prerequisites
+
+**The export is two separate WordPress downloads, zipped by hand** into
+`wordpress-etl/Data/wp-export.zip` (path hardcoded at `Utils/Constants.py`).
+Members are matched by case-sensitive filename prefix:
+
+- `wp-posts*.xml` — posts. An "All content" export is safe here; the extractor
+  drops anything that isn't `post_type == "post"`.
+- `wp-guestAuths*.xml` — a WXR export of the Co-Authors Plus `guest-author` post
+  type. **Do not reuse the all-content export for this half** — the guest-author
+  parser does not filter by post type and would run every post through the
+  author path.
+
+Also confirm before starting:
+
+- Media is synced to Ceph (see step 7 — do it *after* the load, but know the gap
+  exists).
+- You know which `MEDIA_BASE_URL` you want baked into the data. It must be a
+  public hostname, never a private IP: the ETL writes it into `photo_url` **and**
+  into inline `<img>` tags in article bodies, both of which render to browsers.
+
+## 4. Run the ETL
+
+There is a real `--headless` now (ETL commit `2975d05`). No TUI, no scratchpad
+driver — the older notes describing a stub driver are obsolete.
+
+```
+cd wordpress-etl
+MEDIA_BASE_URL=https://delta.thetriangle.org \
+  .venv/bin/python main.py --generate-embeddings --best-guess --headless
+```
+
+Embeddings take about 65 seconds for ~10k articles. `--headless` requires
+`--best-guess`. Note `triangle-cms/scripts/reseed_from_etl.py` does *not* pass
+`--headless`, so it still opens the TUI, and it is local-stack only.
+
+Output lands in `wordpress-etl/logs/sql/`:
+
+```
+articles.sql  authors.sql  articles_authors.sql  seo.sql  comments.sql  article_embeddings.sql
+```
+
+### Prompt traps
+
+`--headless` claims it cannot prompt. That is not quite true. It covers author
+*matching*, but duplicate-record **field conflicts** still hard-exit the run.
+Resolved conflicts are cached in `logs/auth_conflicts.json`.
+
+Historically both ID-keyed caches (`auth_conflicts.json` and
+`logs/article-sanitizer/article_author_resolution_cache.json`) rotted between
+exports, because **WordPress renumbers *and reuses* author IDs**. A stale ID
+either orphaned the link or silently credited an article to the wrong person.
+Fixed upstream in PRs #54/#56/#57: a cached decision now records *which person*
+wins, and the ID is always re-looked-up from the current export. If you ever
+touch that code again, keep that invariant — never write a cached ID.
+
+## 5. Load into DB1
+
+DB1 is `10.248.40.154`; `tadmin` has NOPASSWD sudo there. Delta cannot ssh to
+DB1 (host key unverified, and `triangle_user` is granted only from `.183`/`.168`),
+so load from the workstation.
+
+```
+ssh tadmin@10.248.40.154 'sudo -n mariadb --default-character-set=utf8mb4 -e "DROP DATABASE triangle; CREATE DATABASE triangle;"'
+
+for f in authors articles articles_authors seo article_embeddings comments
+  gzip -c logs/sql/$f.sql | ssh tadmin@10.248.40.154 'gunzip | sudo -n mariadb --default-character-set=utf8mb4 triangle'
+end
+```
+
+Load in that order — `articles_authors` has FK-shaped dependencies on the first
+two.
+
+### `--default-character-set=utf8mb4` is not optional
+
+DB1's `character_set_client`/`character_set_connection` default to **latin1**.
+Piping a UTF-8 file into a bare `mariadb` double-encodes every multibyte
+character: `“` (`E2 80 9C`) is stored as `â€œ`. This cost a full reload on
+2026-08-01.
+
+**The obvious check cannot detect it.** Reading the column back through a bare
+client converts it a second time and prints a correct-looking `“` — the two
+errors cancel. Verify with `SELECT HEX(...)` and expect `E2809C`. Likewise,
+`LIKE "%â€%"` typed at a shell gets mangled in transit and returns 0 rows, which
+reads as "no corruption".
+
+### Always grep the loader output for `^ERROR`
+
+A partial load looks like a successful one. The classic failure is the authors
+file aborting halfway on a duplicate key while every other table loads fine. Do
+not pipe loader output through `head`.
+
+(`article_embeddings.sql` legitimately lacks the `NO_AUTO_VALUE_ON_ZERO`
+preamble the other five carry — its PK is a bare `BIGINT`, not `AUTO_INCREMENT`,
+so the `id=0` row stores literally. Don't "fix" it.)
+
+## 6. Restore what the ETL doesn't produce
+
+**Order matters: restart the backend first.** `site_taxonomy` is created at
+runtime by the Go code, so restoring into a freshly dropped database fails with
+`Table 'triangle.site_taxonomy' doesn't exist`.
+
+1. Restart **both** blue and green backends. Green serves; blue is the rollback
+   target and must see the new schema too.
+2. Restore sections from the pre-reset dump:
+   ```
+   zcat pre-reset.sql.gz | awk '/^INSERT INTO `site_taxonomy`/,/;$/' > taxonomy.sql
+   ```
+   Load it the same way as above. Only 7 of the ~35 rows are `kind='section'`,
+   but restore all of them.
+3. Backfill parent sections. The ETL writes whatever categories WordPress had,
+   which for a subsection article is the subsection alone — so the row carries
+   "Welcome Week" with no "Special Editions" above it. Section *listing* still
+   finds those articles (a section query expands to its subsections), but
+   anything reading `articles.categories` directly, including the public site's
+   per-article section labels, sees an unparented subsection. Must run after
+   step 2: it reads the section tree out of `site_taxonomy`.
+   ```
+   python ./scripts/backfill_parent_sections.py \
+       --cms-dsn 'triangle_user@tcp(10.248.40.154)/triangle' --dry-run
+   ```
+   Via MaxScale add `--skip-ssl`: the proxy does not offer TLS and MariaDB
+   clients 11.4+ require it by default. Delta has no MariaDB client package —
+   `docker run --rm -i -v /tmp:/tmp mariadb:11.7 mariadb "$@"` as a shim on
+   `PATH` works, and the `-v /tmp:/tmp` matters so the script's 0600 option file
+   resolves inside the container.
+
+   Additive and idempotent — it only appends a missing parent, never removes or
+   reorders — so re-running is a no-op and `--dry-run` first costs nothing. It
+   refuses any row whose categories text opens with `[` but will not parse as
+   JSON, reporting the ids rather than risk corrupting them.
+
+   **Read the dry run before applying.** It only adds a parent the article is
+   not already matched by, using the same fuzzy substring rule the read path
+   uses — so an article tagged `Arts & Entertainment` does *not* also get
+   `Entertainment`, because `%entertainment%` already matches it. First run on
+   DB1 (2026-08-02) rewrote **638 of 10058** rows: mostly `Comics` → adds
+   `Comics & Puzzles` (329), plus `Music`/`Cooking` → `Entertainment`,
+   `Public Safety` → `News`, `Men's Basketball` → `Sports`.
+4. Restart the backend again to rebuild taxonomy counts. Note this is *not*
+   needed on account of step 3: counts bucket by section **plus its
+   subsections**, so a subsection-only article was already counted — verified on
+   2026-08-02, `comics-puzzles` read 331 both before and after. The backfill is
+   count-neutral; it changes which sections an article *names*, not the totals.
+5. Re-flag the photo gallery — 25 rows in `media.in_gallery`. Source of truth is
+   `https://cms.thetriangle.org/wp-json/triangle/v1/gallery` (disappears when
+   WordPress is retired); `scripts/backfill_gallery_flags.py` is the durable
+   route but has never been run against the real WP DB.
+6. Log back in; re-enter any breaking-news text.
+
+### Never re-slug a section to fix a count
+
+Section slugs are hardcoded in **both** repos (Scalene's `Header.astro`,
+`SideMenu.astro`, `index.astro`, `siteConfig.ts`; the CMS's `handlers.go`
+homepage block). Changing `comics-puzzles` → `comics` on 2026-08-01 returned
+400s on the live site. The correct fix for an under-matching section is to add a
+**subsection** whose slug matches the real category and leave the section slug
+alone.
+
+## 7. Post-load verification
+
+Run all of these. Each has produced a real defect at least once.
+
+**Media gap.** A fresh export references images added to WP after the last
+rsync. Test the filesystem, not curl — Cloudflare caches 404s:
+
+```
+while read p; do [ -f "/mnt/cephfs/media$p" ] || echo "$p"; done
+```
+
+On 2026-08-01, 24 of 6323 featured images were absent, and 22 of those are
+absent on WordPress itself (irreducible). Sync must be **pushed** from the WP VM
+`10.248.40.141`; Delta cannot pull. rsync exiting **23** with "failed to set
+times on .../2026/08" is one directory's mtime, not a data failure — ignore it.
+
+Newly synced files can 404 publicly for up to 4 hours while the pre-sync edge
+404 ages out. `?v=<ts>` returns 200 immediately; that confirms the file is fine.
+
+**Orphaned author links** — byline present in `articles.authors` but the join
+returns nothing, so the API emits `authors: null`:
+
+```sql
+SELECT COUNT(*) FROM articles_authors aa
+LEFT JOIN authors au ON au.id = aa.author_id
+WHERE au.id IS NULL;
+```
+
+**Mis-credited articles** — the row is valid, so no integrity check catches it:
+
+```sql
+SELECT ar.id FROM articles ar
+JOIN articles_authors aa ON aa.articles_id = ar.id
+JOIN authors au ON au.id = aa.author_id
+WHERE ar.authors NOT LIKE CONCAT('%', au.display_name, '%');
+```
+
+**Encoding** — `SELECT HEX(text) ...`, expect `E2809C` for smart quotes.
+
+**Photo URLs** — sample 15–20 and check they return 200. Note the API field is
+`featured_image`; the DB column is `photo_url`. Easy false alarm.
+
+**Section pages** — hit `/v1/taxonomy` and load a couple of section routes.
+`dev.thetriangle.org` sits behind Cloudflare Access, so page-level checks must
+happen in a browser, not from curl.
+
+### Expected residue that is *not* a bug
+
+- ~1200 `www.thetriangle.org` URLs — article cross-links in body text.
+- 2 `therectangle.org` URLs — also article links (the defunct predecessor
+  domain), not media.
+- `entertainment` counts far fewer than its 2543 `Arts & Entertainment`
+  articles: listing resolves slug → canonical title, counting buckets by
+  `CanonicalizeSlug(category)`. Different keys, so a section can list correctly
+  while its count is wrong. Cosmetic.
+
+## 8. Quick reference
+
+| Thing | Value |
+| --- | --- |
+| ETL repo | `wordpress-etl`, export at `Data/wp-export.zip` |
+| ETL output | `logs/sql/{articles,authors,articles_authors,seo,comments,article_embeddings}.sql` |
+| DB1 | `10.248.40.154`, `tadmin` NOPASSWD sudo, load from workstation |
+| Delta (app host) | `tadmin@10.248.40.168` — reaches DB via MaxScale `10.248.40.183:4006` |
+| WP VM (media source) | `tadmin@10.248.40.141`, docroot `/var/www/html/thetriangle.org/wp-content/uploads/` |
+| Media on Delta | `/mnt/cephfs/media/wp-content/uploads/` |
+| Deploy | merge to `main` → auto-deploys in ~3 min |

--- a/frontend/src/auth/urls.ts
+++ b/frontend/src/auth/urls.ts
@@ -18,3 +18,10 @@ export function authBaseUrl() {
 export function publicSiteUrl() {
   return trimTrailingSlashes(import.meta.env.VITE_PUBLIC_SITE_URL ?? "https://dev.thetriangle.org")
 }
+
+// The public permalink for a slug. The URL is fully determined by the slug, so
+// it can be handed out (newsletter, social scheduling) before the article is
+// published -- it 404s until then, and resolves the moment it goes live.
+export function articleUrl(slug: string) {
+  return `${publicSiteUrl()}/article/${encodeURIComponent(slug)}`
+}

--- a/frontend/src/components/MediaPicker.tsx
+++ b/frontend/src/components/MediaPicker.tsx
@@ -20,6 +20,12 @@ type MediaPickerProps = {
   onSelect: (item: MediaPickerItem) => void
   onClose: () => void
   title?: string
+  // When set, the picker also accepts a bare image URL. Only the featured-image
+  // field wants this: an article's photo_url is served verbatim, so it can point
+  // at an image that was never in our library. Body attachments have no such
+  // escape hatch by design -- they get sideloaded so articles never hotlink.
+  onUseUrl?: (url: string) => void
+  initialUrl?: string
 }
 
 const PAGE_SIZE = 60
@@ -41,7 +47,7 @@ async function errorMessage(response: Response, fallback: string) {
  * notably including alt_text, so a chosen image arrives with its description
  * already written rather than needing it retyped per article.
  */
-function MediaPicker({ onSelect, onClose, title = "Insert image" }: MediaPickerProps) {
+function MediaPicker({ onSelect, onClose, title = "Insert image", onUseUrl, initialUrl = "" }: MediaPickerProps) {
   const apiFetch = useApiFetch()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -51,6 +57,7 @@ function MediaPicker({ onSelect, onClose, title = "Insert image" }: MediaPickerP
   const [isLoading, setIsLoading] = useState(true)
   const [isUploading, setIsUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [urlInput, setUrlInput] = useState(initialUrl)
 
   useEffect(() => {
     const timer = setTimeout(() => setSearch(searchInput.trim()), 300)
@@ -235,6 +242,27 @@ function MediaPicker({ onSelect, onClose, title = "Insert image" }: MediaPickerP
             </div>
           )}
         </div>
+
+        {onUseUrl && (
+          <div className="flex gap-2 border-t border-border pt-4">
+            <input
+              aria-label="Image URL"
+              className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+              onChange={(e) => setUrlInput(e.target.value)}
+              placeholder="Or paste image URL"
+              type="url"
+              value={urlInput}
+            />
+            <button
+              className="whitespace-nowrap rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+              disabled={!urlInput.trim()}
+              onClick={() => onUseUrl(urlInput.trim())}
+              type="button"
+            >
+              Use URL
+            </button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,36 @@
+/**
+ * Copy text to the clipboard, returning whether it worked.
+ *
+ * navigator.clipboard exists only on secure origins. The CMS is still served
+ * over plain HTTP on Delta (see deploy/nginx/triangle-cms.conf), where the whole
+ * API is simply undefined -- so the modern path alone would fail on exactly the
+ * deployment editors use today. Fall back to the deprecated execCommand copy,
+ * which has no such restriction, and only report failure if both fail.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Blocked by permissions policy or a denied prompt; try the fallback.
+    }
+  }
+
+  try {
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    // Keep it off-screen and non-scrolling so the page does not jump.
+    textarea.setAttribute("readonly", "")
+    textarea.style.position = "fixed"
+    textarea.style.top = "-1000px"
+    textarea.style.opacity = "0"
+    document.body.appendChild(textarea)
+    textarea.select()
+    const copied = document.execCommand("copy")
+    document.body.removeChild(textarea)
+    return copied
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/pages/articleView.tsx
+++ b/frontend/src/pages/articleView.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from "react"
-import { ExternalLink, Search, Pencil, Plus, Trash2, X, ChevronFirst, ChevronLast, ChevronLeft, ChevronRight, Undo2 } from "lucide-react"
+import { ExternalLink, Search, Pencil, Plus, Trash2, X, ChevronFirst, ChevronLast, ChevronLeft, ChevronRight, Undo2, Copy, Check } from "lucide-react"
 import { Link, useNavigate } from "react-router-dom"
-import { publicSiteUrl } from "../auth/urls"
+import { articleUrl } from "../auth/urls"
 import { useApiFetch } from "../hooks/useApiFetch"
+import { copyText } from "../lib/clipboard"
 
 type ArticleStatus = "Published" | "Scheduled" | "Draft" | "Archived"
 
@@ -89,12 +90,16 @@ type ArticleViewProps = {
   excludeType?: string
 }
 
+// Mirrors the status values the articles endpoint accepts for editors; "all"
+// means send no status filter at all.
+type PublishedFilter = "all" | "published" | "draft" | "scheduled"
+
 type ArticleViewUIState = {
   searchQuery?: string
   activeTab?: "all" | "trash"
   authorQuery?: string
   sectionFilterSlug?: string
-  publishedFilter?: "all" | "published" | "draft"
+  publishedFilter?: PublishedFilter
   dateSortDirection?: "asc" | "desc"
   pageSize?: number
 }
@@ -123,9 +128,6 @@ const writeSessionJSON = (key: string, value: unknown) => {
 function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: ArticleViewProps) {
   const navigate = useNavigate()
   const apiFetch = useApiFetch()
-  // Same origin the comments view and the editor's permalink preview use, so
-  // "View Live" cannot point at a different site than the rest of the CMS.
-  const siteUrl = useMemo(() => publicSiteUrl(), [])
   const storageKeyBase = `articleView:${fixedType ?? "all"}:${excludeType ?? "none"}`
   const uiStateKey = `${storageKeyBase}:ui`
   const resultsCacheKey = `${storageKeyBase}:results`
@@ -144,12 +146,13 @@ function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: Article
   const [authorQuery, setAuthorQuery] = useState(() => loadUIState().authorQuery ?? "")
   const [sections, setSections] = useState<ApiTaxonomyItem[]>([])
   const [sectionFilterSlug, setSectionFilterSlug] = useState(() => loadUIState().sectionFilterSlug ?? "")
-  const [publishedFilter, setPublishedFilter] = useState<"all" | "published" | "draft">(() => loadUIState().publishedFilter ?? "all")
+  const [publishedFilter, setPublishedFilter] = useState<PublishedFilter>(() => loadUIState().publishedFilter ?? "all")
   const [dateSortDirection, setDateSortDirection] = useState<"asc" | "desc">(() => loadUIState().dateSortDirection ?? "desc")
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [deletingArticleId, setDeletingArticleId] = useState<string | null>(null)
+  const [copiedArticleId, setCopiedArticleId] = useState<string | null>(null)
 
   useEffect(() => {
     writeSessionJSON(uiStateKey, {
@@ -452,6 +455,17 @@ function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: Article
     }
   }
 
+  const copyArticleLink = async (item: ArticleItem) => {
+    if (!item.slug) return
+    if (await copyText(articleUrl(item.slug))) {
+      setCopiedArticleId(item.id)
+      setTimeout(() => setCopiedArticleId((current) => (current === item.id ? null : current)), 1500)
+      return
+    }
+    setCopiedArticleId(null)
+    setDeleteError("Could not copy the link. Your browser blocked clipboard access.")
+  }
+
   const deleteArticle = async (item: ArticleItem) => {
     if (!item.slug || deletingArticleId) return
     const shouldDelete = window.confirm(`Move "${item.title}" to trash?`)
@@ -617,6 +631,7 @@ function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: Article
               <button className={filterTagClass(publishedFilter === "all")} onClick={() => setPublishedFilter("all")} type="button">All</button>
               <button className={filterTagClass(publishedFilter === "published")} onClick={() => setPublishedFilter("published")} type="button">Published</button>
               <button className={filterTagClass(publishedFilter === "draft")} onClick={() => setPublishedFilter("draft")} type="button">Draft</button>
+              <button className={filterTagClass(publishedFilter === "scheduled")} onClick={() => setPublishedFilter("scheduled")} type="button">Scheduled</button>
             </div>
           </div>
         )}
@@ -733,13 +748,27 @@ function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: Article
                       {activeTab !== "trash" && item.status === "Published" && (
                         <a
                           className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
-                          href={item.slug ? `${siteUrl}/article/${encodeURIComponent(item.slug)}` : "#"}
+                          href={item.slug ? articleUrl(item.slug) : "#"}
                           rel="noreferrer"
                           target="_blank"
                         >
                           <ExternalLink className="w-3.5 h-3.5" />
                           View Live
                         </a>
+                      )}
+                      {/* Unlike View Live this is offered at any status: the
+                          link is wanted precisely while the piece is still a
+                          draft or scheduled, to write around it. */}
+                      {activeTab !== "trash" && (
+                        <button
+                          className="p-1.5 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                          disabled={!item.slug}
+                          onClick={() => void copyArticleLink(item)}
+                          title={item.slug ? "Copy article link" : "No link yet"}
+                          type="button"
+                        >
+                          {copiedArticleId === item.id ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                        </button>
                       )}
                       <button
                         className="p-1.5 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"

--- a/frontend/src/pages/editArticleView.tsx
+++ b/frontend/src/pages/editArticleView.tsx
@@ -1,9 +1,11 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { ArrowLeft, Save, Image, Search, X } from "lucide-react"
+import { ArrowLeft, Save, Image, Search, X, Copy, Check } from "lucide-react"
 import { useNavigate, useParams } from "react-router-dom"
 import { useApiFetch } from "../hooks/useApiFetch"
-import { publicSiteUrl } from "../auth/urls"
+import { articleUrl } from "../auth/urls"
 import TrixEditor from "../components/TrixEditor"
+import MediaPicker from "../components/MediaPicker"
+import { copyText } from "../lib/clipboard"
 import { DateTimeField } from "../components/ui/datetime-field"
 
 // Lazy-loaded so the heavy yoastseo bundle only loads when editing an article.
@@ -52,12 +54,6 @@ type PatchPayload = {
   focus_keyword: string
   meta_description: string
   seo_title: string
-}
-
-type MediaItem = {
-  id: string
-  url: string
-  fileName: string
 }
 
 type ApiAuthor = {
@@ -151,37 +147,6 @@ const clearArticleListCache = () => {
   }
 }
 
-const normalizeMediaItems = (payload: unknown): MediaItem[] => {
-  const asRecord = (value: unknown): Record<string, unknown> | null => (value && typeof value === "object" ? (value as Record<string, unknown>) : null)
-  const root = asRecord(payload)
-  const source = Array.isArray(payload)
-    ? payload
-    : Array.isArray(root?.items)
-      ? root.items
-      : Array.isArray(root?.media)
-        ? root.media
-        : []
-
-  const items = source
-    .map((raw) => asRecord(raw))
-    .filter((item): item is Record<string, unknown> => Boolean(item))
-    .map((item, index) => {
-      const url = String(item.url ?? item.photo_url ?? "").trim()
-      const fileName = String(item.file_name ?? item.title ?? item.name ?? url).trim()
-      const id = String(item.id ?? item.media_id ?? index)
-      return { id, url, fileName }
-    })
-    .filter((item) => item.url.length > 0)
-
-  const deduped = new Map<string, MediaItem>()
-  for (const item of items) {
-    if (!deduped.has(item.url)) {
-      deduped.set(item.url, item)
-    }
-  }
-  return [...deduped.values()]
-}
-
 function EditArticleView() {
   const navigate = useNavigate()
   const apiFetch = useApiFetch()
@@ -228,8 +193,11 @@ function EditArticleView() {
   const [metaDescription, setMetaDescription] = useState("")
   const [seoTitle, setSeoTitle] = useState("")
   const [imagePickerOpen, setImagePickerOpen] = useState(false)
-  const [selectedAuthorId, setSelectedAuthorId] = useState<string>("")
-  const [currentArticleAuthor, setCurrentArticleAuthor] = useState<ApiAuthor | null>(null)
+  const [linkCopied, setLinkCopied] = useState(false)
+  // Byline order is selection order: the list is sent as-is and rendered in that
+  // order downstream, so the first author checked leads the byline.
+  const [selectedAuthorIds, setSelectedAuthorIds] = useState<number[]>([])
+  const [currentArticleAuthors, setCurrentArticleAuthors] = useState<ApiAuthor[]>([])
   const [authorSearch, setAuthorSearch] = useState("")
   const [authors, setAuthors] = useState<ApiAuthor[]>([])
   const [authorsLoading, setAuthorsLoading] = useState(false)
@@ -237,11 +205,6 @@ function EditArticleView() {
   const [taxonomyItems, setTaxonomyItems] = useState<TaxonomyItem[]>([])
   const [taxonomyLoading, setTaxonomyLoading] = useState(false)
   const [taxonomyError, setTaxonomyError] = useState<string | null>(null)
-  const [mediaItems, setMediaItems] = useState<MediaItem[]>([])
-  const [mediaLoading, setMediaLoading] = useState(false)
-  const [mediaError, setMediaError] = useState<string | null>(null)
-  const [mediaSearch, setMediaSearch] = useState("")
-  const [customImageURL, setCustomImageURL] = useState("")
   const articleSnapshot = useMemo(() => JSON.stringify({
     title,
     slugInput: isNew ? slugInput : "",
@@ -253,7 +216,7 @@ function EditArticleView() {
     photoURL,
     breakingNews,
     selectedCategorySlugs,
-    selectedAuthorId,
+    selectedAuthorIds,
     keyphrase,
     metaDescription,
     seoTitle,
@@ -269,7 +232,7 @@ function EditArticleView() {
     photoURL,
     breakingNews,
     selectedCategorySlugs,
-    selectedAuthorId,
+    selectedAuthorIds,
     keyphrase,
     metaDescription,
     seoTitle,
@@ -343,14 +306,12 @@ function EditArticleView() {
             .filter((categorySlug) => categorySlug.length > 0)
           setLegacyCategoryTitlesBySlug(legacyCategories)
           setSelectedCategorySlugs([...new Set(categorySlugs)])
-          const firstAuthor = payload.authors?.[0]
-          const firstAuthorId = firstAuthor?.id
-          setSelectedAuthorId(typeof firstAuthorId === "number" ? String(firstAuthorId) : "")
-          setCurrentArticleAuthor(
-            typeof firstAuthorId === "number"
-              ? { id: firstAuthorId, display_name: (firstAuthor?.name ?? "").trim() }
-              : null,
-          )
+          // Keep the server's order: it is the byline order readers see.
+          const articleAuthors = (payload.authors ?? [])
+            .filter((author): author is { id: number; name?: string } => typeof author.id === "number")
+            .map((author) => ({ id: author.id, display_name: (author.name ?? "").trim() }))
+          setSelectedAuthorIds([...new Set(articleAuthors.map((author) => author.id))])
+          setCurrentArticleAuthors(articleAuthors)
         }
       } catch (err) {
         if (!cancelled) {
@@ -509,42 +470,6 @@ function EditArticleView() {
     }
   }, [apiFetch])
 
-  useEffect(() => {
-    if (!imagePickerOpen) return
-    let cancelled = false
-
-    setCustomImageURL(photoURL)
-    setMediaSearch("")
-    setMediaError(null)
-
-    const fetchMedia = async () => {
-      if (mediaItems.length > 0) return
-      setMediaLoading(true)
-      try {
-        const response = await apiFetch("/v1/media?limit=200")
-        if (!response.ok) {
-          throw new Error(`Media request failed (${response.status})`)
-        }
-        const payload = (await response.json()) as unknown
-        if (cancelled) return
-        setMediaItems(normalizeMediaItems(payload))
-      } catch (err) {
-        if (cancelled) return
-        const message = err instanceof Error ? err.message : "Unable to load media items."
-        setMediaError(message)
-      } finally {
-        if (!cancelled) {
-          setMediaLoading(false)
-        }
-      }
-    }
-
-    void fetchMedia()
-    return () => {
-      cancelled = true
-    }
-  }, [apiFetch, imagePickerOpen, mediaItems.length, photoURL])
-
   const saveArticle = async (nextTiming?: PublishTiming, options: { autosave?: boolean } = {}) => {
     const autosave = options.autosave === true
     const snapshotToSave = currentSnapshotRef.current
@@ -582,7 +507,7 @@ function EditArticleView() {
     // as import artifacts. Drafts are exempt from that filter for editors, so
     // this only has to block on the way to published — where the row would
     // otherwise vanish from both the CMS list and the public site.
-    if (effectiveStatus === "published" && !selectedAuthorId && categories.length === 0) {
+    if (effectiveStatus === "published" && selectedAuthorIds.length === 0 && categories.length === 0) {
       validationError(
         "Add at least one author or category so the article shows up in the list.",
         "Autosave paused until an author or section is set.",
@@ -619,7 +544,7 @@ function EditArticleView() {
           photo_url: photoURL.trim(),
           breaking_news: breakingNews,
           categories,
-          authors: selectedAuthorId ? [Number(selectedAuthorId)] : [],
+          authors: selectedAuthorIds,
           focus_keyword: keyphrase.trim(),
           meta_description: metaDescription.trim(),
           seo_title: seoTitle.trim(),
@@ -652,7 +577,7 @@ function EditArticleView() {
         photo_url: photoURL.trim(),
         breaking_news: breakingNews,
         categories,
-        authors: selectedAuthorId ? [Number(selectedAuthorId)] : [],
+        authors: selectedAuthorIds,
         focus_keyword: keyphrase.trim(),
         meta_description: metaDescription.trim(),
         seo_title: seoTitle.trim(),
@@ -695,7 +620,7 @@ function EditArticleView() {
     if (isNew || isLoading || lockedBy || isSaving || isAutoSaving) return
     if (!snapshotInitializedRef.current) return
     if (articleSnapshot === lastSavedSnapshotRef.current) return
-    if (publishTiming !== "draft" && !selectedAuthorId && selectedCategorySlugs.length === 0) {
+    if (publishTiming !== "draft" && selectedAuthorIds.length === 0 && selectedCategorySlugs.length === 0) {
       setAutoSaveMessage("Autosave paused until an author or section is set.")
       return
     }
@@ -710,7 +635,7 @@ function EditArticleView() {
     }, AUTOSAVE_DELAY_MS)
 
     return () => window.clearTimeout(timer)
-  }, [articleSnapshot, isAutoSaving, isLoading, isNew, isSaving, lockedBy, publishTiming, publishedAt, selectedAuthorId, selectedCategorySlugs])
+  }, [articleSnapshot, isAutoSaving, isLoading, isNew, isSaving, lockedBy, publishTiming, publishedAt, selectedAuthorIds, selectedCategorySlugs])
 
   const inputClass ="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition"
   const selectClass = "w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition"
@@ -792,36 +717,70 @@ function EditArticleView() {
     visibleCategoryGroups.reduce((count, group) => count + 1 + group.subsections.length, 0)
     + visibleLegacyCategoryChoices.length
   ), [visibleCategoryGroups, visibleLegacyCategoryChoices])
+  // Selected authors sit at the top, in byline order, and stay visible through a
+  // search that would otherwise hide them -- unchecking someone you can no longer
+  // see is how a byline silently loses a name.
   const visibleAuthors = useMemo(() => {
     const query = authorSearch.trim().toLowerCase()
     const namedAuthors = authors.filter((author) => author.display_name.trim().length > 0)
+    const byId = new Map(namedAuthors.map((author) => [author.id, author]))
+    for (const author of currentArticleAuthors) {
+      if (!byId.has(author.id) && author.display_name.trim()) byId.set(author.id, author)
+    }
+
+    const selected = selectedAuthorIds
+      .map((id) => byId.get(id))
+      .filter((author): author is ApiAuthor => Boolean(author))
     const matches = query
       ? namedAuthors.filter((author) => author.display_name.toLowerCase().includes(query))
       : namedAuthors
 
-    if (!selectedAuthorId) {
-      return matches
-    }
-
-    const selectedAuthor = namedAuthors.find((author) => String(author.id) === selectedAuthorId)
-      ?? (currentArticleAuthor && String(currentArticleAuthor.id) === selectedAuthorId && currentArticleAuthor.display_name.trim()
-        ? currentArticleAuthor
-        : null)
-    if (!selectedAuthor) {
-      return matches
-    }
-
     return [
-      selectedAuthor,
-      ...matches.filter((author) => String(author.id) !== selectedAuthorId),
+      ...selected,
+      ...matches.filter((author) => !selectedAuthorIds.includes(author.id)),
     ]
-  }, [authorSearch, authors, currentArticleAuthor, selectedAuthorId])
-  const toggleCategory = (categorySlug: string) => {
-    setSelectedCategorySlugs((current) => (
-      current.includes(categorySlug)
-        ? current.filter((slugValue) => slugValue !== categorySlug)
-        : [...current, categorySlug]
+  }, [authorSearch, authors, currentArticleAuthors, selectedAuthorIds])
+  // On a new article the slug the server will assign is not known until it is
+  // saved, so only offer the link once there is a real one.
+  const effectiveSlug = isNew ? "" : slug
+  const copyArticleLink = async () => {
+    if (!effectiveSlug) return
+    if (await copyText(articleUrl(effectiveSlug))) {
+      setLinkCopied(true)
+      setTimeout(() => setLinkCopied(false), 1500)
+      return
+    }
+    setLinkCopied(false)
+    setError("Could not copy the link. Your browser blocked clipboard access.")
+  }
+  const bylinePreview = useMemo(() => {
+    const namesById = new Map([...authors, ...currentArticleAuthors].map((author) => [author.id, author.display_name]))
+    const names = selectedAuthorIds.map((id) => namesById.get(id)?.trim() || `#${String(id)}`)
+    if (names.length <= 2) return names.join(" and ")
+    return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`
+  }, [authors, currentArticleAuthors, selectedAuthorIds])
+  const toggleAuthor = (authorId: number) => {
+    setSelectedAuthorIds((current) => (
+      current.includes(authorId)
+        ? current.filter((id) => id !== authorId)
+        : [...current, authorId]
     ))
+  }
+  // Checking a subsection also files the article under its parent section. A
+  // subsection alone leaves the article off the parent's own section page, which
+  // is never what an editor picking "Welcome Week" under "Special Editions"
+  // means. Unchecking the subsection deliberately leaves the parent in place --
+  // it is a legitimate standalone choice, and removing it silently would undo an
+  // explicit selection.
+  const toggleCategory = (categorySlug: string) => {
+    const parentSlug = taxonomyBySlug.get(categorySlug)?.parent_slug?.trim()
+    setSelectedCategorySlugs((current) => {
+      if (current.includes(categorySlug)) {
+        return current.filter((slugValue) => slugValue !== categorySlug)
+      }
+      const next = [...current, categorySlug]
+      return parentSlug && !next.includes(parentSlug) ? [...next, parentSlug] : next
+    })
   }
 
   return (
@@ -955,6 +914,25 @@ function EditArticleView() {
               ) : (
                 <input className={`${inputClass} bg-muted/50 text-muted-foreground cursor-default`} readOnly type="text" value={slug} />
               )}
+              {/* Available on drafts too: the newsletter and social posts are
+                  built ahead of publication and need the link before the article
+                  is live. A new article has no slug until it is saved, so the
+                  URL would be a guess -- offer it only once one exists. */}
+              {effectiveSlug ? (
+                <button
+                  className="inline-flex w-fit items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+                  onClick={() => void copyArticleLink()}
+                  title={articleUrl(effectiveSlug)}
+                  type="button"
+                >
+                  {linkCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                  {linkCopied ? "Link copied" : "Copy article link"}
+                </button>
+              ) : (
+                <span className="text-[11px] text-muted-foreground">
+                  Save once to get a shareable link.
+                </span>
+              )}
             </label>
 
             <div className={labelClass}>
@@ -999,7 +977,7 @@ function EditArticleView() {
             ) : null}
 
             <div className={labelClass}>
-              <span className={labelTextClass}>Author</span>
+              <span className={labelTextClass}>Authors</span>
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
                 <input
@@ -1019,32 +997,32 @@ function EditArticleView() {
                   </p>
                 ) : (
                   <div className="flex flex-col gap-1">
-                    <label className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 cursor-pointer">
-                      <input
-                        checked={selectedAuthorId === ""}
-                        className="h-4 w-4 border-border"
-                        onChange={() => setSelectedAuthorId("")}
-                        type="radio"
-                      />
-                      <span className="font-medium text-foreground">No author</span>
-                    </label>
-                    {visibleAuthors.map((author) => (
-                      <label key={author.id} className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 cursor-pointer">
-                        <input
-                          checked={selectedAuthorId === String(author.id)}
-                          className="h-4 w-4 border-border"
-                          onChange={() => setSelectedAuthorId(String(author.id))}
-                          type="radio"
-                        />
-                        <span className="text-foreground">{author.display_name}</span>
-                      </label>
-                    ))}
+                    {visibleAuthors.map((author) => {
+                      const bylinePosition = selectedAuthorIds.indexOf(author.id)
+                      return (
+                        <label key={author.id} className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 cursor-pointer">
+                          <input
+                            checked={bylinePosition !== -1}
+                            className="h-4 w-4 rounded border-border"
+                            onChange={() => toggleAuthor(author.id)}
+                            type="checkbox"
+                          />
+                          <span className="text-foreground">{author.display_name}</span>
+                          {/* Only worth numbering once there is an order to convey. */}
+                          {selectedAuthorIds.length > 1 && bylinePosition !== -1 ? (
+                            <span className="ml-auto text-[11px] text-muted-foreground">{bylinePosition + 1}</span>
+                          ) : null}
+                        </label>
+                      )
+                    })}
                   </div>
                 )}
               </div>
-              {authorSearch.trim() && !authorsLoading ? (
+              {!authorsLoading ? (
                 <span className="text-[11px] text-muted-foreground">
-                  {visibleAuthors.length} match{visibleAuthors.length === 1 ? "" : "es"}
+                  {selectedAuthorIds.length === 0
+                    ? "No authors selected."
+                    : `Byline: ${bylinePreview}`}
                 </span>
               ) : null}
             </div>
@@ -1220,108 +1198,29 @@ function EditArticleView() {
                 title={seoTitle.trim() || title}
                 description={metaDescription}
                 slug={isNew ? slugInput : slug}
-                permalink={`${publicSiteUrl()}/${isNew ? slugInput : slug}`}
+                permalink={articleUrl(isNew ? slugInput : slug)}
               />
             </Suspense>
           </aside>
         </div>
       )}
 
-      {/* Image picker modal */}
+      {/* Shares the library picker with the body editor and settings, so the
+          featured image gets the same upload, search and alt-text handling. */}
       {imagePickerOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Select image"
-        >
-          <div className="flex flex-col w-full max-w-2xl max-h-[85vh] rounded-xl border border-border bg-card shadow-2xl overflow-hidden">
-            {/* Modal header */}
-            <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-              <h3 className="text-base font-semibold text-foreground">Select image</h3>
-              <button
-                className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                onClick={() => setImagePickerOpen(false)}
-                type="button"
-                aria-label="Close"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
-
-            {/* Search */}
-            <div className="px-5 py-3 border-b border-border">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-                <input
-                  className="w-full pl-9 pr-4 py-2 rounded-lg border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition"
-                  onChange={(e) => setMediaSearch(e.target.value)}
-                  placeholder="Search media..."
-                  type="search"
-                  value={mediaSearch}
-                />
-              </div>
-            </div>
-
-            {/* Media grid */}
-            <div className="flex-1 overflow-y-auto p-4">
-              {mediaLoading ? (
-                <p className="text-center text-sm text-muted-foreground py-8">Loading media...</p>
-              ) : mediaItems.length === 0 ? (
-                <p className="text-center text-sm text-muted-foreground py-8">
-                  {mediaError ?? "No media items available yet. You can paste an image URL below."}
-                </p>
-              ) : (
-                <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
-                  {mediaItems
-                    .filter((item) => item.fileName.toLowerCase().includes(mediaSearch.trim().toLowerCase()))
-                    .map((item) => (
-                      <button
-                        className="flex flex-col gap-1.5 p-1.5 rounded-lg border border-border hover:border-primary hover:bg-primary/5 transition-colors text-left"
-                        key={`${item.id}-${item.url}`}
-                        onClick={() => {
-                          setPhotoURL(item.url)
-                          setImagePickerOpen(false)
-                        }}
-                        type="button"
-                      >
-                        <img
-                          alt={item.fileName || "Media"}
-                          className="w-full aspect-square object-cover rounded-md bg-muted"
-                          src={item.url}
-                          referrerPolicy="no-referrer"
-                          loading="lazy"
-                        />
-                        <span className="text-xs text-muted-foreground truncate w-full">{item.fileName || item.url}</span>
-                      </button>
-                    ))}
-                </div>
-              )}
-            </div>
-
-            {/* Footer: paste URL */}
-            <div className="flex gap-2 px-5 py-4 border-t border-border bg-muted/30">
-              <input
-                className="flex-1 px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition"
-                onChange={(e) => setCustomImageURL(e.target.value)}
-                placeholder="Or paste image URL"
-                type="url"
-                value={customImageURL}
-              />
-              <button
-                className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors whitespace-nowrap"
-                onClick={() => {
-                  if (!customImageURL.trim()) return
-                  setPhotoURL(customImageURL.trim())
-                  setImagePickerOpen(false)
-                }}
-                type="button"
-              >
-                Use URL
-              </button>
-            </div>
-          </div>
-        </div>
+        <MediaPicker
+          initialUrl={photoURL}
+          onClose={() => setImagePickerOpen(false)}
+          onSelect={(item) => {
+            setPhotoURL(item.url)
+            setImagePickerOpen(false)
+          }}
+          onUseUrl={(url) => {
+            setPhotoURL(url)
+            setImagePickerOpen(false)
+          }}
+          title="Featured image"
+        />
       )}
     </div>
   )

--- a/frontend/src/pages/mediaView.tsx
+++ b/frontend/src/pages/mediaView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { Copy, Check, ImageOff, Images, Search, Trash2, Upload, X } from "lucide-react"
 import { useApiFetch } from "../hooks/useApiFetch"
 import { useCurrentUserRole } from "../hooks/useCurrentUserRole"
+import { copyText } from "../lib/clipboard"
 
 type MediaItem = {
   id: number
@@ -445,13 +446,12 @@ function MediaDetailPanel({ item, canEdit, onClose, onSave }: MediaDetailPanelPr
   }, [onClose])
 
   const copyPath = async () => {
-    try {
-      await navigator.clipboard.writeText(item.path)
+    if (await copyText(item.path)) {
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
-    } catch {
-      setCopied(false)
+      return
     }
+    setCopied(false)
   }
 
   const save = async () => {

--- a/scripts/backfill_parent_sections.py
+++ b/scripts/backfill_parent_sections.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""File every article that sits in a subsection under its parent section too.
+
+The editor now adds the parent automatically when a subsection is checked, but
+rows written before that (and everything the ETL imported) carry the subsection
+alone. Those articles are missing from their parent section's own page: listing
+by section expands to the subsections underneath it, so a reader browsing
+"Special Editions" does see them -- but anything reading `articles.categories`
+directly, including the public site's per-article section labels, sees only
+"Welcome Week" with no parent above it.
+
+  python ./scripts/backfill_parent_sections.py \
+      --cms-dsn 'triangle_user@tcp(10.248.40.183:4006)/triangle' --skip-ssl --dry-run
+
+The password comes from CMS_DB_PASSWORD (or a prompt), never from argv.
+Re-runnable and additive: it only ever appends a parent that is missing, and
+never removes or reorders what is already there, so a second run is a no-op.
+Run it with --dry-run first and read the sample -- it rewrites a text column.
+
+"Missing" is judged with the read path's fuzzy substring rule, not exact slug
+equality: an article tagged "Arts & Entertainment" is already matched by the
+"entertainment" section, so it does not also get "Entertainment" bolted on.
+Skipping that distinction would have rewritten 2159 rows instead of 638 and put
+a redundant second section label on 2000+ articles.
+
+First run against DB1 on 2026-08-02: 638 of 10058 rows rewritten.
+
+Archived (trashed) articles are included: they keep their sections while in the
+trash and would otherwise come back restored-but-unparented.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import NamedTuple
+
+DSN_RE = re.compile(
+    r"^(?P<user>[^:@/]+)(?::(?P<password>[^@]*))?@tcp\((?P<host>[^:)]+)(?::(?P<port>\d+))?\)/(?P<database>[^?]+)"
+)
+
+# Mirrors slugifyCategory in frontend/src/pages/editArticleView.tsx. Matching on
+# the slugified title is an exact comparison, deliberately stricter than the
+# fuzzy LIKE the read path uses: this writes to the database, so a near-miss
+# must skip rather than guess a parent.
+SLUG_SUB = re.compile(r"[^a-z0-9]+")
+
+
+class Fail(Exception):
+    """A preflight or verification failure with a human-readable reason."""
+
+
+class Parent(NamedTuple):
+    """A parent section: the title written into an article, and the slug the
+    section's own listing filter matches on."""
+
+    title: str
+    slug: str
+
+
+def info(msg: str) -> None:
+    print(f"  {msg}")
+
+
+def step(msg: str) -> None:
+    print(f"\n==> {msg}")
+
+
+def warn(msg: str) -> None:
+    # stdout is block-buffered when piped; flush so warnings land in sequence
+    # with the surrounding progress output instead of ahead of all of it.
+    sys.stdout.flush()
+    print(f"  WARNING: {msg}", file=sys.stderr)
+    sys.stderr.flush()
+
+
+def slugify(value: str) -> str:
+    return SLUG_SUB.sub("-", value.strip().lower()).strip("-")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Add each article's parent section alongside any subsection it is filed under."
+    )
+    parser.add_argument(
+        "--cms-dsn",
+        required=True,
+        help="CMS database: user:password@tcp(host:port)/database (password optional)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would change without writing anything",
+    )
+    parser.add_argument(
+        "--limit-sample",
+        type=int,
+        default=10,
+        help="how many example rewrites to print (default: 10)",
+    )
+    parser.add_argument(
+        "--skip-ssl",
+        action="store_true",
+        help=(
+            "connect without TLS. Needed via the MaxScale proxy (10.248.40.183:4006), "
+            "which does not offer TLS while MariaDB clients 11.4+ require it by default; "
+            "the backend reaches it the same way over the internal LAN."
+        ),
+    )
+    return parser.parse_args()
+
+
+def resolve_dsn(dsn: str, label: str, password_env: str) -> dict:
+    match = DSN_RE.match(dsn.strip())
+    if not match:
+        raise Fail(f"--{label}-dsn must look like user:password@tcp(host:port)/database")
+
+    parts = match.groupdict()
+    target = {
+        "user": parts["user"],
+        "host": parts["host"],
+        "port": int(parts["port"] or 3306),
+        "database": parts["database"],
+        "password": parts["password"] or os.getenv(password_env) or "",
+    }
+    if not target["password"]:
+        if not sys.stdin.isatty():
+            raise Fail(f"no password for {label}: set {password_env}, or run interactively.")
+        target["password"] = getpass.getpass(f"Password for {target['user']}@{target['host']} ({label}): ")
+    return target
+
+
+def mysql_client() -> str:
+    for candidate in ("mariadb", "mysql"):
+        if shutil.which(candidate):
+            return candidate
+    raise Fail("neither `mariadb` nor `mysql` is on PATH; install a MariaDB client.")
+
+
+class Client:
+    """Runs SQL against one target without ever putting the password in argv."""
+
+    def __init__(self, target: dict, skip_ssl: bool = False):
+        self.target = target
+        self.binary = mysql_client()
+        # An option file keeps the password out of `ps` and shell history. 0600,
+        # in a private temp dir, removed on exit.
+        self._dir = tempfile.mkdtemp(prefix="triangle-sections-")
+        self.defaults = Path(self._dir) / "my.cnf"
+        self.defaults.write_text(
+            "[client]\n"
+            f"host={target['host']}\n"
+            f"port={target['port']}\n"
+            f"user={target['user']}\n"
+            f"password={target['password']}\n"
+            + ("ssl=0\n" if skip_ssl else ""),
+            encoding="utf-8",
+        )
+        self.defaults.chmod(0o600)
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    def rows(self, sql: str) -> list[list[str]]:
+        cmd = [self.binary, f"--defaults-file={self.defaults}", self.target["database"], "-N", "-B", "-e", sql]
+        done = subprocess.run(cmd, capture_output=True, text=True)
+        if done.returncode != 0:
+            raise Fail(f"query failed on {self.target['database']}: {done.stderr.strip()}")
+        return [line.split("\t") for line in done.stdout.splitlines() if line]
+
+    def scalar(self, sql: str) -> str:
+        rows = self.rows(sql)
+        return rows[0][0] if rows and rows[0] else ""
+
+    def execute_script(self, statements: list[str]) -> None:
+        """Run many statements in one transaction, fed over stdin so the payload
+        never has to fit in an argv-sized -e argument."""
+        script = Path(self._dir) / "backfill.sql"
+        script.write_text(
+            "START TRANSACTION;\n" + "\n".join(statements) + "\nCOMMIT;\n",
+            encoding="utf-8",
+        )
+        cmd = [self.binary, f"--defaults-file={self.defaults}", self.target["database"]]
+        with script.open("rb") as handle:
+            done = subprocess.run(cmd, stdin=handle, capture_output=True, text=True)
+        if done.returncode != 0:
+            raise Fail(f"backfill failed on {self.target['database']}: {done.stderr.strip()}")
+
+
+def quote(value: str) -> str:
+    """Single-quoted SQL literal. These strings come from the database, so they
+    get escaped rather than trusted."""
+    return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'"
+
+
+class Unparseable(Exception):
+    """Categories text that looks like JSON but is not, so it must not be rewritten."""
+
+
+def decode_categories(raw: str) -> tuple[list[str], bool]:
+    """The stored list plus whether it was JSON.
+
+    Matches ParseStringListField on the Go side: a JSON array when it parses as
+    one, otherwise a bare comma-separated list left over from the import.
+
+    A value that opens with "[" but will not parse is neither. Go's reader
+    comma-splits it, which is merely wrong in memory; appending to it here would
+    write "[...],Parent" back to the column and make the damage permanent. Those
+    rows are refused instead.
+    """
+    text = raw.strip()
+    if not text:
+        return [], True
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed], True
+        raise Unparseable(text)
+    except json.JSONDecodeError:
+        if text.startswith("["):
+            raise Unparseable(text) from None
+    return [part for part in text.split(",")], False
+
+
+def encode_categories(values: list[str], as_json: bool) -> str:
+    """Serialize the way the read path and the section-matching LIKE both want.
+
+    Note this writes a literal "&", where Go's json.Marshal (FormatTags) would
+    emit "\\u0026". The category LIKE patterns are built from the plain
+    character, so the escaped form silently fails to match -- keep the plain one.
+    """
+    if not as_json:
+        return ",".join(values)
+    return json.dumps(values, ensure_ascii=False)
+
+
+def load_parent_titles(cms: Client) -> dict[str, Parent]:
+    """Lookup key for a subsection -> canonical title of its parent section.
+
+    Keyed on both the taxonomy slug and the slugified canonical title, because
+    the two disagree wherever a title has an apostrophe: "Men's Basketball"
+    slugifies to "men-s-basketball" while its stored slug is "mens-basketball".
+    Articles store titles, so the title-derived key is the one that usually hits.
+    """
+    subsections = cms.rows(
+        "SELECT `slug`, `canonical_title`, `parent_slug` FROM `site_taxonomy` "
+        "WHERE `kind` = 'subsection' AND `parent_slug` IS NOT NULL AND `parent_slug` <> ''"
+    )
+    sections = cms.rows("SELECT `slug`, `canonical_title` FROM `site_taxonomy` WHERE `kind` = 'section'")
+    title_by_slug = {row[0]: row[1] for row in sections if len(row) >= 2}
+
+    parents: dict[str, Parent] = {}
+    orphans: list[str] = []
+    for row in subsections:
+        if len(row) < 3:
+            continue
+        slug, canonical_title, parent_slug = row[0], row[1], row[2]
+        title = title_by_slug.get(parent_slug)
+        if not title:
+            orphans.append(f"{slug} -> {parent_slug}")
+            continue
+        for key in (slug, slugify(canonical_title)):
+            if key:
+                parents[key] = Parent(title=title, slug=parent_slug)
+
+    if orphans:
+        warn(f"{len(orphans)} subsection(s) point at a section that does not exist; skipping them:")
+        for entry in orphans[:10]:
+            info(f"  {entry}")
+    return parents
+
+
+def category_match_patterns(slug: str) -> list[str]:
+    """Mirrors CategoryMatchPatterns in server/internal/database/taxonomy.go.
+
+    The substrings a section's LIKE filter matches on, minus the SQL wildcards.
+    """
+    normalized = slug.strip().lower()
+    if not normalized:
+        return []
+
+    patterns = [normalized]
+    if "-" in normalized:
+        spaced = normalized.replace("-", " ")
+        for variant in (spaced, normalized.replace("-", " & ")):
+            if variant not in patterns:
+                patterns.append(variant)
+    return patterns
+
+
+def parent_already_covered(values: list[str], parent: Parent) -> bool:
+    """Whether the article is already filed under this parent section.
+
+    Deliberately uses the read path's fuzzy substring rule rather than exact
+    slug equality. The legacy category "Arts & Entertainment" is not slug-equal
+    to the section title "Entertainment", but `%entertainment%` matches it, so
+    those articles already list under the section -- adding the canonical title
+    as well would only paint a second, redundant section label on the article.
+    """
+    patterns = category_match_patterns(parent.slug)
+    for value in values:
+        lowered = value.strip().lower()
+        if slugify(value) == slugify(parent.title):
+            return True
+        if any(pattern in lowered for pattern in patterns):
+            return True
+    return False
+
+
+def plan_row(raw: str, parents: dict[str, Parent]) -> str | None:
+    """The rewritten categories value for one row, or None to leave it alone."""
+    # -N -B renders a SQL NULL as the literal \N; nothing to do with it.
+    if raw == "\\N":
+        return None
+
+    values, as_json = decode_categories(raw)  # may raise Unparseable
+    additions: list[str] = []
+    for value in values:
+        parent = parents.get(slugify(value))
+        if not parent:
+            continue
+        # Checked against the running list so a second subsection under the same
+        # parent does not add it twice.
+        if parent_already_covered(values + additions, parent):
+            continue
+        additions.append(parent.title)
+
+    if not additions:
+        return None
+    return encode_categories(values + additions, as_json)
+
+
+def main() -> int:
+    args = parse_args()
+    cms_client: Client | None = None
+
+    try:
+        cms_client = Client(resolve_dsn(args.cms_dsn, "cms", "CMS_DB_PASSWORD"), skip_ssl=args.skip_ssl)
+
+        step("Reading the section tree")
+        parent_titles = load_parent_titles(cms_client)
+        if not parent_titles:
+            raise Fail(
+                "no subsections with a valid parent in site_taxonomy; "
+                "nothing to inherit. Check this is the CMS database."
+            )
+        info(f"{len(parent_titles)} subsection(s) with a parent section")
+
+        step("Scanning articles")
+        rows = cms_client.rows(
+            "SELECT `id`, `categories` FROM `articles` "
+            "WHERE `categories` IS NOT NULL AND TRIM(`categories`) <> ''"
+        )
+        info(f"{len(rows)} article(s) carry categories")
+
+        updates: list[str] = []
+        samples: list[str] = []
+        unparseable: list[str] = []
+        for row in rows:
+            if len(row) < 2:
+                continue
+            article_id, raw = row[0], row[1]
+            try:
+                encoded = plan_row(raw, parent_titles)
+            except Unparseable:
+                unparseable.append(str(article_id))
+                continue
+            if encoded is None:
+                continue
+
+            updates.append(f"UPDATE `articles` SET `categories` = {quote(encoded)} WHERE `id` = {int(article_id)};")
+            if len(samples) < args.limit_sample:
+                samples.append(f"#{article_id}: {raw}  ->  {encoded}")
+
+        if unparseable:
+            warn(
+                f"{len(unparseable)} article(s) have categories that start with '[' but are not valid "
+                "JSON; left untouched rather than risk corrupting them:"
+            )
+            info(f"  ids: {', '.join(unparseable[:20])}" + (" ..." if len(unparseable) > 20 else ""))
+
+        step("Applying")
+        info(f"{len(updates)} article(s) need a parent section added")
+        for sample in samples:
+            info(f"  {sample}")
+        if len(updates) > len(samples):
+            info(f"  ... and {len(updates) - len(samples)} more")
+
+        if not updates:
+            info("Nothing to do.")
+            return 0
+        if args.dry_run:
+            info("--dry-run: nothing written.")
+            return 0
+
+        cms_client.execute_script(updates)
+        info(f"{len(updates)} article(s) updated.")
+
+        # No count rebuild needed: site_taxonomy.article_count buckets by section
+        # plus its subsections, so these articles were already counted under the
+        # parent. Confirmed on DB1 2026-08-02 -- comics-puzzles read 331 both
+        # before and after. This changes which sections an article names, not
+        # any total.
+        info("Section totals are unaffected; no taxonomy count rebuild needed.")
+        return 0
+
+    except Fail as err:
+        print(f"\nERROR: {err}", file=sys.stderr)
+        return 1
+    finally:
+        if cms_client:
+            cms_client.cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Five editor items from the working list, plus a one-off backfill for the
existing archive. All the app changes are frontend — the backend already
supported everything needed.

## Editor and article list

**Multiple authors.** The author radio list becomes a checkbox list.
`articles_authors`, `ReplaceArticleAuthors` and the `ORDER BY aa.id` read were
already N-author; only the UI was single-select. Selection order is byline
order and round-trips through save/load, so the sidebar shows an ordinal and a
byline preview.

**Parent section inheritance.** Checking a subsection also checks its parent.
Unchecking the subsection deliberately leaves the parent — it is a valid
standalone choice, and removing it would undo an explicit selection.

**Copy article link.** New `articleUrl()` helper, plus a copy control in the
editor and on every non-trash list row. Offered at any status, since the point
is having the URL while the piece is still a draft, for the newsletter and
social posts. New articles show "Save once to get a shareable link" — the slug
is not known until the server assigns it.

**Scheduled filter.** Added the chip to the article list; the API already
accepted `status=scheduled` for editors.

**Featured image upload** — reported as "broken on Chrome", but not a browser
bug. The featured-image field had its own older modal (search + paste URL, no
upload) while `MediaPicker`, with upload and alt-text warnings, was wired only
into the body editor and settings. Swapped it in. `MediaPicker` gains an opt-in
`onUseUrl` prop so the paste-a-URL escape hatch is not lost; only the featured
image gets it, since `photo_url` is served verbatim while body attachments are
deliberately sideloaded.

## Two fixes found along the way

**Clipboard on HTTP.** `navigator.clipboard` is undefined on insecure origins
and the CMS is still served over plain HTTP on Delta, so copy would have failed
on exactly the deployment editors use today. `lib/clipboard.ts` falls back to
`execCommand`; verified with the modern API stubbed out. The media library's
existing "Copy path" moves onto it too.

**Permalink shape.** The editor's Yoast permalink was `${site}/${slug}` while
the list and comments views use `${site}/article/${slug}`. All three now go
through `articleUrl()`.

## Backfill

`scripts/backfill_parent_sections.py` files existing subsection-only articles
under their parent. This is a permanent step, not a one-off: the ETL writes
whatever categories WordPress had, so every rebuild reintroduces the condition.
Added to `docs/ETL-REBUILD.md` as step 3 of section 6.

**Already run against DB1 on 2026-08-02: 638 of 10058 rows rewritten.**

| Count | Parent added | Typical source |
| --- | --- | --- |
| 329 | Comics & Puzzles | `Comics`, `Crossword` |
| 80 | Entertainment | `Music`, `Cooking` |
| 68 | News | `Public Safety` |
| 60 | Special Editions | `Welcome Week` |
| 55 | Sports | `Men's Basketball` |
| 42 | Columns | — |
| 27 | Opinion | — |

The dry run earned its keep. The first version tested "is the parent already
here?" with strict slug equality and wanted **2159** rows — it would have added
`Entertainment` to 2000+ articles already tagged `Arts & Entertainment`, the
same section under a different name, putting a redundant second label on a
fifth of the archive. The check now mirrors the read path's fuzzy substring
rule.

Also refuses any row whose categories text opens with `[` but will not parse as
JSON — Go's reader comma-splits those, which is merely wrong in memory, but
appending here would write `[...],Parent` back and make it permanent.

Section totals are unaffected: counts bucket by section **plus its
subsections**, so these articles were already counted under the parent
(`comics-puzzles` recomputed to 331 both before and after). No backend restart
needed on account of this.

## Review notes

- `docs/ETL-REBUILD.md` was previously uncommitted, so this PR adds the whole
  file, not just the new step.
- Verification: `tsc`, `eslint` and `vite build` clean (one pre-existing
  `exhaustive-deps` warning on the autosave effect). Editor and list changes
  screenshotted in a real browser through a temporary stubbed-fetch harness,
  since there is no login-free path to authed pages; the harness is not part of
  this diff. Backfill logic covered by a scratch MariaDB run before DB1.
- Merging deploys automatically in ~3 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
