### PR TITLE
Start the embedding sidecar during deployment

### DIFF
--- a/deploy/scripts/common.sh
+++ b/deploy/scripts/common.sh
@@ -14,6 +14,9 @@ DEPLOY_LOCK_FILE="${DEPLOY_LOCK_FILE:-/tmp/triangle-cms-deploy.lock}"
 BACKEND_HEALTH_TIMEOUT="${BACKEND_HEALTH_TIMEOUT:-180}"
 FRONTEND_HEALTH_TIMEOUT="${FRONTEND_HEALTH_TIMEOUT:-120}"
 PUBLIC_HEALTH_TIMEOUT="${PUBLIC_HEALTH_TIMEOUT:-30}"
+# Generous: this covers pulling the image and loading the ONNX model on a host
+# with no GPU. Exceeding it only costs semantic search, never the deployment.
+EMBEDDINGS_HEALTH_TIMEOUT="${EMBEDDINGS_HEALTH_TIMEOUT:-240}"
 
 compose() {
 	docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" "$@"
@@ -240,6 +243,30 @@ wait_for_url() {
     fi
     sleep 3
   done
+}
+
+# wait_for_embeddings polls the container's health state rather than an HTTP
+# endpoint, because the sidecar is deliberately not published to the host -- only
+# the backends reach it, over the compose network. Its healthcheck 503s until the
+# model has finished loading, so "healthy" here means it can actually answer.
+wait_for_embeddings() {
+	local deadline=$((SECONDS + EMBEDDINGS_HEALTH_TIMEOUT))
+	local container status=""
+
+	while true; do
+		container="$(compose ps -q embeddings 2>/dev/null || true)"
+		if [[ -n "${container}" ]]; then
+			status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${container}" 2>/dev/null || true)"
+			if [[ "${status}" == "healthy" ]]; then
+				return 0
+			fi
+		fi
+		if (( SECONDS >= deadline )); then
+			echo "timed out waiting for the embeddings sidecar (last status: ${status:-unknown})" >&2
+			return 1
+		fi
+		sleep 3
+	done
 }
 
 wait_for_slot() {

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -30,6 +30,28 @@ next_slot="$(opposite_slot "${current_slot}")"
 echo "active slot: ${current_slot}"
 echo "deploying ${CMS_IMAGE_TAG} to inactive slot: ${next_slot}"
 
+# The embedding sidecar is shared by both slots rather than duplicated per slot:
+# it is stateless, so a second copy would only cost memory on a host that has
+# little to spare. That means it is not part of the blue/green swap and has to be
+# brought up separately -- the slot services below are started with --no-deps.
+#
+# Deliberately never fatal. Search degrades to lexical-only when the sidecar is
+# missing or still loading its model, so a sidecar problem must not block or roll
+# back a deployment that is otherwise fine.
+if ! compose pull embeddings; then
+  echo "warning: could not pull the embeddings sidecar; semantic search may be unavailable" >&2
+fi
+if compose up -d --no-deps embeddings; then
+  # Recreated on every deploy because its image tag is the commit SHA, so it
+  # reloads its model each time. Waiting here keeps the window where search is
+  # lexical-only from overlapping the slot switch.
+  if ! wait_for_embeddings; then
+    echo "warning: the embeddings sidecar did not become healthy; search will serve lexical results until it does" >&2
+  fi
+else
+  echo "warning: could not start the embeddings sidecar; search will serve lexical results" >&2
+fi
+
 compose pull "backend-${next_slot}" "frontend-${next_slot}"
 compose up -d --no-deps "backend-${next_slot}" "frontend-${next_slot}"
 


### PR DESCRIPTION
Follow-up to #158. **The sidecar has never actually run in production.**

`deploy.sh` brings up only `backend-${slot}` and `frontend-${slot}`, with `--no-deps`. The embedding sidecar is shared by both slots rather than duplicated per slot — it holds no state, and a second copy would only cost memory on a host with little to spare — so it is not part of the blue/green swap and was never started at all. #158 added the service to `compose.cms.yml`, but no deployment ever created it.

## Current production state

Running with `EMBEDDINGS_URL` pointing at a host that does not resolve:

```
WARN embedding reconciler pass failed
  error="Get \"http://embeddings:8000/health\": dial tcp: lookup embeddings on 127.0.0.11:53"
```

This degrades exactly as designed — `/v1/search` returns **200 in 13.6ms** with correct FULLTEXT ranking, and no request fails. So the lexical half of #158 is live and working; only the semantic half is inert, and it never comes up on its own.

## Change

The sidecar is pulled and started before the slot services, and waited for before the nginx switch, so the window where search is lexical-only does not overlap the cutover. It is recreated on every deploy because its image tag is the commit SHA, so it reloads its model each time.

**Every step is non-fatal on purpose.** A missing or slow sidecar costs the semantic half of ranking and nothing else, so it must never block or roll back a deployment that is otherwise healthy — hence warnings rather than `set -e` aborts.

`wait_for_embeddings` polls container health rather than an HTTP endpoint, because the sidecar is deliberately not published to the host — only the backends reach it, over the compose network. Its healthcheck 503s until the model finishes loading, so "healthy" means it can actually answer. The 240s default timeout covers pulling the image and loading the ONNX model on a CPU-only host.

## Note

`TRUNCATE TABLE article_embeddings` from #158's deploy notes **must not run until this is deployed and the sidecar is healthy**. Truncating now would clear the 10,058 existing vectors with nothing able to refill them, taking related-articles down completely instead of just leaving it on stale ones.

Verified with `bash -n`; the image itself is confirmed published at `fcdf4b7d` by the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)