### PR TITLE
Open poll management to editors

### DIFF
--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -2839,7 +2839,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Editor-facing listing. Separate from GET /v1/polls so unpublished questions are never reachable without admin auth.",
+                "description": "Editor-facing listing. Separate from GET /v1/polls so unpublished questions are never reachable without auth.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -2836,7 +2836,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Editor-facing listing. Separate from GET /v1/polls so unpublished questions are never reachable without admin auth.",
+                "description": "Editor-facing listing. Separate from GET /v1/polls so unpublished questions are never reachable without auth.",
                 "produces": [
                     "application/json"
                 ],

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -3124,7 +3124,7 @@ paths:
   /v1/polls/manage:
     get:
       description: Editor-facing listing. Separate from GET /v1/polls so unpublished
-        questions are never reachable without admin auth.
+        questions are never reachable without auth.
       parameters:
       - description: Max polls to return (default 50, max 200)
         in: query

--- a/server/internal/handlers/poll_handlers.go
+++ b/server/internal/handlers/poll_handlers.go
@@ -344,7 +344,7 @@ func GetPolls(conn *sql.DB) http.Handler {
 }
 
 // @Summary List all polls including drafts
-// @Description Editor-facing listing. Separate from GET /v1/polls so unpublished questions are never reachable without admin auth.
+// @Description Editor-facing listing. Separate from GET /v1/polls so unpublished questions are never reachable without auth.
 // @Tags poll
 // @Produce json
 // @Param limit query int false "Max polls to return (default 50, max 200)"

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -110,24 +110,26 @@ func Register(mux *http.ServeMux, conn *sql.DB, verifier *oidc.IDTokenVerifier, 
 	mux.Handle("GET /v1/poll/options", handlers.GetPollOptions(conn))
 
 	// Poll archive. GET /v1/polls is public and hides drafts; the editor-facing
-	// listing that includes them is a separate admin-gated path.
+	// listing that includes them is a separate authenticated path.
 	mux.Handle("GET /v1/polls", handlers.GetPolls(conn))
 	mux.Handle("GET /v1/polls/{id}", handlers.GetPollByID(conn))
 	mux.Handle("GET /v1/developing-stories", handlers.GetDevelopingStories(conn))
 	mux.Handle("GET /v1/taxonomy", handlers.GetTaxonomy(conn))
 	mux.Handle("GET /v1/taxonomy/{type}/{slug}", handlers.GetTaxonomyItem(conn))
-	mux.Handle("PATCH /v1/poll/title", authMW(adminOnly(handlers.PatchPollTitle(conn))))
-	mux.Handle("POST /v1/poll/options", authMW(adminOnly(handlers.PostPollOption(conn))))
-	mux.Handle("PATCH /v1/poll/options", authMW(adminOnly(handlers.PatchPollOption(conn))))
-	mux.Handle("DELETE /v1/poll/options", authMW(adminOnly(handlers.DeletePollOption(conn))))
+	// Running the poll is part of editorial work, not site administration, so
+	// authoring and moderating questions is open to any signed-in editor.
+	mux.Handle("PATCH /v1/poll/title", authMW(handlers.PatchPollTitle(conn)))
+	mux.Handle("POST /v1/poll/options", authMW(handlers.PostPollOption(conn)))
+	mux.Handle("PATCH /v1/poll/options", authMW(handlers.PatchPollOption(conn)))
+	mux.Handle("DELETE /v1/poll/options", authMW(handlers.DeletePollOption(conn)))
 	// "manage" is a literal segment, so Go's mux prefers it over /v1/polls/{id}.
-	mux.Handle("GET /v1/polls/manage", authMW(adminOnly(handlers.GetPollsManage(conn))))
-	mux.Handle("POST /v1/polls", authMW(adminOnly(handlers.PostPollRecord(conn))))
-	mux.Handle("PATCH /v1/polls/{id}", authMW(adminOnly(handlers.PatchPollRecord(conn))))
-	mux.Handle("DELETE /v1/polls/{id}", authMW(adminOnly(handlers.DeletePollRecord(conn))))
-	mux.Handle("POST /v1/polls/{id}/options", authMW(adminOnly(handlers.PostPollRecordOption(conn))))
-	mux.Handle("PATCH /v1/polls/{id}/options/{option_id}", authMW(adminOnly(handlers.PatchPollRecordOption(conn))))
-	mux.Handle("DELETE /v1/polls/{id}/options/{option_id}", authMW(adminOnly(handlers.DeletePollRecordOption(conn))))
+	mux.Handle("GET /v1/polls/manage", authMW(handlers.GetPollsManage(conn)))
+	mux.Handle("POST /v1/polls", authMW(handlers.PostPollRecord(conn)))
+	mux.Handle("PATCH /v1/polls/{id}", authMW(handlers.PatchPollRecord(conn)))
+	mux.Handle("DELETE /v1/polls/{id}", authMW(handlers.DeletePollRecord(conn)))
+	mux.Handle("POST /v1/polls/{id}/options", authMW(handlers.PostPollRecordOption(conn)))
+	mux.Handle("PATCH /v1/polls/{id}/options/{option_id}", authMW(handlers.PatchPollRecordOption(conn)))
+	mux.Handle("DELETE /v1/polls/{id}/options/{option_id}", authMW(handlers.DeletePollRecordOption(conn)))
 	mux.Handle("POST /v1/developing-stories", authMW(adminOnly(handlers.PostDevelopingStory(conn))))
 	mux.Handle("DELETE /v1/developing-stories", authMW(adminOnly(handlers.DeleteDevelopingStory(conn))))
 	mux.Handle("PATCH /v1/settings/site", authMW(adminOnly(handlers.PatchSiteSettings(conn))))


### PR DESCRIPTION
Running the weekly poll is editorial work, not site administration, but every write path behind it was `adminOnly`. The sidebar shows **Poll** to everyone under Content, so a non-admin editor could open the page and then 403 on every action.

## Changes
- `routes.go`: dropped `adminOnly` from the eleven poll write/manage routes — `PATCH /v1/poll/title`, the `/v1/poll/options` CRUD, `GET /v1/polls/manage`, and the `/v1/polls` record + option CRUD. All still sit behind `authMW`.
- Public paths untouched: `GET /v1/poll*`, `GET /v1/polls`, `GET /v1/polls/{id}`, and the rate-limited vote `POST /v1/poll`.
- Refreshed the `/v1/polls/manage` swagger description (and regenerated `docs/`) that claimed drafts needed admin auth.

No frontend change needed — `pollView.tsx` never checked `isAdmin`.

## Testing
`go build ./...`, `go vet`, and `go test ./internal/routes/... ./internal/handlers/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)