### PR TITLE
Make article images selectable, captionable and movable

### DIFF
--- a/frontend/src/components/TrixEditor.css
+++ b/frontend/src/components/TrixEditor.css
@@ -241,7 +241,22 @@ trix-editor.trix-content .attachment img {
   max-width: 100%;
   height: auto;
   border-radius: calc(var(--radius, 0.5rem) - 2px);
-  cursor: move;
+  /* `grab` rather than `move`: it reads as "pick this up", and pairs with the
+     `grabbing` cursor the drag handler sets on the body mid-drag. */
+  cursor: grab;
+  transition: outline-color 100ms ease-out;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+/* Hovering the image is the only hint that it can be picked up at all, so make
+   it visible before the author commits to a drag. */
+trix-editor.trix-content .attachment--preview:hover img {
+  outline-color: hsl(var(--border, 220 13% 91%));
+}
+
+trix-editor.trix-content .attachment.attachment--preview.attachment--dragging img {
+  cursor: grabbing;
 }
 
 /* Caption. Trix renders <figcaption class="attachment__caption">; when the
@@ -259,6 +274,41 @@ trix-editor.trix-content .attachment__caption {
 trix-editor.trix-content .attachment__caption .attachment__name,
 trix-editor.trix-content .attachment__caption .attachment__size {
   display: inline;
+}
+
+/* An image with no caption yet. Trix marks the empty <figcaption> with
+   data-trix-placeholder ("Add a caption…") but ships no CSS for it, so the
+   element collapses to zero height -- invisible, and with nothing to click.
+   Rendering the placeholder gives the author both the prompt and the target. */
+trix-editor.trix-content .attachment__caption[data-trix-placeholder]:empty::before {
+  content: attr(data-trix-placeholder);
+  opacity: 0.65;
+}
+
+/* Widen the hit area so the caption row is easy to land on, and say so with the
+   cursor. Sized to its own text rather than to the figure, which is full-bleed:
+   a hover highlight stretching the whole column would read as a selected
+   paragraph, not as a caption field. min-width keeps an empty one big enough to
+   aim at. */
+trix-editor.trix-content .attachment--preview .attachment__caption {
+  width: fit-content;
+  min-width: 14em;
+  max-width: 100%;
+  margin-inline: auto;
+  padding: 0.35em 0.6em;
+  border-radius: calc(var(--radius, 0.5rem) - 4px);
+  cursor: text;
+}
+
+trix-editor.trix-content .attachment--preview .attachment__caption:hover {
+  background: hsl(var(--muted, 220 14% 96%));
+}
+
+/* While editing, the caption is a textarea sized at width:100% of this box, so
+   fit-content would collapse it to nothing as soon as the text was cleared. */
+trix-editor.trix-content .attachment--preview .attachment__caption--editing {
+  width: min(100%, 32em);
+  background: hsl(var(--muted, 220 14% 96%));
 }
 
 trix-editor.trix-content .attachment__caption-editor {
@@ -285,6 +335,104 @@ trix-editor.trix-content .attachment__caption-editor::placeholder {
 trix-editor.trix-content .attachment.attachment--preview.attachment--selected img {
   outline: 2px solid hsl(var(--primary, 243 75% 59%));
   outline-offset: 2px;
+}
+
+/* ── Attachment toolbar (Remove, plus our move buttons) ──────────────────────
+   Trix floats this over the top edge of a selected attachment. It ships only
+   positioning, so without this the buttons are unstyled browser chrome sitting
+   on top of the image. Pulled fully above the image rather than overlapping it,
+   so it never covers the picture it belongs to. */
+
+trix-editor.trix-content .attachment__toolbar {
+  top: -2.4em;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button-row {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid hsl(var(--border, 220 13% 91%));
+  border-radius: var(--radius, 0.5rem);
+  background: hsl(var(--card, 0 0% 100%));
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.12);
+  pointer-events: auto;
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button-group {
+  display: inline-flex;
+  gap: 2px;
+  border: none;
+  margin: 0;
+}
+
+/* Separator between Trix's Remove group and our move group. */
+trix-editor.trix-content .attachment__toolbar .trix-button-group + .trix-button-group {
+  margin-left: 4px;
+  padding-left: 5px;
+  border-left: 1px solid hsl(var(--border, 220 13% 91%));
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button {
+  float: none;
+  border: none;
+  background: transparent;
+  color: hsl(var(--foreground, 224 71% 4%));
+  font-size: 12px;
+  font-family: inherit;
+  line-height: 1;
+  padding: 0 8px;
+  min-width: 26px;
+  height: 26px;
+  border-radius: calc(var(--radius, 0.5rem) - 3px);
+  cursor: pointer;
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button:hover:not(:disabled) {
+  background: hsl(var(--muted, 220 14% 96%));
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button--move {
+  font-size: 14px;
+}
+
+/* Trix also hangs a filename/filesize pill off the toolbar. Ours carry no
+   filesize and a filename the author never chose, so it renders as a small
+   dark blob sitting on the corner of the image with nothing legible in it. */
+trix-editor.trix-content .attachment__toolbar .attachment__metadata-container {
+  display: none;
+}
+
+/* Remove. Trix draws this as a white circle with a 2px `highlight` (system
+   accent) border and hides the text label behind text-indent, showing an ✕ via
+   a ::before background image. Keep the icon -- undoing the text-indent would
+   leave the button empty -- and drop only the standalone-circle chrome, which
+   looks wrong now that it sits inside a grouped toolbar. */
+trix-editor.trix-content .attachment__toolbar .trix-button--remove {
+  position: relative;
+  width: 26px;
+  padding: 0;
+  border: none;
+  border-radius: calc(var(--radius, 0.5rem) - 3px);
+  background-color: transparent;
+  box-shadow: none;
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button--remove::before {
+  background-size: 64%;
+  opacity: 0.75;
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button--remove:hover {
+  border-color: transparent;
+  background-color: hsl(var(--destructive, 0 72% 51%) / 0.12);
 }
 
 /* Drag-in-progress state on the source figure. */

--- a/frontend/src/components/TrixEditor.css
+++ b/frontend/src/components/TrixEditor.css
@@ -403,6 +403,16 @@ trix-editor.trix-content .attachment__toolbar .trix-button--move {
   font-size: 14px;
 }
 
+trix-editor.trix-content .attachment__toolbar .trix-button--copy-url .trix-icon {
+  width: 14px;
+  height: 14px;
+}
+
+/* Confirmation tick, matching "Copy article link" going green on success. */
+trix-editor.trix-content .attachment__toolbar .trix-button--copied {
+  color: hsl(var(--primary, 243 75% 59%));
+}
+
 /* Trix also hangs a filename/filesize pill off the toolbar. Ours carry no
    filesize and a filename the author never chose, so it renders as a small
    dark blob sitting on the corner of the image with nothing legible in it. */

--- a/frontend/src/components/TrixEditor.tsx
+++ b/frontend/src/components/TrixEditor.tsx
@@ -12,11 +12,14 @@ import {
   trixHtmlToArticle,
 } from "./trixImageHtml"
 
-// Show the filename in the auto-generated caption under attachments, but hide
-// the file size this matches the upstream Trix demo's defaults and gives users an
-// editable caption field below each image.
+// Leave the caption area of an image empty until it has a real caption. Trix's
+// default is to fill it with the filename and file size, which reads as a
+// caption the author didn't write, and -- because the slot is then never empty
+// -- suppresses the "Add a caption…" placeholder that tells them it is editable.
+// Non-previewable file attachments are unaffected: Trix forces the name on for
+// those, and a file stub with no label would be nothing at all.
 if (typeof window !== "undefined" && window.Trix) {
-  window.Trix.config.attachments.preview.caption.name = true
+  window.Trix.config.attachments.preview.caption.name = false
   window.Trix.config.attachments.preview.caption.size = false
 }
 
@@ -160,7 +163,11 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
         }
         try {
           const { url } = JSON.parse(xhr.responseText) as { url: string }
-          attachment.setAttributes({ url, href: url })
+          // href only for non-images. Trix wraps an attachment carrying an href
+          // in an <a>, which for a previewable image swallows every click on the
+          // figure -- including the caption field. A file stub, by contrast, has
+          // nothing to edit and a download link is the whole point of it.
+          attachment.setAttributes(file.type.startsWith("image/") ? { url } : { url, href: url })
           attachment.setUploadProgress(100)
         } catch {
           failAttachment(attachment, `Could not add ${file.name}: unexpected server response.`)
@@ -202,7 +209,8 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
           return (await response.json()) as { url: string }
         })
         .then(({ url }) => {
-          attachment.setAttributes({ url, href: url })
+          // No href: this path only ever handles pasted images. See uploadFile.
+          attachment.setAttributes({ url })
           attachment.setUploadProgress(100)
         })
         .catch((err: unknown) => {
@@ -253,9 +261,11 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       savedRangeRef.current = null
     }
 
+    // Deliberately no href -- see uploadFile. The saved article is a plain
+    // <figure><img> either way, so the link would only ever have existed inside
+    // the editor, where it fights with selecting and captioning the image.
     const attachment = new Trix.Attachment({
       url: item.url,
-      href: item.url,
       contentType: item.mime_type || contentTypeForUrl(item.url),
       filename: item.alt_text || item.file_name,
       alt: item.alt_text ?? "",
@@ -356,54 +366,114 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       dropIndicator.style.width = `${indicatorWidth.toString()}px`
     }
 
-    // Move the attachment via Trix's editor API. Strategy:
-    //   1. Clone the figure, stripping the stale data-trix-id so Trix mints a
-    //      fresh attachment on insert rather than colliding with the live
-    //      attachment we're about to remove. data-trix-attributes is left
-    //      untouched, which is what carries any pre-existing alignment through
-    //      the move intact.
-    //   2. Capture a DOM Range anchored on the target block BEFORE removing
-    //      the source. Trix's remove() can collapse or detach adjacent empty
-    //      blocks, which would invalidate setStartBefore/After afterwards.
-    //   3. Focus the editor BEFORE applying the selection. Focusing a
-    //      contenteditable that isn't currently focused resets the caret to
-    //      its last internal position, which would blow away our range.
-    //   4. Then remove the attachment, apply the captured range, and insert.
-    const commitMove = (figure: HTMLElement, target: DropTarget) => {
-      const trixId = figure.getAttribute("data-trix-id")
-      if (!trixId) return
-      const attachment = editor.editor.getDocument().getAttachments().find((a) => String(a.id) === trixId)
-      if (!attachment) return
-      if (!target.block.isConnected) return
-      // Dropping onto the figure's own block moves nothing. With alignment gone
-      // there is no longer any secondary effect to apply, so this is a no-op --
-      // and skipping it avoids a needless remove/reinsert of the attachment.
-      if (target.block.contains(figure)) return
-
-      const clone = figure.cloneNode(true) as HTMLElement
-      clone.removeAttribute("data-trix-id")
-      const html = clone.outerHTML
-
-      const range = document.createRange()
-      if (target.insertBefore) range.setStartBefore(target.block)
-      else range.setStartAfter(target.block)
-      range.collapse(true)
-
-      editor.focus()
-      attachment.remove()
-
-      if (target.block.isConnected) {
-        const selection = window.getSelection()
-        selection?.removeAllRanges()
-        selection?.addRange(range)
-      }
-
-      editor.editor.insertHTML(html)
-      editor.dispatchEvent(new Event("input", { bubbles: true }))
+    // The top-level child of the editor that contains this figure. Trix renders
+    // one element per document block, so these are the units a move reorders.
+    const blockContaining = (node: HTMLElement): HTMLElement | null => {
+      let current: HTMLElement = node
+      while (current.parentElement && current.parentElement !== editor) current = current.parentElement
+      return current.parentElement === editor ? current : null
     }
 
+    // Put an attachment into Trix's "being edited" state -- the state that
+    // shows its caption field and its toolbar. Trix only enters it from a
+    // mousedown of its own, which is no help either when that mousedown's
+    // selection gets reset (see onUp) or after a move has replaced the element.
+    const editAttachmentForFigure = (figure: Element | null | undefined) => {
+      const trixId = figure?.getAttribute("data-trix-id")
+      if (!trixId) return
+      const attachment = editor.editor
+        .getDocument()
+        .getAttachments()
+        .find((a) => String(a.id) === trixId)
+      if (attachment) editor.editor.composition.editAttachment(attachment)
+    }
+
+    // Move the figure's whole block to sit before or after the target block.
+    //
+    // This reorders Trix's serialized HTML and reloads it, rather than splicing
+    // the live document through Trix's mutation APIs. The obvious approach --
+    // remove the attachment, then insert it at a captured DOM Range -- cannot
+    // work: the Attachment objects on editor.getDocument() are plain models
+    // with no remove() of their own (only the ManagedAttachment passed to
+    // trix-attachment-add has one), and any removal re-renders the blocks the
+    // captured Range was anchored to. Reordering the serialization sidesteps
+    // both problems and is order-of-blocks-in, order-of-blocks-out.
+    //
+    // The cost is that a move is one undo step that restores the whole document
+    // rather than a fine-grained edit, which for a whole-block move is what the
+    // author would expect to get back anyway.
+    const commitMove = (figure: HTMLElement, target: DropTarget) => {
+      // Re-resolve the figure by id. The one handed to us may already be
+      // detached: selecting an attachment -- which Trix does on the very
+      // mousedown that starts a drag -- re-renders it, so by the time the drag
+      // ends the element captured at the start is a corpse, and every drop
+      // silently did nothing.
+      const trixId = figure.getAttribute("data-trix-id")
+      const live = figure.isConnected
+        ? figure
+        : trixId
+          ? editor.querySelector<HTMLElement>(`[data-trix-id="${trixId}"]`)
+          : null
+      if (!live) return
+
+      const sourceBlock = blockContaining(live)
+      if (!sourceBlock || !target.block.isConnected) return
+      if (target.block === sourceBlock) return
+
+      const liveBlocks = Array.from(editor.children) as HTMLElement[]
+      const from = liveBlocks.indexOf(sourceBlock)
+      const to = liveBlocks.indexOf(target.block)
+      if (from < 0 || to < 0) return
+
+      const serialized = Array.from(
+        new DOMParser().parseFromString(editor.value, "text/html").body.children,
+      )
+      // The serialized blocks line up with the rendered ones by index. If that
+      // ever stops holding, bail rather than reorder the wrong block.
+      if (serialized.length !== liveBlocks.length) return
+
+      // Where the block lands once it has been lifted out of the list.
+      let insertAt = target.insertBefore ? to : to + 1
+      if (from < insertAt) insertAt -= 1
+      if (insertAt === from) return
+
+      const [moved] = serialized.splice(from, 1)
+      serialized.splice(insertAt, 0, moved)
+
+      // Take the attachment editor down before swapping the document out from
+      // under it. Its controller holds a reference to the figure it was
+      // installed on; reloading leaves it pointing at a detached element and
+      // Trix's own click handling then throws on the next click on any image
+      // (getRangeOfAttachment on an attachment the document no longer has).
+      editor.editor.composition.stopEditingAttachment()
+      editor.editor.loadHTML(serialized.map((block) => block.outerHTML).join(""))
+
+      // Re-select the image at its new home. Without this every nudge costs the
+      // author the selection -- and with it the toolbar they are clicking --
+      // so moving an image three blocks would mean three round trips to it.
+      //
+      // Two frames, not one. One frame is enough for the element to exist, but
+      // not for Trix to have finished rendering the reloaded document, and
+      // re-installing the attachment editor into that half-settled state leaves
+      // its element-to-attachment mapping stale: the next DOM mutation anywhere
+      // in the editor makes Trix re-parse into a document whose attachments no
+      // longer match the data-trix-id attributes still on the figures, and from
+      // then on every click on an image throws inside Trix. The alignment
+      // effect above mutates figure classes on each change, so this is a
+      // reachable state, not a theoretical one.
+      requestAnimationFrame(() => { requestAnimationFrame(() => {
+        if (!editor.isConnected) return
+        editAttachmentForFigure(editor.children[insertAt]?.querySelector("[data-trix-id]"))
+      }) })
+    }
+
+    // Note the absence of preventDefault on the mousedown itself. Suppressing
+    // the default is what a drag needs (it stops the browser turning the
+    // gesture into a text selection), but on a plain click it also blocks the
+    // native focus/selection that Trix uses to select the attachment and raise
+    // its caption field and toolbar. So the default is left alone until the
+    // pointer has actually travelled far enough to be a drag.
     const beginDrag = (figure: HTMLElement, downEvent: MouseEvent) => {
-      downEvent.preventDefault()
       const startX = downEvent.clientX
       const startY = downEvent.clientY
       let dragging = false
@@ -413,6 +483,9 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
         dragging = true
         figure.classList.add("attachment--dragging")
         document.body.style.cursor = "grabbing"
+        // Drop whatever text selection the un-prevented mousedown started, so
+        // the drag doesn't paint a selection highlight across the article.
+        window.getSelection()?.removeAllRanges()
       }
 
       const onMove = (moveEvent: MouseEvent) => {
@@ -422,6 +495,9 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
           if (dx < DRAG_THRESHOLD_PX && dy < DRAG_THRESHOLD_PX) return
           enterDragMode()
         }
+        // Now that this is a drag, keep the browser from extending a text
+        // selection under the pointer.
+        moveEvent.preventDefault()
 
         const block = findBlockAt(moveEvent.clientY)
         if (!block) {
@@ -451,11 +527,15 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
         if (dragging && dropTarget) {
           commitMove(figure, dropTarget)
         } else if (!dragging) {
-          // Treat as a plain click: select the figure and restore focus so
-          // subsequent keyboard input still lands in the editor (our
-          // preventDefault on mousedown blocked the native focus path).
           selectFigure(figure)
-          editor.focus()
+          // Re-assert Trix's own attachment selection. Trix makes it on
+          // mousedown, but when the click is what focuses the editor in the
+          // first place, the focus that follows resets the selection and takes
+          // the attachment toolbar back down with it -- so the first click on
+          // an image in a freshly loaded editor appeared to do nothing, and it
+          // took a second click to get at Remove or the move buttons. Trix
+          // ignores this when the attachment is already the one being edited.
+          editAttachmentForFigure(figure)
         }
       }
 
@@ -464,11 +544,21 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       activeGestureCleanup = cleanup
     }
 
+    // Trix's own attachment chrome: the caption (static <figcaption>, and the
+    // <textarea> that replaces it while editing) and the floating toolbar that
+    // carries Remove. These have to keep their native mousedown, because that
+    // is the event Trix uses to select the attachment and focus the caption
+    // field. Running beginDrag over them instead -- it calls preventDefault,
+    // and its mouseup pulls focus back to the editor body -- is what made the
+    // caption impossible to click into.
+    const TRIX_ATTACHMENT_CHROME = "figcaption, .attachment__caption, .attachment__toolbar"
+
     // ── Selection / drag entry point (capture phase so Trix can't preempt) ──
     const onEditorMouseDown = (event: MouseEvent) => {
       const target = event.target as HTMLElement
       const figure = target.closest(".attachment--preview") as HTMLElement | null
       if (!figure) return
+      if (target.closest(TRIX_ATTACHMENT_CHROME)) return
       beginDrag(figure, event)
     }
     const onDocumentMouseDown = (event: MouseEvent) => {
@@ -479,6 +569,61 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       selectFigure(null)
     }
 
+    // ── Move buttons on the attachment toolbar ─────────────────────────────
+    // Dragging is workable in a short article and miserable in a long one,
+    // where the drop target is off screen and the page has to auto-scroll.
+    // These step the image over one block at a time, need no aim, and are the
+    // only way to move an image without a mouse. They ride along on the toolbar
+    // Trix already shows over a selected attachment, next to Remove.
+
+    const siblingBlock = (figure: HTMLElement, direction: "up" | "down"): HTMLElement | null => {
+      const block = blockContaining(figure)
+      const sibling = direction === "up" ? block?.previousElementSibling : block?.nextElementSibling
+      return sibling instanceof HTMLElement ? sibling : null
+    }
+
+    const onBeforeToolbar = (event: Event) => {
+      const { toolbar, attachment } = event as TrixAttachmentToolbarEvent
+      const figure = editor.querySelector<HTMLElement>(`[data-trix-id="${String(attachment.id)}"]`)
+      // Only previewable attachments are positioned as their own block; a file
+      // stub sits inline in a paragraph, where "move up a block" is meaningless.
+      if (!figure?.classList.contains("attachment--preview")) return
+
+      const group = document.createElement("span")
+      group.className = "trix-button-group trix-button-group--move"
+
+      for (const direction of ["up", "down"] as const) {
+        const button = document.createElement("button")
+        button.type = "button"
+        button.className = `trix-button trix-button--move trix-button--move-${direction}`
+        button.title = direction === "up" ? "Move image up" : "Move image down"
+        button.textContent = direction === "up" ? "↑" : "↓"
+        // Nothing to swap with at the top or bottom of the document.
+        button.disabled = !siblingBlock(figure, direction)
+        // Suppress mousedown so pressing the button doesn't collapse the
+        // attachment selection (and tear down this very toolbar) before the
+        // click lands.
+        button.addEventListener("mousedown", (mouseEvent) => { mouseEvent.preventDefault() })
+        button.addEventListener("click", (clickEvent) => {
+          clickEvent.preventDefault()
+          const target = siblingBlock(figure, direction)
+          if (target) commitMove(figure, { block: target, insertBefore: direction === "up" })
+        })
+        group.appendChild(button)
+      }
+
+      toolbar.querySelector(".trix-button-row")?.appendChild(group)
+    }
+
+    // With the mousedown default no longer suppressed, the browser is free to
+    // start its own native image drag, which would race our rearrange gesture
+    // and can drop the image into another window entirely.
+    const onDragStart = (event: DragEvent) => {
+      if ((event.target as HTMLElement | null)?.closest(".attachment--preview")) event.preventDefault()
+    }
+
+    editor.addEventListener("dragstart", onDragStart)
+    editor.addEventListener("trix-attachment-before-toolbar", onBeforeToolbar)
     editor.addEventListener("mousedown", onEditorMouseDown, true)
     document.addEventListener("mousedown", onDocumentMouseDown)
 
@@ -486,6 +631,8 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       // Abort any in-progress drag so we don't leave document-level
       // listeners or a stuck `grabbing` cursor behind on unmount.
       if (activeGestureCleanup) activeGestureCleanup()
+      editor.removeEventListener("dragstart", onDragStart)
+      editor.removeEventListener("trix-attachment-before-toolbar", onBeforeToolbar)
       editor.removeEventListener("mousedown", onEditorMouseDown, true)
       document.removeEventListener("mousedown", onDocumentMouseDown)
       dropIndicator.remove()
@@ -503,6 +650,12 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       const target = event.target as HTMLElement | null
       const link = target?.closest("a")
       if (!link || !editor.contains(link)) return
+      // An image preview is something you edit, not something you follow. Trix
+      // wraps an attachment that has an href in an <a> spanning the whole
+      // figure, so navigating here would make the image and its caption field
+      // unclickable. Attachments we create no longer set href, but content
+      // saved before that -- or pasted as <a><img></a> -- still can.
+      if (link.closest(".attachment--preview")) return
       const href = link.getAttribute("href")
       if (!href) return
       event.preventDefault()

--- a/frontend/src/components/TrixEditor.tsx
+++ b/frontend/src/components/TrixEditor.tsx
@@ -3,6 +3,7 @@ import "trix"
 import "trix/dist/trix.css"
 import "./TrixEditor.css"
 import { apiBaseUrl } from "../auth/urls"
+import { copyText } from "../lib/clipboard"
 import MediaPicker, { type MediaPickerItem } from "./MediaPicker"
 import {
   ALIGNMENTS,
@@ -22,6 +23,36 @@ if (typeof window !== "undefined" && window.Trix) {
   window.Trix.config.attachments.preview.caption.name = false
   window.Trix.config.attachments.preview.caption.size = false
 }
+
+// The attachment toolbar is built by Trix as plain DOM, not by React, so its
+// icons are hand-built SVG rather than the lucide components used elsewhere.
+// These are lucide's own Copy and Check paths, so the button reads the same as
+// "Copy article link" in the editor header.
+const svgIcon = (paths: string[]): SVGSVGElement => {
+  const ns = "http://www.w3.org/2000/svg"
+  const svg = document.createElementNS(ns, "svg")
+  svg.setAttribute("viewBox", "0 0 24 24")
+  svg.setAttribute("fill", "none")
+  svg.setAttribute("stroke", "currentColor")
+  svg.setAttribute("stroke-width", "2")
+  svg.setAttribute("stroke-linecap", "round")
+  svg.setAttribute("stroke-linejoin", "round")
+  svg.setAttribute("aria-hidden", "true")
+  svg.classList.add("trix-icon")
+  for (const d of paths) {
+    const path = document.createElementNS(ns, "path")
+    path.setAttribute("d", d)
+    svg.appendChild(path)
+  }
+  return svg
+}
+
+const copyIcon = () => svgIcon([
+  "M20 9h-9a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2v-9a2 2 0 0 0-2-2z",
+  "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1",
+])
+
+const checkIcon = () => svgIcon(["M20 6 9 17l-5-5"])
 
 // Hosts we may embed directly. A pasted image already served from our own media
 // infrastructure needs no sideload — it is the same file we would be copying.
@@ -610,6 +641,47 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
           if (target) commitMove(figure, { block: target, insertBefore: direction === "up" })
         })
         group.appendChild(button)
+      }
+
+      // Copy the image's URL, matching the "Copy article link" button in the
+      // editor header: same clipboard helper (which falls back to execCommand,
+      // since the CMS is served over plain HTTP where navigator.clipboard does
+      // not exist) and the same swap-to-a-tick confirmation.
+      const url = typeof attachment.getAttribute("url") === "string" ? String(attachment.getAttribute("url")) : ""
+      if (url) {
+        const copyGroup = document.createElement("span")
+        copyGroup.className = "trix-button-group trix-button-group--copy"
+
+        const copyButton = document.createElement("button")
+        copyButton.type = "button"
+        copyButton.className = "trix-button trix-button--copy-url"
+        copyButton.title = `Copy image URL (${url})`
+        copyButton.appendChild(copyIcon())
+
+        let resetIcon: number | undefined
+        copyButton.addEventListener("mousedown", (mouseEvent) => { mouseEvent.preventDefault() })
+        copyButton.addEventListener("click", (clickEvent) => {
+          clickEvent.preventDefault()
+          void copyText(url).then((copied) => {
+            if (!copied) {
+              setNotice("Could not copy the image URL. Your browser blocked clipboard access.")
+              return
+            }
+            copyButton.replaceChildren(checkIcon())
+            copyButton.classList.add("trix-button--copied")
+            window.clearTimeout(resetIcon)
+            resetIcon = window.setTimeout(() => {
+              // The toolbar is torn down whenever the image is deselected, so
+              // by the time this fires the button may be long gone.
+              if (!copyButton.isConnected) return
+              copyButton.replaceChildren(copyIcon())
+              copyButton.classList.remove("trix-button--copied")
+            }, 1500)
+          })
+        })
+
+        copyGroup.appendChild(copyButton)
+        toolbar.querySelector(".trix-button-row")?.appendChild(copyGroup)
       }
 
       toolbar.querySelector(".trix-button-row")?.appendChild(group)

--- a/frontend/src/trix.d.ts
+++ b/frontend/src/trix.d.ts
@@ -36,7 +36,18 @@ declare global {
     getAttachments(): TrixAttachment[]
   }
 
+  // Not part of Trix's documented editor API, but the only way to put an
+  // attachment back into its "being edited" state (caption field + attachment
+  // toolbar) from code. Trix itself only ever enters that state from a mousedown
+  // on the figure, which is no use after we move an attachment and the original
+  // element is gone.
+  interface TrixComposition {
+    editAttachment(attachment: TrixAttachment, options?: { editCaption?: boolean }): void
+    stopEditingAttachment(): void
+  }
+
   interface TrixEditorInternal {
+    composition: TrixComposition
     loadHTML(html: string): void
     getDocument(): TrixDocument
     getSelectedRange(): [number, number]
@@ -64,6 +75,14 @@ declare global {
   }
 
   interface TrixAttachmentAddEvent extends Event {
+    attachment: TrixAttachment
+  }
+
+  // Fired while Trix is building the little toolbar that floats over a selected
+  // attachment, before it is inserted -- our hook for adding buttons of our own
+  // next to Trix's built-in Remove.
+  interface TrixAttachmentToolbarEvent extends Event {
+    toolbar: HTMLElement
     attachment: TrixAttachment
   }
 }


### PR DESCRIPTION
Clicking an image in the article editor — or anywhere near it — opened it in a new tab instead of selecting it, which made the caption and the image itself effectively uneditable.

## The cause

Attachments were created with `href` set to their own URL. Trix wraps an attachment carrying an `href` in an `<a>` spanning the whole figure, caption row included, and the editor's link handler then navigated on any click inside it. The `href` was never reachable in output either — `trixHtmlToArticle` only ever emits `<figure><img>`, never an anchor.

It is now set only for non-previewable file attachments, where a download link is the point, and the link handler ignores links inside an attachment preview so content saved before this change behaves too.

## What else this surfaced

With clicks reaching Trix again, three further problems showed up under a browser. Two were pre-existing:

- **Drag-to-rearrange never worked.** `commitMove` called `attachment.remove()`, which does not exist on the `Attachment` models `getDocument()` returns — only on the `ManagedAttachment` passed to `trix-attachment-add`. Every drop threw. Moves now reorder the serialized blocks and reload, and re-resolve the figure by id, since selecting an attachment re-renders the element captured when the drag began.
- **The first click on an image did nothing visible.** The drag handler's blanket `preventDefault` on mousedown, plus a refocus on mouseup, cancelled the selection Trix makes on mousedown, so reaching Remove took two clicks. The default is now suppressed only once the pointer has moved far enough to be a drag.
- **Re-selecting after a move needs two frames, not one.** At one frame Trix has not finished rendering the reloaded document, and re-installing the attachment editor into that state leaves its element-to-attachment mapping stale: the next DOM mutation anywhere in the editor makes Trix re-parse into a document whose attachments no longer match the `data-trix-id` attributes still on the figures, and from then on *every* click on an image throws inside Trix. The alignment effect in this same component mutates figure classes on each change, so this was reachable, not theoretical.

## Ergonomics

- **Move up/down buttons** on Trix's attachment toolbar — no aim required, and they work when the drop target is off screen. Disabled at the top and bottom of the document.
- **A copy-image-URL button**, mirroring "Copy article link" in the editor header: same `copyText` helper (which falls back to `execCommand`, since the CMS is served over plain HTTP where `navigator.clipboard` is undefined) and the same swap-to-a-tick confirmation.
- **Captions read as editable.** Trix sets a `data-trix-placeholder` on an empty `figcaption` but ships no CSS for it, so an uncaptioned image had a zero-height caption with nothing to click. It now shows "Add a caption…", and the auto-filled filename that masqueraded as a caption is off.
- The attachment toolbar and Trix's Remove button are styled to the design system; Trix's empty filename/filesize pill, which rendered as a dark blob on the corner of the image, is hidden.

## Testing

Driven in Chromium against a throwaway harness mounting `TrixEditor` directly — there is no login-free path to the authed editor, so this was not run against a live CMS. Verified: no new tab on any click; caption editable on both a captioned and an uncaptioned image; move up/down including repeated presses without re-selecting, plus disabled states at both ends; drag-to-rearrange; Remove; copy button for both a path and a data URL; and no page errors across the whole sequence.

`tsc -b`, `eslint`, and `vite build` are clean (the one remaining lint warning is pre-existing, in `editArticleView.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)