### PR TITLE
Fix four image and typing bugs in the article editor

### DIFF
--- a/frontend/src/components/TrixEditor.tsx
+++ b/frontend/src/components/TrixEditor.tsx
@@ -22,6 +22,27 @@ import {
 if (typeof window !== "undefined" && window.Trix) {
   window.Trix.config.attachments.preview.caption.name = false
   window.Trix.config.attachments.preview.caption.size = false
+
+  // Keep every image in a block of its own. Trix tags previewable attachments
+  // with presentation "gallery" by default, and its attachmentGalleryFilter
+  // then fuses any run of two or more adjacent ones into a single
+  // attachmentGallery block. That block is the unit our reordering works in, so
+  // two images placed next to each other became one thing: dragging either
+  // moved both, and swapping them with each other was not expressible at all.
+  // Nothing here styles galleries, so switching the presentation off costs
+  // nothing and leaves the filter with no run to ever match.
+  window.Trix.config.attachments.preview.presentation = null
+
+  // Let alignment survive on the attachment piece. Trix's permitted list is
+  // ["caption", "presentation"] and removeProhibitedAttributes drops everything
+  // else as soon as the piece is built, so `align` only ever lived on the live
+  // figure as a class our own effect re-applied. That class was enough to make
+  // alignment look preserved until Trix re-rendered the figure from the piece
+  // -- which editing a caption does -- at which point the alignment silently
+  // vanished from both the editor and the saved article.
+  if (!window.Trix.AttachmentPiece.permittedAttributes.includes("align")) {
+    window.Trix.AttachmentPiece.permittedAttributes.push("align")
+  }
 }
 
 // The attachment toolbar is built by Trix as plain DOM, not by React, so its
@@ -76,9 +97,31 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
   const toolbarId = useId()
   const editorRef = useRef<TrixEditorElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
-  // Tracks the last HTML we emitted so we don't call loadHTML on our own onChange updates,
-  // which would reset the cursor mid-edit.
-  const lastEmittedRef = useRef<string>("")
+  // Every HTML string we have emitted since the last load from outside, so we
+  // never call loadHTML on our own output -- which would reset the document and
+  // drop the caret at the top of the article mid-edit.
+  //
+  // This has to be a set of everything emitted, not just the most recent one.
+  // The effect below is passive, so React can run it with a `value` several
+  // keystrokes behind what the editor already holds; a single "last emitted"
+  // string has by then moved on, the stale echo fails the comparison, and the
+  // editor is reloaded from it. That is the "type fast and your text jumps to
+  // the top" bug: each reload rewound the document and reset the caret to 0, so
+  // the following keystrokes landed at the start of the article.
+  const emittedRef = useRef<Set<string>>(new Set())
+  // Bounded so a long editing session (one entry per keystroke) doesn't grow
+  // without limit. Re-inserting keeps the set in least-recently-emitted order,
+  // so eviction drops the entries least likely to still be in flight.
+  const rememberEmitted = useCallback((html: string) => {
+    const emitted = emittedRef.current
+    emitted.delete(html)
+    emitted.add(html)
+    while (emitted.size > 100) {
+      const oldest = emitted.values().next()
+      if (oldest.done) break
+      emitted.delete(oldest.value)
+    }
+  }, [])
   // Caret position captured before the picker steals focus, so the image lands
   // where the author was typing rather than at the top of the document.
   const savedRangeRef = useRef<[number, number] | null>(null)
@@ -89,10 +132,14 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
   useEffect(() => {
     const editor = editorRef.current
     if (!editor) return
-    if (value !== lastEmittedRef.current) {
-      editor.editor.loadHTML(articleHtmlToTrix(value))
-      lastEmittedRef.current = value
-    }
+    // An echo of our own output, however far behind. Reloading would only undo
+    // edits the author has already made.
+    if (emittedRef.current.has(value)) return
+    // A genuine load from outside: the editor is about to hold exactly this, so
+    // nothing emitted before it can still be worth honouring.
+    emittedRef.current.clear()
+    emittedRef.current.add(value)
+    editor.editor.loadHTML(articleHtmlToTrix(value))
   }, [value])
 
   useEffect(() => {
@@ -101,18 +148,18 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
 
     const handleChange = () => {
       // Emit the semantic markup we persist, not Trix's internal attachment
-      // format. lastEmittedRef has to hold the *converted* HTML: it is compared
+      // format. What we remember has to be the *converted* HTML: it is compared
       // against the incoming value prop to decide whether to reload the editor,
       // and reloading on our own output would reset the caret on every
       // keystroke.
       const html = trixHtmlToArticle(editor.value)
-      lastEmittedRef.current = html
+      rememberEmitted(html)
       onChange(html)
     }
 
     editor.addEventListener("trix-change", handleChange)
     return () => { editor.removeEventListener("trix-change", handleChange) }
-  }, [onChange])
+  }, [onChange, rememberEmitted])
 
   // Reflect each attachment's stored alignment onto the live figure so our CSS
   // can style it. Alignment round-trips as a data-trix-attributes value (Trix
