### PR TITLE
Show SEO tags in article editor

### DIFF
--- a/frontend/src/pages/editArticleView.tsx
+++ b/frontend/src/pages/editArticleView.tsx
@@ -37,6 +37,10 @@ type ApiArticleDetail = {
     seo_title?: string
     meta_description?: string
     focus_keyword?: string
+    tags?: Array<{
+      name?: string
+      slug?: string
+    }>
   }
 }
 
@@ -50,6 +54,7 @@ type PatchPayload = {
   photo_url: string
   breaking_news: boolean
   categories: string[]
+  tags: string[]
   authors: number[]
   focus_keyword: string
   meta_description: string
@@ -89,6 +94,20 @@ const slugifyCategory = (value: string): string =>
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
+
+const parseSEOTags = (value: string): string[] => {
+  const seen = new Set<string>()
+  return value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter((tag) => {
+      if (!tag) return false
+      const key = tag.toLowerCase()
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+}
 
 const toLocalInput = (value?: string): string => {
   if (!value) return ""
@@ -192,6 +211,7 @@ function EditArticleView() {
   const [keyphrase, setKeyphrase] = useState("")
   const [metaDescription, setMetaDescription] = useState("")
   const [seoTitle, setSeoTitle] = useState("")
+  const [seoTagsInput, setSeoTagsInput] = useState("")
   const [imagePickerOpen, setImagePickerOpen] = useState(false)
   const [linkCopied, setLinkCopied] = useState(false)
   // Byline order is selection order: the list is sent as-is and rendered in that
@@ -216,6 +236,7 @@ function EditArticleView() {
     photoURL,
     breakingNews,
     selectedCategorySlugs,
+    seoTagsInput,
     selectedAuthorIds,
     keyphrase,
     metaDescription,
@@ -232,6 +253,7 @@ function EditArticleView() {
     photoURL,
     breakingNews,
     selectedCategorySlugs,
+    seoTagsInput,
     selectedAuthorIds,
     keyphrase,
     metaDescription,
@@ -276,6 +298,10 @@ function EditArticleView() {
           setExcerpt(payload.excerpt ?? "")
           setKeyphrase(payload.seo?.focus_keyword ?? "")
           setSeoTitle(payload.seo?.seo_title ?? "")
+          setSeoTagsInput((payload.seo?.tags ?? [])
+            .map((tag) => (tag.name ?? "").trim())
+            .filter((tag) => tag.length > 0)
+            .join(", "))
           // Fall back to the excerpt as a starting point when no meta description
           // has been saved yet.
           setMetaDescription(payload.seo?.meta_description ?? payload.excerpt ?? "")
@@ -502,6 +528,7 @@ function EditArticleView() {
         ?? categorySlug
       ).trim())
       .filter((category) => category.length > 0)
+    const seoTags = parseSEOTags(seoTagsInput)
 
     // Rows with neither an author nor a category are filtered out of the listing
     // as import artifacts. Drafts are exempt from that filter for editors, so
@@ -544,6 +571,7 @@ function EditArticleView() {
           photo_url: photoURL.trim(),
           breaking_news: breakingNews,
           categories,
+          tags: seoTags,
           authors: selectedAuthorIds,
           focus_keyword: keyphrase.trim(),
           meta_description: metaDescription.trim(),
@@ -577,6 +605,7 @@ function EditArticleView() {
         photo_url: photoURL.trim(),
         breaking_news: breakingNews,
         categories,
+        tags: seoTags,
         authors: selectedAuthorIds,
         focus_keyword: keyphrase.trim(),
         meta_description: metaDescription.trim(),
@@ -1176,6 +1205,17 @@ function EditArticleView() {
                 placeholder="e.g. campus housing"
                 type="text"
                 value={keyphrase}
+              />
+            </label>
+
+            <label className={labelClass}>
+              <span className={labelTextClass}>SEO Tags</span>
+              <input
+                className={inputClass}
+                onChange={(e) => setSeoTagsInput(e.target.value)}
+                placeholder="Comma-separated tags"
+                type="text"
+                value={seoTagsInput}
               />
             </label>
 

--- a/server/internal/database/http_models.go
+++ b/server/internal/database/http_models.go
@@ -581,6 +581,11 @@ func ArticleInputToDBFields(body models.ArticleInput) []any {
 		excerpt = deriveExcerpt(body.Content)
 	}
 
+	tags := FormatTags(body.Tags)
+	if tags == "" {
+		tags = "[]"
+	}
+
 	return []any{
 		body.Title,
 		slug,
@@ -597,7 +602,7 @@ func ArticleInputToDBFields(body models.ArticleInput) []any {
 		// Default tags/metadata to empty JSON so list filters that don't
 		// COALESCE these columns (e.g. exclude_type) don't drop new articles
 		// on a NULL comparison.
-		"[]",
+		tags,
 		"{}",
 		strings.TrimSpace(body.FocusKeyword),
 		strings.TrimSpace(body.MetaDescription),

--- a/server/internal/database/http_models_test.go
+++ b/server/internal/database/http_models_test.go
@@ -121,6 +121,37 @@ func TestArticleInputToDBFields_StoresFuturePublishDateAsSchedule(t *testing.T) 
 	}
 }
 
+func TestArticleInputToDBFields_StoresTags(t *testing.T) {
+	fields := ArticleInputToDBFields(models.ArticleInput{
+		Title:   "Tagged story",
+		Content: "Body",
+		Status:  models.ArticleStatusDraft,
+		Tags:    []string{"campus", "housing"},
+	})
+
+	const tagsFieldIndex = 12
+	got, ok := fields[tagsFieldIndex].(string)
+	if !ok {
+		t.Fatalf("tags field has type %T, want string", fields[tagsFieldIndex])
+	}
+	if got != `["campus","housing"]` {
+		t.Fatalf("tags = %q, want JSON tag list", got)
+	}
+}
+
+func TestArticleInputToDBFields_DefaultsEmptyTagsToJSONList(t *testing.T) {
+	fields := ArticleInputToDBFields(models.ArticleInput{
+		Title:   "Untagged story",
+		Content: "Body",
+		Status:  models.ArticleStatusDraft,
+	})
+
+	const tagsFieldIndex = 12
+	if got := fields[tagsFieldIndex]; got != "[]" {
+		t.Fatalf("empty tags = %v, want []", got)
+	}
+}
+
 // A full replacement is still an edit, and it used to write mod_date = NULL.
 // Two things depend on that column: the public sitemap's lastmod is
 // COALESCE(mod_date, pub_date), and the embedding reconciler decides a vector is

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -2203,6 +2203,7 @@ func PatchArticle(conn *sql.DB) http.HandlerFunc {
 			"excerpt":          "excerpt",
 			"content":          "text",
 			"categories":       "categories",
+			"tags":             "tags",
 			"published_date":   "pub_date",
 			"is_featured":      "priority",
 			"breaking_news":    "breaking_news",
@@ -2224,24 +2225,30 @@ func PatchArticle(conn *sql.DB) http.HandlerFunc {
 				continue
 			}
 			switch jsonField {
-			case "categories":
+			case "categories", "tags":
 				arr, ok := v.([]any)
 				if !ok {
-					writeError(w, http.StatusBadRequest, "categories must be an array of strings")
+					writeError(w, http.StatusBadRequest, jsonField+" must be an array of strings")
 					return
 				}
-				categories := make([]string, 0, len(arr))
+				values := make([]string, 0, len(arr))
 				for _, raw := range arr {
 					s, ok := raw.(string)
 					if !ok {
-						writeError(w, http.StatusBadRequest, "categories must be an array of strings")
+						writeError(w, http.StatusBadRequest, jsonField+" must be an array of strings")
 						return
 					}
-					categories = append(categories, s)
+					values = append(values, s)
 				}
 				setCols = append(setCols, column)
-				setArgs = append(setArgs, db.FormatTags(categories))
-				nextCategories = categories
+				formatted := db.FormatTags(values)
+				if jsonField == "tags" && formatted == "" {
+					formatted = "[]"
+				}
+				setArgs = append(setArgs, formatted)
+				if jsonField == "categories" {
+					nextCategories = values
+				}
 			case "published_date":
 				s, ok := v.(string)
 				if !ok {

--- a/server/internal/models/types.go
+++ b/server/internal/models/types.go
@@ -153,6 +153,7 @@ type ArticleInput struct {
 	Content         string        `json:"content"`
 	Excerpt         string        `json:"excerpt,omitempty"`
 	Categories      []string      `json:"categories"`
+	Tags            []string      `json:"tags,omitempty"`
 	PhotoURL        string        `json:"photo_url"`
 	IsFeatured      bool          `json:"is_featured"`
 	BreakingNews    bool          `json:"breaking_news"`
@@ -169,6 +170,7 @@ type ArticlePatch struct {
 	Authors         *[]int64       `json:"authors,omitempty"`
 	Content         *string        `json:"content,omitempty"`
 	Categories      *[]string      `json:"categories,omitempty"`
+	Tags            *[]string      `json:"tags,omitempty"`
 	Excerpt         *string        `json:"excerpt,omitempty"`
 	PhotoURL        *string        `json:"photo_url,omitempty"`
 	IsFeatured      *bool          `json:"is_featured,omitempty"`


### PR DESCRIPTION
## Summary
- Hydrate article SEO tags from the API into the editor
- Add a comma-separated SEO Tags field and include tags in create/patch saves
- Persist article tags through the backend and cover create-time tag storage with tests

## Root Cause
The API returned database-backed SEO tags under seo.tags, but the editor did not hydrate or render that field, and article save payloads did not write articles.tags back to the database.

## Validation
- go test ./...
- npm run build