### PR TITLE
Make moving an image undoable

### DIFF
--- a/frontend/src/components/TrixEditor.tsx
+++ b/frontend/src/components/TrixEditor.tsx
@@ -430,9 +430,9 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
     // captured Range was anchored to. Reordering the serialization sidesteps
     // both problems and is order-of-blocks-in, order-of-blocks-out.
     //
-    // The cost is that a move is one undo step that restores the whole document
-    // rather than a fine-grained edit, which for a whole-block move is what the
-    // author would expect to get back anyway.
+    // A move is one undo step that restores the whole document rather than a
+    // fine-grained edit, which for a whole-block move is what the author would
+    // expect to get back anyway.
     const commitMove = (figure: HTMLElement, target: DropTarget) => {
       // Re-resolve the figure by id. The one handed to us may already be
       // detached: selecting an attachment -- which Trix does on the very
@@ -477,7 +477,21 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       // Trix's own click handling then throws on the next click on any image
       // (getRangeOfAttachment on an attachment the document no longer has).
       editor.editor.composition.stopEditingAttachment()
-      editor.editor.loadHTML(serialized.map((block) => block.outerHTML).join(""))
+
+      // Swap the document in under a recorded undo entry, rather than through
+      // loadHTML. loadHTML routes to Editor#loadSnapshot, which replaces the
+      // whole UndoManager -- so a move was not merely un-undoable, it silently
+      // threw away every undo step the author had built up before it.
+      // recordUndoEntry snapshots the current document and selection onto the
+      // stack, and Composition#setDocument then mutates without disturbing it.
+      const Trix = window.Trix
+      if (!Trix) return
+      const movedDocument = Trix.HTMLParser.parse(serialized.map((block) => block.outerHTML).join(""), {
+        referenceElement: editor,
+      }).getDocument()
+
+      editor.editor.recordUndoEntry("Move Image")
+      editor.editor.composition.setDocument(movedDocument)
 
       // Re-select the image at its new home. Without this every nudge costs the
       // author the selection -- and with it the toolbar they are clicking --

--- a/frontend/src/trix.d.ts
+++ b/frontend/src/trix.d.ts
@@ -29,6 +29,12 @@ declare global {
         }
       }
       Attachment: new (attributes: TrixAttachmentAttributes) => TrixAttachment
+      // Trix re-exports its internal models on the global. HTMLParser is how a
+      // Document is built from HTML without going through Editor#loadHTML,
+      // which would reset the undo stack.
+      HTMLParser: {
+        parse(html: string, options?: { referenceElement?: Element }): { getDocument(): TrixDocument }
+      }
     }
   }
 
@@ -44,11 +50,16 @@ declare global {
   interface TrixComposition {
     editAttachment(attachment: TrixAttachment, options?: { editCaption?: boolean }): void
     stopEditingAttachment(): void
+    // Replaces the document in place. Unlike Editor#loadHTML / loadSnapshot,
+    // this leaves the UndoManager alone, so a caller that has recorded its own
+    // undo entry stays undoable.
+    setDocument(document: TrixDocument): void
   }
 
   interface TrixEditorInternal {
     composition: TrixComposition
     loadHTML(html: string): void
+    recordUndoEntry(description: string, options?: { context?: unknown; consolidatable?: boolean }): void
     getDocument(): TrixDocument
     getSelectedRange(): [number, number]
     setSelectedRange(range: [number, number] | number): void


### PR DESCRIPTION
Ctrl+Z did not undo an image move.

## Cause

`commitMove` swapped the reordered document in with `Editor#loadHTML`, which routes to `Editor#loadSnapshot`:

```js
loadSnapshot(snapshot) {
  this.undoManager = new UndoManager(this.composition);   // ← whole stack discarded
  return this.composition.loadSnapshot(snapshot);
}
```

So a move was not merely un-undoable — it silently threw away **every undo step the author had accumulated before it**, for the rest of the session. Moving an image meant losing the ability to undo the paragraph you wrote five minutes earlier.

## Fix

Parse the reordered blocks into a document directly via `Trix.HTMLParser`, record an undo entry, and apply it with `Composition#setDocument`, which mutates in place and leaves the `UndoManager` untouched:

```ts
const movedDocument = Trix.HTMLParser.parse(html, { referenceElement: editor }).getDocument()
editor.editor.recordUndoEntry("Move Image")
editor.editor.composition.setDocument(movedDocument)
```

Undo then restores through `Composition#loadSnapshot` — the composition method, not the `Editor` method of the same name that resets the stack — so history survives.

## Testing

Driven in Chromium against a throwaway harness mounting `TrixEditor` directly (no login-free path to the authed editor). Typing a marker, moving an image, then undoing twice:

```
1. after typing: [..., "IMG<Alpha>", "Second paragraph…", "IMG<Bravo>", "Third paragraph, last block. MARKER"]
2. after move:   [..., "Second paragraph…", "IMG<Alpha>", "IMG<Bravo>", "Third paragraph, last block. MARKER"]
3. undo #1:      [..., "IMG<Alpha>", "Second paragraph…", "IMG<Bravo>", "Third paragraph, last block. MARKER"]
4. undo #2:      [..., "IMG<Alpha>", "Second paragraph…", "IMG<Bravo>", "Third paragraph, last block."]
```

Undo #1 restores the image's original position with the earlier typing intact; undo #2 reaches back past the move into that earlier edit. Redo returns both.

Re-ran the full image-editing suite against the new mutation path — move up/down including repeated presses and disabled edge states, drag-to-rearrange, caption editing on captioned and uncaptioned images, Remove, copy-URL, and the document/DOM attachment-id sync check that guards the click-crash fixed in #165. All pass, no page errors. `tsc -b` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)