@@ -343,6 +390,9 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
     wrapper.appendChild(dropIndicator)
 
     let activeFigure: HTMLElement | null = null
+    // True from the mousedown on a figure until the mouse is released, whether
+    // or not the pointer has travelled far enough to count as a drag yet.
+    let gestureActive = false
     // Per-gesture cleanup set while a drag is in progress so the outer effect's
     // teardown can abort it on unmount (prevents leaked document listeners and
     // a stuck `grabbing` cursor).
@@ -559,6 +609,7 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       // Idempotent state-restorer, invoked from onUp on normal release AND
       // from the outer effect's cleanup if the component unmounts mid-drag.
       const cleanup = () => {
+        gestureActive = false
         document.removeEventListener("mousemove", onMove)
         document.removeEventListener("mouseup", onUp)
         document.body.style.cursor = ""
@@ -584,6 +635,7 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
         }
       }
 
+      gestureActive = true
       document.addEventListener("mousemove", onMove)
       document.addEventListener("mouseup", onUp)
       activeGestureCleanup = cleanup
@@ -702,13 +754,27 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
     }
 
     // With the mousedown default no longer suppressed, the browser is free to
-    // start its own native image drag, which would race our rearrange gesture
-    // and can drop the image into another window entirely.
+    // start its own native drag, which would race our rearrange gesture and can
+    // drop the image into another window entirely. Once a native drag begins
+    // the browser stops sending mousemove, so our gesture goes dead and the
+    // image simply stays where it was.
+    //
+    // Keying this off the event target alone is not enough. Trix selects the
+    // attachment on the same mousedown that starts the gesture, so what the
+    // browser goes on to drag is the *selection*, and the dragstart it fires
+    // for that is targeted at whatever node the selection is anchored in --
+    // routinely the editor or a text block rather than anything inside the
+    // figure. So suppress unconditionally while our own gesture is in flight,
+    // and keep the target test for the rest of the time (a native image drag
+    // out of the article is never something we want). Capture phase on the
+    // document, because Trix has dragstart handlers of its own on the editor.
     const onDragStart = (event: DragEvent) => {
-      if ((event.target as HTMLElement | null)?.closest(".attachment--preview")) event.preventDefault()
+      if (gestureActive || (event.target as HTMLElement | null)?.closest(".attachment--preview")) {
+        event.preventDefault()
+      }
     }
 
-    editor.addEventListener("dragstart", onDragStart)
+    document.addEventListener("dragstart", onDragStart, true)
     editor.addEventListener("trix-attachment-before-toolbar", onBeforeToolbar)
     editor.addEventListener("mousedown", onEditorMouseDown, true)
     document.addEventListener("mousedown", onDocumentMouseDown)
