### PR TITLE
Cap the embedding sidecar's CPU

### DIFF
--- a/deploy/cms.env.example
+++ b/deploy/cms.env.example
@@ -34,3 +34,8 @@ MEDIA_MAX_UPLOAD_BYTES=
 # server/internal/database/schema/article_embeddings.sql.
 EMBEDDINGS_URL=http://embeddings:8000
 EMBED_MODEL=BAAI/bge-small-en-v1.5
+# Cores the sidecar may use, out of the host's 6. Uncapped, embedding a freshly
+# reseeded corpus pins nearly the whole machine for over an hour and starves the
+# backends. Raising this speeds up that backfill and nothing else -- ordinary
+# search only embeds one short query at a time, and caches the result.
+EMBED_CPUS=4

--- a/deploy/compose.cms.yml
+++ b/deploy/compose.cms.yml
@@ -83,11 +83,24 @@ services:
     image: ${CMS_EMBEDDINGS_IMAGE:-ghcr.io/drexeltriangle/triangle-cms-embeddings}:${CMS_IMAGE_TAG:?CMS_IMAGE_TAG is required}
     restart: unless-stopped
     stop_grace_period: 10s
+    # Delta has 6 cores. Left uncapped, the backfill after a reseed pins nearly
+    # all of them for over an hour (measured: 579% of 600%, load average 5.4)
+    # and would starve the backends of the CPU they need to serve requests.
+    #
+    # Both settings are needed, and they should match. cpus is a cgroup ceiling;
+    # without OMP_NUM_THREADS, onnxruntime still spawns one thread per visible
+    # core and thrashes against that ceiling instead of respecting it.
+    #
+    # This trades backfill throughput for headroom -- roughly 2 articles/sec
+    # becomes 1.4 -- which is the right way round: the backfill is background
+    # work that converges on its own, and nothing waits on it.
+    cpus: ${EMBED_CPUS:-4}
     environment:
       # Must match the WordPress ETL's --embedding-model. Vectors from two
       # different models share a table but not a coordinate space, so a mismatch
       # corrupts ranking silently rather than failing.
       EMBED_MODEL: ${EMBED_MODEL:-BAAI/bge-small-en-v1.5}
+      OMP_NUM_THREADS: ${EMBED_CPUS:-4}
     healthcheck:
       # /health 503s until the model is loaded.
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')\""]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,14 @@ services:
       context: ./embeddings
       dockerfile: Dockerfile
     restart: unless-stopped
+    # Capped for the same reason as production (see deploy/compose.cms.yml):
+    # uncapped, embedding a freshly seeded corpus saturates every core on the
+    # machine. Both settings are needed and should match -- cpus is the ceiling,
+    # OMP_NUM_THREADS stops onnxruntime spawning a thread per core regardless.
+    cpus: ${EMBED_CPUS:-4}
     environment:
       EMBED_MODEL: ${EMBED_MODEL:-BAAI/bge-small-en-v1.5}
+      OMP_NUM_THREADS: ${EMBED_CPUS:-4}
     healthcheck:
       # /health 503s until the model finishes loading, so this gates the CMS's
       # first search rather than letting it fail against a cold container.


### PR DESCRIPTION
Follow-up to #158, from watching the first real backfill run.

Delta has 6 cores. Uncapped, the sidecar takes essentially all of them while backfilling:

```
triangle-cms-embeddings-1   579.05%   1.281GiB / 3.823GiB
load average: 5.39, 4.64, 2.54     (was 0.92 before the backfill started)
```

The backends showed 0% throughout — but only because this ran at 5am with no traffic. A reseed during the day would have starved them of the CPU they need to serve requests, and a reseed is a daytime activity.

## Both settings, and they must match

`cpus` is a cgroup ceiling. On its own it is not enough: onnxruntime still spawns one thread per *visible* core and thrashes against the ceiling rather than respecting it. `OMP_NUM_THREADS` is what actually makes it use fewer threads.

## The tradeoff

Backfill throughput drops from ~2 articles/sec to ~1.4 — a full 10k rebuild goes from ~80 minutes to ~2 hours. That is the right way round: the backfill is background work that converges on its own and nothing waits on it, whereas a slow CMS is immediately visible to readers and editors.

**Ordinary search is unaffected.** It embeds one short query at a time and caches the result; the query cache means repeated searches never reach the sidecar at all. The cap only matters while a bulk backfill is draining.

Tunable via `EMBED_CPUS` for a future host with a different core count. Verified `docker compose config` renders `cpus: 4` and `OMP_NUM_THREADS: "4"`.

Applied to the dev compose too, for the same reason — seeding a local corpus otherwise saturates the whole laptop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)