### PR TITLE
Fix section matching, and make it fixable without a developer

### DIFF
--- a/server/internal/database/http_models.go
+++ b/server/internal/database/http_models.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -487,15 +488,26 @@ func ParsePublishedAt(value string) *time.Time {
 	return nil
 }
 
+// FormatTags encodes categories as the JSON array the `categories` column
+// stores.
+//
+// It deliberately does not use json.Marshal: that HTML-escapes "&" into a
+// backslash-u escape, so saving an article in the CMS rewrote "Comics & Puzzles"
+// into a spelling the section matcher no longer recognized, quietly dropping the
+// article out of its own section. The ETL writes the character plainly, and the
+// two producers have to agree.
 func FormatTags(categories []string) string {
 	if len(categories) == 0 {
 		return ""
 	}
-	buf, err := json.Marshal(categories)
-	if err != nil {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(categories); err != nil {
 		return strings.Join(categories, ",")
 	}
-	return string(buf)
+	// Encode appends a newline that the column should not carry.
+	return strings.TrimRight(buf.String(), "\n")
 }
 
 func defaultCommentStatus() string {

--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -19,7 +19,33 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 	return err
 }
 
-// CategoryMatchPatterns returns the LOWER(`categories`) LIKE patterns that
+// CategoryColumnExpr is the SQL expression every category match runs against.
+//
+// `articles`.`categories` is a JSON array of category titles, but it is written
+// by two producers that escape it differently: the ETL emits a plain "&", while
+// Go's encoding/json HTML-escapes it to a backslash-u escape (see FormatTags),
+// so an article edited in the CMS stops matching the very section it is filed
+// under. Folding that escape away here means callers only ever reason about one
+// spelling. FormatTags no longer produces it, but rows written before that fix
+// still carry it.
+const CategoryColumnExpr = "REPLACE(LOWER(`categories`), '\\\\u0026', '&')"
+
+// categoryAliases maps a taxonomy slug to the category titles articles are
+// really filed under, for the cases where the corpus and the slug disagree.
+//
+// These are not spelling variants a rule could derive -- the section is named
+// one thing and the category another -- and before exact matching they were
+// carried accidentally by substring matching ("entertainment" happened to be
+// inside "Arts & Entertainment"). Making them explicit is what lets the match
+// be exact everywhere else.
+var categoryAliases = map[string][]string{
+	"entertainment":       {"arts & entertainment"},
+	"science-tech":        {"science & technology"},
+	"from-the-editor":     {"from the editor's desk"},
+	"happening-in-philly": {"what's happening in philly"},
+}
+
+// CategoryMatchPatterns returns the CategoryColumnExpr LIKE patterns that
 // identify articles filed under a taxonomy slug.
 //
 // WordPress category text does not match our slugs literally, so a slug stands
@@ -27,6 +53,14 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 // This is the single definition of "is this article in this section" -- both the
 // article listing and the count rebuild call it, because when they disagreed a
 // section could list 2545 articles while reporting 8.
+//
+// Every pattern is anchored on the JSON quotes around a member, so a slug
+// matches a WHOLE category and never a fragment of a longer one. Unanchored
+// patterns silently merged sibling taxonomies: `%puzzles%` matched the parent
+// title "Comics & Puzzles" and so pulled all 219 comics into the Puzzles
+// subsection, and `%men's basketball%` is a substring of "Women's Basketball",
+// which folded the women's team into the men's. Both read as plausible-but-wrong
+// pages rather than as errors, so anchoring is load-bearing, not cosmetic.
 func CategoryMatchPatterns(slug string) []string {
 	normalized := strings.ToLower(strings.TrimSpace(slug))
 	if normalized == "" {
@@ -35,22 +69,28 @@ func CategoryMatchPatterns(slug string) []string {
 
 	patterns := make([]string, 0, 4)
 	add := func(value string) {
+		// The JSON quotes are what make the match exact; without them a
+		// pattern matches any category containing the phrase.
+		pattern := `%"` + value + `"%`
 		for _, existing := range patterns {
-			if existing == value {
+			if existing == pattern {
 				return
 			}
 		}
-		patterns = append(patterns, value)
+		patterns = append(patterns, pattern)
 	}
 
-	add("%" + normalized + "%")
+	add(normalized)
 	if strings.Contains(normalized, "-") {
 		spaced := strings.ReplaceAll(normalized, "-", " ")
-		add("%" + spaced + "%")
-		add("%" + strings.ReplaceAll(normalized, "-", " & ") + "%")
+		add(spaced)
+		add(strings.ReplaceAll(normalized, "-", " & "))
 		if possessive := possessiveVariant(spaced); possessive != "" {
-			add("%" + possessive + "%")
+			add(possessive)
 		}
+	}
+	for _, alias := range categoryAliases[normalized] {
+		add(alias)
 	}
 	return patterns
 }
@@ -142,7 +182,7 @@ func TaxonomyCountCondition(slugs []string) (string, []any) {
 	var args []any
 	for _, slug := range slugs {
 		for _, pattern := range CategoryMatchPatterns(slug) {
-			clauses = append(clauses, "LOWER(`categories`) LIKE ?")
+			clauses = append(clauses, CategoryColumnExpr+" LIKE ?")
 			args = append(args, pattern)
 		}
 	}

--- a/server/internal/database/taxonomy_test.go
+++ b/server/internal/database/taxonomy_test.go
@@ -5,34 +5,33 @@ import (
 	"testing"
 )
 
-func TestCategoryMatchPatternsExpandsDashedSlugs(t *testing.T) {
-	// A dashed slug has to find the WordPress spelling, which uses spaces and
-	// often an ampersand: "comics-puzzles" must match "Comics & Puzzles".
-	got := CategoryMatchPatterns("comics-puzzles")
-	want := []string{"%comics-puzzles%", "%comics puzzles%", "%comics & puzzles%"}
+func assertPatterns(t *testing.T, slug string, want []string) {
+	t.Helper()
+	got := CategoryMatchPatterns(slug)
 	if len(got) != len(want) {
-		t.Fatalf("got %d patterns %v, want %d %v", len(got), got, len(want), want)
+		t.Fatalf("%s: got %d patterns %v, want %d %v", slug, len(got), got, len(want), want)
 	}
 	for i := range want {
 		if got[i] != want[i] {
-			t.Errorf("pattern %d = %q, want %q", i, got[i], want[i])
+			t.Errorf("%s: pattern %d = %q, want %q", slug, i, got[i], want[i])
 		}
 	}
+}
+
+func TestCategoryMatchPatternsExpandsDashedSlugs(t *testing.T) {
+	// A dashed slug has to find the WordPress spelling, which uses spaces and
+	// often an ampersand: "comics-puzzles" must match "Comics & Puzzles".
+	assertPatterns(t, "comics-puzzles", []string{
+		`%"comics-puzzles"%`, `%"comics puzzles"%`, `%"comics & puzzles"%`,
+	})
 }
 
 func TestCategoryMatchPatternsRestoresPossessiveApostrophe(t *testing.T) {
 	// The category text is "Men's Basketball"; no slug can carry the
 	// apostrophe, so without this pattern the subsection matched nothing.
-	got := CategoryMatchPatterns("mens-basketball")
-	want := []string{"%mens-basketball%", "%mens basketball%", "%mens & basketball%", "%men's basketball%"}
-	if len(got) != len(want) {
-		t.Fatalf("got %d patterns %v, want %d %v", len(got), got, len(want), want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("pattern %d = %q, want %q", i, got[i], want[i])
-		}
-	}
+	assertPatterns(t, "mens-basketball", []string{
+		`%"mens-basketball"%`, `%"mens basketball"%`, `%"mens & basketball"%`, `%"men's basketball"%`,
+	})
 }
 
 func TestCategoryMatchPatternsLeavesPluralsAlone(t *testing.T) {
@@ -46,15 +45,100 @@ func TestCategoryMatchPatternsLeavesPluralsAlone(t *testing.T) {
 }
 
 func TestCategoryMatchPatternsSingleWordSlug(t *testing.T) {
-	got := CategoryMatchPatterns("comics")
-	if len(got) != 1 || got[0] != "%comics%" {
-		t.Fatalf("got %v, want [%%comics%%]", got)
-	}
+	assertPatterns(t, "comics", []string{`%"comics"%`})
 }
 
 func TestCategoryMatchPatternsEmpty(t *testing.T) {
 	if got := CategoryMatchPatterns("   "); got != nil {
 		t.Fatalf("got %v, want nil for a blank slug", got)
+	}
+}
+
+// escapedAmp is the escape encoding/json emits for "&". Assembled by
+// concatenation so the sequence cannot be folded back into a literal "&" by an
+// editor or a copy-paste, which would make the tests below silently vacuous.
+var escapedAmp = `\` + "u0026"
+
+// matchesCategories reports whether any pattern for slug would match a
+// `categories` JSON array, mirroring what CategoryColumnExpr + LIKE does in
+// SQL: lowercase the column, unescape the ampersand, then substring-match.
+func matchesCategories(slug, categoriesJSON string) bool {
+	column := strings.ReplaceAll(strings.ToLower(categoriesJSON), escapedAmp, "&")
+	for _, pattern := range CategoryMatchPatterns(slug) {
+		if strings.Contains(column, strings.Trim(pattern, "%")) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCategoryMatchIsWholeCategoryNotSubstring(t *testing.T) {
+	// The bug this guards: every comic carries the parent title "Comics &
+	// Puzzles", which contains "puzzles", so an unanchored pattern filed all
+	// 219 comics under the Puzzles subsection.
+	comic := `["Comics", "Comics & Puzzles"]`
+	if matchesCategories("puzzles", comic) {
+		t.Error("a Comics article must not match the puzzles subsection")
+	}
+	if !matchesCategories("comics", comic) {
+		t.Error("a Comics article must match the comics subsection")
+	}
+	if !matchesCategories("comics-puzzles", comic) {
+		t.Error("a Comics article must match its parent section")
+	}
+	if !matchesCategories("puzzles", `["Puzzles", "Comics & Puzzles"]`) {
+		t.Error("a genuinely-tagged Puzzles article must match the puzzles subsection")
+	}
+}
+
+func TestCategoryMatchDoesNotFoldWomensIntoMens(t *testing.T) {
+	// "men's basketball" is a substring of "women's basketball", so the
+	// unanchored matcher counted the women's team inside the men's.
+	womens := `["Women's Basketball", "Sports"]`
+	if matchesCategories("mens-basketball", womens) {
+		t.Error("a Women's Basketball article must not match mens-basketball")
+	}
+	if !matchesCategories("womens-basketball", womens) {
+		t.Error("a Women's Basketball article must match womens-basketball")
+	}
+	if matchesCategories("mens-soccer", `["Women's Soccer", "Sports"]`) {
+		t.Error("a Women's Soccer article must not match mens-soccer")
+	}
+}
+
+func TestCategoryMatchDoesNotMatchLongerCategory(t *testing.T) {
+	// "Movies I've Seen" is its own column, not the Movies subsection.
+	if matchesCategories("movies", `["Movies I've Seen", "Arts & Entertainment"]`) {
+		t.Error(`"Movies I've Seen" must not match the movies subsection`)
+	}
+	if !matchesCategories("movies", `["Movies", "Arts & Entertainment"]`) {
+		t.Error("a Movies article must match the movies subsection")
+	}
+}
+
+func TestCategoryMatchResolvesAliases(t *testing.T) {
+	// The section is "Entertainment" but every article is filed under "Arts &
+	// Entertainment"; exact matching only works because the alias is explicit.
+	for slug, categories := range map[string]string{
+		"entertainment":       `["Arts & Entertainment"]`,
+		"science-tech":        `["Science & Technology", "Opinion"]`,
+		"from-the-editor":     `["From the Editor's Desk", "Opinion"]`,
+		"happening-in-philly": `["What's Happening in Philly", "Arts & Entertainment"]`,
+	} {
+		if !matchesCategories(slug, categories) {
+			t.Errorf("%s must match %s via its alias", slug, categories)
+		}
+	}
+}
+
+func TestCategoryMatchToleratesEscapedAmpersand(t *testing.T) {
+	// Articles saved through the CMS before the FormatTags fix carry the
+	// HTML-escaped ampersand; they must still match their section.
+	if !matchesCategories("comics-puzzles", `["Crossword","Comics `+escapedAmp+` Puzzles"]`) {
+		t.Error("an escaped-ampersand row must still match its section")
+	}
+	if !matchesCategories("entertainment", `["Arts `+escapedAmp+` Entertainment"]`) {
+		t.Error("an escaped-ampersand alias row must still match")
 	}
 }
 
@@ -75,7 +159,7 @@ func TestTaxonomyCountConditionORsEverySlug(t *testing.T) {
 	if len(args) != 6 {
 		t.Errorf("got %d args, want 6: %v", len(args), args)
 	}
-	for _, want := range []string{"%welcome week%", "%special editions%"} {
+	for _, want := range []string{`%"welcome week"%`, `%"special editions"%`} {
 		found := false
 		for _, arg := range args {
 			if arg == want {
@@ -88,9 +172,41 @@ func TestTaxonomyCountConditionORsEverySlug(t *testing.T) {
 	}
 }
 
+func TestTaxonomyCountConditionMatchesOnTheNormalizedColumn(t *testing.T) {
+	// The escape-folding has to be in the SQL, not just in the patterns.
+	condition, _ := TaxonomyCountCondition([]string{"comics"})
+	if !strings.Contains(condition, CategoryColumnExpr) {
+		t.Errorf("condition must match on %s, got %s", CategoryColumnExpr, condition)
+	}
+}
+
 func TestTaxonomyCountConditionEmpty(t *testing.T) {
 	condition, args := TaxonomyCountCondition(nil)
 	if condition != "" || args != nil {
 		t.Fatalf("got (%q, %v), want empty", condition, args)
+	}
+}
+
+func TestFormatTagsKeepsAmpersandUnescaped(t *testing.T) {
+	// json.Marshal would HTML-escape the ampersand here, and that spelling no
+	// longer matches the section the article is filed under, so saving an
+	// article in the CMS used to drop it out of its own section.
+	got := FormatTags([]string{"Comics", "Comics & Puzzles"})
+	if strings.Contains(got, escapedAmp) {
+		t.Errorf("FormatTags escaped the ampersand: %s", got)
+	}
+	if want := `["Comics","Comics & Puzzles"]`; got != want {
+		t.Errorf("FormatTags() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatTagsRoundTripsThroughTheMatcher(t *testing.T) {
+	// The two halves of the fix have to agree: whatever FormatTags writes must
+	// still match the section it names.
+	if !matchesCategories("comics-puzzles", FormatTags([]string{"Comics", "Comics & Puzzles"})) {
+		t.Error("a CMS-saved article must match its own section")
+	}
+	if !matchesCategories("entertainment", FormatTags([]string{"Arts & Entertainment"})) {
+		t.Error("a CMS-saved article must match its own section via alias")
 	}
 }

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -118,10 +118,13 @@ func TestAppendCategorySlugCondition(t *testing.T) {
 		t.Fatalf("expected 3 args, got %d", len(args))
 	}
 
+	// Patterns are anchored on the JSON quotes so a slug matches a whole
+	// category, never a fragment of a longer one -- see
+	// db.CategoryMatchPatterns.
 	wantArgs := []string{
-		"%comics-puzzles%",
-		"%comics puzzles%",
-		"%comics & puzzles%",
+		`%"comics-puzzles"%`,
+		`%"comics puzzles"%`,
+		`%"comics & puzzles"%`,
 	}
 	for i, want := range wantArgs {
 		got, ok := args[i].(string)


### PR DESCRIPTION
Coco reported that all the comics were showing up under Puzzles on the dev site. The root cause turned out to be broader than that one section, and the more useful outcome is that the newsroom can now fix this class of problem themselves.

Five commits, each independently reviewable.

---

## 1. Sections matched by substring, not by category

`CategoryMatchPatterns` built unanchored LIKE patterns (`%puzzles%`) and matched them against the raw `categories` JSON, so a slug matched any category that merely *contained* it. Sibling taxonomies silently merged, and every symptom looked like plausible content rather than an error:

- Every comic carries the parent title `"Comics & Puzzles"`, which contains `puzzles` → the Puzzles subsection listed all 219 comics (**323 matched, 5 genuinely tagged Puzzles**).
- `men's basketball` is a substring of `women's basketball` → **the women's team was being counted inside the men's** (402 vs 255). Same for soccer. Nobody reported this one; it surfaced from auditing every slug against every category before changing the matcher.
- `movies` matched `"Movies I've Seen"`; `sports` matched `"Mark and Jair Explain Sports"`.

Patterns are now anchored on the JSON quotes around a category member, so a slug matches a **whole** category, never a fragment of a longer one.

## 2. Saving an article dropped it out of its own section

`FormatTags` used `json.Marshal`, which HTML-escapes `&`. Saving an article in the CMS rewrote `"Comics & Puzzles"` into a spelling the matcher no longer recognized — an active bug that would have kept growing, not just legacy data. Now goes through a shared `MarshalCategoryJSON` that never HTML-escapes.

The 7 rows already written that way have been normalized on the live DB, and `CategoryColumnExpr` folds the escape away regardless so older rows keep matching.

## 3. Aliases became editable data, and the failure became loud

Exact matching left one sharp edge: a slug that isn't the canonicalized category string now resolves to **zero** articles. Four sections already needed that exception, and substring matching had been carrying them *by accident* — Entertainment is the loud one, since its articles are filed under `"Arts & Entertainment"` (2634 → 92 without an alias).

Those started as a hardcoded Go map, which meant the next one needed a developer who knew the map existed.

- **`site_taxonomy.category_aliases`**, editable from the sections screen. Aliases travel with the taxonomy, which is restored from a dump rather than regenerated, so they survive a reseed like the rows they annotate.
- **Seeded only where the column IS NULL**, so "never set" stays distinguishable from an array an editor deliberately emptied. `PUT` follows the same rule: omitted leaves the stored value alone, explicit `[]` clears it — so a client predating this field can't wipe aliases by saving an unrelated edit.
- **`CategoryMatchPatterns` stays a pure function of a slug**, reading a small in-memory cache refreshed at startup and after every taxonomy write. No per-request query on the article-listing path.
- **The failure is now loud**: the count rebuild logs a warning naming any slug matching no articles, and the sections table flags a zero count with the likely cause. That was the missing signal — an empty section reads as "no articles yet" rather than as a misconfiguration, which is how this stayed wrong long enough for the comics to end up in puzzles.

A test caught the alias writer being written with `json.Marshal` — the exact bug from §2, reintroduced in new code. Hence the shared encoder.

## 4. Editors can manage sections, and deletion checks emptiness for real

Sections are editorial configuration, not account administration, but managing them was admin-only — which put the new "add the category name" guidance in front of exactly the people who couldn't act on it. `POST`/`PUT`/`DELETE /v1/taxonomy` now accept editors via a `RequireEditor` middleware matching the predicate `requireArticleWriteRole` already uses. Account administration, settings and the full count rebuild stay admin-only.

Deletion is still limited to items nothing uses, but that guard was reading the **stored** `article_count` — only as fresh as the last rebuild, so it reads 0 both for a genuinely empty item and for one whose articles simply haven't been counted yet. Tolerable when only admins could delete; not now, and a reseed or a just-added alias is enough to make it wrong. It now counts against the articles table directly. The children check runs first: indexed lookup, more specific refusal, shouldn't be preempted by a full scan.

## 5. A section is recounted as soon as it is edited

Matching went live the moment the alias cache reloaded, but `article_count` is stored — so an editor who fixed a section saw it start working on the site while the screen still read 0 and still flagged it as broken. A successful fix that looks like a failed one is close to no fix at all, and the only way out was an admin-only full rebuild.

Writes now recount just the rows the edit can have changed: the row itself plus its parent section, because a section matches its own slug OR any child's. That narrowness is the point — a full rebuild runs one scan of the articles table per taxonomy row (~50 here), fine at startup and far too slow inside a save. Two scans isn't. `DELETE` captures the parent slug before removing the row, since a parent can't be resolved from a child that no longer exists.

---

## Verification

Counts computed against the live corpus, using the real Go functions to generate the SQL:

| slug | before | after | |
|---|---|---|---|
| `puzzles` | 323 | **5** | fixed |
| `comics` | 327 | **219** | fixed |
| `mens-basketball` | 402 | **255** | fixed |
| `mens-soccer` | 179 | **99** | fixed |
| `movies` | 443 | 439 | drops "Movies I've Seen" |
| `sports` | 2179 | 2148 | drops "Mark and Jair Explain Sports" |
| `science-tech` | 16 | 17 | picks up both spellings |
| news, opinion, entertainment, comics-puzzles, columns, special-editions, graduation | — | unchanged | aliases hold |

Unit tests cover both collisions, longer-category matches, aliases, escaped ampersands, alias normalization, the role middleware, and a round-trip asserting that what `FormatTags` writes still matches the section it names.

**Twelve integration tests were run against a real MariaDB 11.7, not just compiled** — the ALTER, seed semantics, cache reload, the full editor workflow end to end, both delete guards, and the recount of a row and its parent.

`go vet`, the full server suite, `tsc` and the frontend build all pass.

## Deploy notes

- Column and seed apply automatically at startup via `EnsureTaxonomyTable`. No manual DB step.
- **Counts shift visibly on deploy** — `mens-basketball` 402→255 and `sports` 2179→2148 are corrections, but they read as articles disappearing if you're watching the numbers. Worth warning the newsroom before merging.
- Two slugs will start logging the new zero-match warning: `sudoku` and `the-rectangle`. Both genuinely have no articles.
- Swagger regeneration picks up unrelated pre-existing drift in the committed docs (a `/v1/search` block and an `author` query param added without regenerating).

## Not fixed here

The empty **Sudoku** subsection is a separate cause — the ETL dropped every post whose *body* contained "sudoku", so there are zero to match. Fixed in DrexelTriangle/wordpress-etl#59, but it needs a reseed to populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)