@@ -717,7 +783,7 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       // Abort any in-progress drag so we don't leave document-level
       // listeners or a stuck `grabbing` cursor behind on unmount.
       if (activeGestureCleanup) activeGestureCleanup()
-      editor.removeEventListener("dragstart", onDragStart)
+      document.removeEventListener("dragstart", onDragStart, true)
       editor.removeEventListener("trix-attachment-before-toolbar", onBeforeToolbar)
       editor.removeEventListener("mousedown", onEditorMouseDown, true)
       document.removeEventListener("mousedown", onDocumentMouseDown)

--- a/frontend/src/components/trixImageHtml.ts
+++ b/frontend/src/components/trixImageHtml.ts
@@ -64,7 +64,11 @@ type AttachmentData = {
   previewable?: boolean
 }
 
-/** The piece attributes Trix stores in data-trix-attributes. */
+/**
+ * The piece attributes Trix stores in data-trix-attributes. `align` is only
+ * kept because TrixEditor.tsx adds it to AttachmentPiece.permittedAttributes;
+ * Trix strips unrecognised piece attributes on its own.
+ */
 type AttachmentAttributes = {
   caption?: string
   presentation?: string
@@ -159,7 +163,9 @@ export const articleHtmlToTrix = (html: string): string => {
     if (width) data.width = width
     if (height) data.height = height
 
-    const attributes: AttachmentAttributes = { presentation: "gallery" }
+    // Deliberately no presentation. Trix's "gallery" presentation fuses
+    // adjacent images into a single block -- see the config in TrixEditor.tsx.
+    const attributes: AttachmentAttributes = {}
     if (caption) attributes.caption = caption
     if (align) attributes.align = align
 
@@ -173,7 +179,24 @@ export const articleHtmlToTrix = (html: string): string => {
     if (alt) newImg.setAttribute("alt", alt)
     figure.appendChild(newImg)
 
-    container.replaceWith(figure)
+    // Give each image a block of its own. Trix deliberately does not count an
+    // attachment element as a block (its isBlockElement bails on anything
+    // carrying data-trix-attachment), so figures that are siblings in the
+    // stored markup -- the ordinary shape of the WordPress corpus -- parse into
+    // one shared block. A block is the unit the editor's reordering moves, so
+    // that made two adjacent images inseparable: dragging either moved both,
+    // and swapping them was not expressible at all. The <div> wrapper is how
+    // Trix serializes an attachment block itself, so this round-trips cleanly.
+    //
+    // Only at the top level: a <div> nested inside a <p> would not survive
+    // being re-parsed, and a figure already inside a block has one.
+    if (container.parentElement === doc.body) {
+      const block = doc.createElement("div")
+      block.appendChild(figure)
+      container.replaceWith(block)
+    } else {
+      container.replaceWith(figure)
+    }
     changed = true
   }
 

--- a/frontend/src/trix.d.ts
+++ b/frontend/src/trix.d.ts
@@ -21,6 +21,10 @@ declare global {
       config: {
         attachments: {
           preview: {
+            // Trix's default is "gallery", which is what makes its gallery
+            // filter fuse adjacent images into one block. Nullable so we can
+            // turn that off -- see TrixEditor.tsx.
+            presentation: string | null
             caption: {
               name: boolean
               size: boolean
@@ -28,6 +32,10 @@ declare global {
           }
         }
       }
+      // The attribute allowlist Trix applies to the piece that carries an
+      // attachment. Anything not in it is stripped the moment the piece is
+      // built, so an attribute has to be added here to survive a re-render.
+      AttachmentPiece: { permittedAttributes: string[] }
       Attachment: new (attributes: TrixAttachmentAttributes) => TrixAttachment
       // Trix re-exports its internal models on the global. HTMLParser is how a
       // Document is built from HTML without going through Editor#loadHTML,


### PR DESCRIPTION
Fixes the editor problems Michael hit, plus two more found while investigating.

## 1. Fast typing threw text to the top of the editor

The effect syncing the `value` prop into Trix is passive, so React can run it with a `value` several keystrokes behind what the editor already holds. `lastEmittedRef` only remembered the *most recent* emission, so a stale echo of our own output failed the comparison and got fed to `loadHTML` — rewinding the document and resetting the caret to 0, which is why the next characters landed at the start of the article.

Typing one sentence at full speed produced:

```
'doaze  t ove jumpfobrowne First paragraph of the article...'   caret: [0,0]
```

At 150ms/key it was perfect, so it was purely a race. Instrumenting `loadHTML` caught it directly — 3 spurious reloads, each rewinding the document. Now 0.

**Fix:** remember every string emitted since the last load from outside (bounded to 100, LRU-evicted) and skip any incoming value that is one of ours, however far behind.

## 2. Dragging an image did nothing for some authors

⚠️ **This is the one fix that is reasoned rather than reproduced — worth confirming with Michael before closing the report.**

I could not provoke the failure: dragging worked in Chromium *and* Firefox across cold drag, drag up/down, click-then-drag, two drags in a row, after fast typing, and under 6× CPU throttle with 120ms render lag. The one thing Playwright's mouse API structurally cannot exercise is the browser's **native HTML5 drag**, which a real mouse does trigger — and that was the only untested branch.

The guard against it keyed off the `dragstart` target. That is unsound: Trix selects the attachment on the same mousedown that starts the gesture, so what the browser drags is the *selection*, and its `dragstart` is targeted at whatever node the selection is anchored in — routinely the editor or a text block, not the figure. Miss that `preventDefault` and a native drag begins, `mousemove` stops arriving, the gesture goes dead, and the image stays put. Timing-dependent, which fits it working for one person and not another.

**Fix:** suppress `dragstart` unconditionally while our own gesture is in flight, in capture phase on the document (Trix has its own `dragstart` handlers on the editor — `trix.esm.js:11543` and `:12165`).

## 3. Alignment vanished when a caption was edited

`AttachmentPiece.permittedAttributes` is `["caption", "presentation"]` (`trix.esm.js:6969`) and `removeProhibitedAttributes` strips everything else as the piece is built. So `align` never existed in Trix's model — it survived only as a class re-applied to the live figure, and any re-render from the piece (which editing a caption forces) dropped it from both the editor and the saved article. Confirmed pre-existing by testing against the unmodified code.

**Fix:** add `"align"` to the permitted list, so it round-trips the way the existing comments already claimed.

## 4. Two adjacent images could not be separated

My first diagnosis here was wrong and testing caught it. I switched off the gallery presentation and the images *still* merged — the container was a plain `DIV`, not `attachment-gallery`, so the gallery filter was never the culprit.

The real cause: `isBlockElement` bails on anything carrying `data-trix-attachment` (`trix.esm.js:8788`), so `<figure>` siblings — the ordinary WordPress corpus shape — parse into one shared block. A block is the unit reordering moves, so dragging either image moved both and swapping them was not expressible at all.

**Fix:** wrap each top-level figure in the `<div>` Trix itself uses to serialize an attachment block. The gallery presentation is switched off too, since nothing here styles galleries and it is a second way to fuse images into one block.

## Verification

Driven against the real component in a browser, Chromium and Firefox:

- Fast typing leaves the sentence intact, caret at the end, 0 spurious `loadHTML` calls
- Drag up / down / cold / after a click / twice in a row / after fast typing — all move, including under CPU throttling and 120ms render lag
- Two adjacent images are separate blocks and drag past each other (order goes `[A, B]` → `[B, A]`; previously unchanged)
- `alignleft` and `aligncenter` both survive a caption edit *and* a move, and stay distinct
- Load→save→load is idempotent: exactly one wrapper div per image, no accumulation, `saved === saved2`
- Remove, caption and undo unchanged; no page errors in any run

`tsc -b`, `eslint` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
