### PR TITLE
Make section matching fixable without a developer

### DIFF
--- a/frontend/src/pages/sectionsView.tsx
+++ b/frontend/src/pages/sectionsView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { Columns3, Pencil, Plus, RefreshCw, Search, Trash2, X } from "lucide-react"
+import { AlertTriangle, Columns3, Pencil, Plus, RefreshCw, Search, Trash2, X } from "lucide-react"
 import { useApiFetch } from "../hooks/useApiFetch"
 
 type TaxonomyKind = "section" | "subsection"
@@ -11,6 +11,7 @@ type TaxonomyItem = {
   canonical_title: string
   parent_slug?: string | null
   article_count: number
+  category_aliases?: string[] | null
 }
 
 type SectionRow = {
@@ -26,6 +27,10 @@ type FormState = {
   canonicalTitle: string
   slug: string
   parentSlug: string
+  // One alias per line in the textarea; articles are matched on the whole
+  // category name, so this is how a section whose slug differs from its
+  // category ("entertainment" vs "Arts & Entertainment") finds its articles.
+  categoryAliases: string
 }
 
 type EditorState =
@@ -47,7 +52,14 @@ const emptyForm: FormState = {
   canonicalTitle: "",
   slug: "",
   parentSlug: "",
+  categoryAliases: "",
 }
+
+// Article matching is exact, so a slug that is not the category name resolves
+// to nothing and the section page renders empty -- which reads as "no articles
+// yet" rather than as a misconfiguration. Say what it usually means.
+const emptyCountHint =
+  "No articles match this item. If it should have articles, add the exact category name they are filed under under Category Names."
 
 const slugify = (value: string) =>
   value
@@ -205,6 +217,7 @@ export default function SectionsView() {
       canonicalTitle: item.canonical_title,
       slug: item.slug,
       parentSlug: item.parent_slug ?? "",
+      categoryAliases: (item.category_aliases ?? []).join("\n"),
     })
     setSlugTouched(true)
     setError(null)
@@ -241,6 +254,10 @@ export default function SectionsView() {
     const canonicalTitle = form.canonicalTitle.trim()
     const slug = slugify(form.slug)
     const parentSlug = form.type === "subsection" ? form.parentSlug.trim() : ""
+    const categoryAliases = form.categoryAliases
+      .split("\n")
+      .map((alias) => alias.trim())
+      .filter((alias) => alias.length > 0)
 
     if (!canonicalTitle) {
       setError("Name is required.")
@@ -263,6 +280,7 @@ export default function SectionsView() {
         slug,
         canonical_title: canonicalTitle,
         parent_slug: form.type === "subsection" ? parentSlug : null,
+        category_aliases: categoryAliases,
       }
 
       const response = editor.mode === "create"
@@ -278,6 +296,7 @@ export default function SectionsView() {
             slug,
             canonical_title: canonicalTitle,
             parent_slug: form.type === "subsection" ? parentSlug : null,
+            category_aliases: categoryAliases,
           }),
         })
 
@@ -426,7 +445,15 @@ export default function SectionsView() {
                     <td className="px-4 py-3 text-muted-foreground">{typeLabel(item)}</td>
                     <td className="px-4 py-3 text-muted-foreground font-mono text-xs">{item.slug}</td>
                     <td className="px-4 py-3">
-                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
+                      <span
+                        className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                          articleCount === 0
+                            ? "bg-amber-500/10 text-amber-600 dark:text-amber-500"
+                            : "bg-primary/10 text-primary"
+                        }`}
+                        title={articleCount === 0 ? emptyCountHint : undefined}
+                      >
+                        {articleCount === 0 ? <AlertTriangle className="w-3 h-3" /> : null}
                         {articleCount.toLocaleString()}
                       </span>
                     </td>
@@ -521,6 +548,23 @@ export default function SectionsView() {
                   </select>
                 </label>
               ) : null}
+
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Category Names</span>
+                <textarea
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                  rows={3}
+                  placeholder="Arts &amp; Entertainment"
+                  value={form.categoryAliases}
+                  onChange={(event) => setForm((current) => ({ ...current, categoryAliases: event.target.value }))}
+                />
+                <span className="text-xs text-muted-foreground">
+                  One per line. Articles are matched on the exact category name, so add one
+                  here whenever the name on the articles differs from the name above &mdash;
+                  the Entertainment section holds articles filed under &ldquo;Arts &amp; Entertainment&rdquo;.
+                  Leave empty when they match.
+                </span>
+              </label>
             </div>
             <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-4">
               <button

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -98,6 +98,12 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by author display name or slug (partial match)",
+                        "name": "author",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by section slug",
                         "name": "section_slug",
                         "in": "query"
@@ -3164,56 +3170,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/v1/search": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "articles"
-                ],
-                "summary": "Search articles",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search term",
-                        "name": "q",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Max results",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Offset",
-                        "name": "offset",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.ArticleListItem"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/models.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/v1/sections/{section_slug}/articles": {
             "get": {
                 "produces": [
@@ -4435,6 +4391,9 @@ const docTemplate = `{
                 "published_date": {
                     "type": "string"
                 },
+                "scheduled_date": {
+                    "type": "string"
+                },
                 "seo_title": {
                     "type": "string"
                 },
@@ -4564,6 +4523,9 @@ const docTemplate = `{
                 "photo_url": {
                     "type": "string"
                 },
+                "published_date": {
+                    "type": "string"
+                },
                 "seo_title": {
                     "type": "string"
                 },
@@ -4572,6 +4534,12 @@ const docTemplate = `{
                 },
                 "status": {
                     "$ref": "#/definitions/models.ArticleStatus"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "title": {
                     "type": "string"
@@ -4668,11 +4636,20 @@ const docTemplate = `{
                 "photo_url": {
                     "type": "string"
                 },
+                "published_date": {
+                    "type": "string"
+                },
                 "seo_title": {
                     "type": "string"
                 },
                 "status": {
                     "$ref": "#/definitions/models.ArticleStatus"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "title": {
                     "type": "string"
@@ -4683,10 +4660,12 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "draft",
+                "scheduled",
                 "published"
             ],
             "x-enum-varnames": [
                 "ArticleStatusDraft",
+                "ArticleStatusScheduled",
                 "ArticleStatusPublished"
             ]
         },
@@ -5862,6 +5841,12 @@ const docTemplate = `{
                 "canonical_title": {
                     "type": "string"
                 },
+                "category_aliases": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "parent_slug": {
                     "type": "string"
                 },
@@ -5882,6 +5867,13 @@ const docTemplate = `{
                 "canonical_title": {
                     "type": "string"
                 },
+                "category_aliases": {
+                    "description": "CategoryAliases are extra category titles whose articles belong to this\nitem, for when the corpus disagrees with the slug (the Entertainment\nsection is filed under \"Arts \u0026 Entertainment\"). Article matching is\nexact, so a slug that is not the category string needs one of these.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -5901,6 +5893,13 @@ const docTemplate = `{
             "properties": {
                 "canonical_title": {
                     "type": "string"
+                },
+                "category_aliases": {
+                    "description": "Pointer so an omitted field leaves the stored aliases alone, while an\nexplicit [] clears them.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "parent_slug": {
                     "type": "string"

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -95,6 +95,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by author display name or slug (partial match)",
+                        "name": "author",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by section slug",
                         "name": "section_slug",
                         "in": "query"
@@ -3161,56 +3167,6 @@
                 }
             }
         },
-        "/v1/search": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "articles"
-                ],
-                "summary": "Search articles",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search term",
-                        "name": "q",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Max results",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Offset",
-                        "name": "offset",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.ArticleListItem"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/models.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/v1/sections/{section_slug}/articles": {
             "get": {
                 "produces": [
@@ -4432,6 +4388,9 @@
                 "published_date": {
                     "type": "string"
                 },
+                "scheduled_date": {
+                    "type": "string"
+                },
                 "seo_title": {
                     "type": "string"
                 },
@@ -4561,6 +4520,9 @@
                 "photo_url": {
                     "type": "string"
                 },
+                "published_date": {
+                    "type": "string"
+                },
                 "seo_title": {
                     "type": "string"
                 },
@@ -4569,6 +4531,12 @@
                 },
                 "status": {
                     "$ref": "#/definitions/models.ArticleStatus"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "title": {
                     "type": "string"
@@ -4665,11 +4633,20 @@
                 "photo_url": {
                     "type": "string"
                 },
+                "published_date": {
+                    "type": "string"
+                },
                 "seo_title": {
                     "type": "string"
                 },
                 "status": {
                     "$ref": "#/definitions/models.ArticleStatus"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "title": {
                     "type": "string"
@@ -4680,10 +4657,12 @@
             "type": "string",
             "enum": [
                 "draft",
+                "scheduled",
                 "published"
             ],
             "x-enum-varnames": [
                 "ArticleStatusDraft",
+                "ArticleStatusScheduled",
                 "ArticleStatusPublished"
             ]
         },
@@ -5859,6 +5838,12 @@
                 "canonical_title": {
                     "type": "string"
                 },
+                "category_aliases": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "parent_slug": {
                     "type": "string"
                 },
@@ -5879,6 +5864,13 @@
                 "canonical_title": {
                     "type": "string"
                 },
+                "category_aliases": {
+                    "description": "CategoryAliases are extra category titles whose articles belong to this\nitem, for when the corpus disagrees with the slug (the Entertainment\nsection is filed under \"Arts \u0026 Entertainment\"). Article matching is\nexact, so a slug that is not the category string needs one of these.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -5898,6 +5890,13 @@
             "properties": {
                 "canonical_title": {
                     "type": "string"
+                },
+                "category_aliases": {
+                    "description": "Pointer so an omitted field leaves the stored aliases alone, while an\nexplicit [] clears them.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "parent_slug": {
                     "type": "string"

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -121,6 +121,8 @@ definitions:
         type: string
       published_date:
         type: string
+      scheduled_date:
+        type: string
       seo_title:
         type: string
       slug:
@@ -206,12 +208,18 @@ definitions:
         type: string
       photo_url:
         type: string
+      published_date:
+        type: string
       seo_title:
         type: string
       slug:
         type: string
       status:
         $ref: '#/definitions/models.ArticleStatus'
+      tags:
+        items:
+          type: string
+        type: array
       title:
         type: string
     type: object
@@ -277,20 +285,28 @@ definitions:
         type: string
       photo_url:
         type: string
+      published_date:
+        type: string
       seo_title:
         type: string
       status:
         $ref: '#/definitions/models.ArticleStatus'
+      tags:
+        items:
+          type: string
+        type: array
       title:
         type: string
     type: object
   models.ArticleStatus:
     enum:
     - draft
+    - scheduled
     - published
     type: string
     x-enum-varnames:
     - ArticleStatusDraft
+    - ArticleStatusScheduled
     - ArticleStatusPublished
   models.ArticlesResponse:
     properties:
@@ -1055,6 +1071,10 @@ definitions:
     properties:
       canonical_title:
         type: string
+      category_aliases:
+        items:
+          type: string
+        type: array
       parent_slug:
         type: string
       slug:
@@ -1068,6 +1088,15 @@ definitions:
         type: integer
       canonical_title:
         type: string
+      category_aliases:
+        description: |-
+          CategoryAliases are extra category titles whose articles belong to this
+          item, for when the corpus disagrees with the slug (the Entertainment
+          section is filed under "Arts & Entertainment"). Article matching is
+          exact, so a slug that is not the category string needs one of these.
+        items:
+          type: string
+        type: array
       id:
         type: integer
       parent_slug:
@@ -1081,6 +1110,13 @@ definitions:
     properties:
       canonical_title:
         type: string
+      category_aliases:
+        description: |-
+          Pointer so an omitted field leaves the stored aliases alone, while an
+          explicit [] clears them.
+        items:
+          type: string
+        type: array
       parent_slug:
         type: string
       slug:
@@ -1172,6 +1208,10 @@ paths:
       - description: Filter by author slug
         in: query
         name: author_slug
+        type: string
+      - description: Filter by author display name or slug (partial match)
+        in: query
+        name: author
         type: string
       - description: Filter by section slug
         in: query
@@ -3150,39 +3190,6 @@ paths:
       summary: List all polls including drafts
       tags:
       - poll
-  /v1/search:
-    get:
-      parameters:
-      - description: Search term
-        in: query
-        name: q
-        required: true
-        type: string
-      - default: 20
-        description: Max results
-        in: query
-        name: limit
-        type: integer
-      - description: Offset
-        in: query
-        name: offset
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/models.ArticleListItem'
-            type: array
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/models.ErrorResponse'
-      summary: Search articles
-      tags:
-      - articles
   /v1/sections/{section_slug}/articles:
     get:
       parameters:

--- a/server/internal/database/http_models.go
+++ b/server/internal/database/http_models.go
@@ -488,26 +488,36 @@ func ParsePublishedAt(value string) *time.Time {
 	return nil
 }
 
+// MarshalCategoryJSON encodes category text as JSON WITHOUT HTML-escaping.
+//
+// Use this for anything holding a category title. json.Marshal escapes "&" into
+// a backslash-u escape, and category matching compares against the plain
+// character the ETL writes, so an escaped value stops matching its own section:
+// saving an article in the CMS used to rewrite "Comics & Puzzles" and quietly
+// drop the article out of Comics & Puzzles. Both the articles column and
+// site_taxonomy aliases go through here so the two can never disagree.
+func MarshalCategoryJSON(value any) (string, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return "", err
+	}
+	// Encode appends a newline that the column should not carry.
+	return strings.TrimRight(buf.String(), "\n"), nil
+}
+
 // FormatTags encodes categories as the JSON array the `categories` column
 // stores.
-//
-// It deliberately does not use json.Marshal: that HTML-escapes "&" into a
-// backslash-u escape, so saving an article in the CMS rewrote "Comics & Puzzles"
-// into a spelling the section matcher no longer recognized, quietly dropping the
-// article out of its own section. The ETL writes the character plainly, and the
-// two producers have to agree.
 func FormatTags(categories []string) string {
 	if len(categories) == 0 {
 		return ""
 	}
-	var buf bytes.Buffer
-	encoder := json.NewEncoder(&buf)
-	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(categories); err != nil {
+	encoded, err := MarshalCategoryJSON(categories)
+	if err != nil {
 		return strings.Join(categories, ",")
 	}
-	// Encode appends a newline that the column should not carry.
-	return strings.TrimRight(buf.String(), "\n")
+	return encoded
 }
 
 func defaultCommentStatus() string {

--- a/server/internal/database/schema/site_taxonomy.sql
+++ b/server/internal/database/schema/site_taxonomy.sql
@@ -5,6 +5,11 @@ CREATE TABLE IF NOT EXISTS site_taxonomy (
   canonical_title VARCHAR(255) NOT NULL,
   parent_slug VARCHAR(255) NULL,
   article_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  -- Extra category titles whose articles belong to this row, for when the
+  -- corpus disagrees with the slug: the Entertainment section is filed under
+  -- "Arts & Entertainment". NULL means "never set" and is seeded with the
+  -- known defaults; an empty array means an editor deliberately cleared it.
+  category_aliases JSON NULL,
   UNIQUE KEY uq_site_taxonomy_kind_slug (kind, slug),
   KEY idx_site_taxonomy_kind (kind),
   KEY idx_site_taxonomy_parent_slug (parent_slug)

--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -3,7 +3,10 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"log/slog"
 	"strings"
+	"sync"
 )
 
 func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
@@ -12,11 +15,131 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 		return err
 	}
 
-	_, err = conn.ExecContext(ctx, `
+	if _, err = conn.ExecContext(ctx, `
 		ALTER TABLE site_taxonomy
 		ADD COLUMN IF NOT EXISTS article_count BIGINT UNSIGNED NOT NULL DEFAULT 0
+	`); err != nil {
+		return err
+	}
+
+	if _, err = conn.ExecContext(ctx, `
+		ALTER TABLE site_taxonomy
+		ADD COLUMN IF NOT EXISTS category_aliases JSON NULL
+	`); err != nil {
+		return err
+	}
+
+	if err = SeedDefaultCategoryAliases(ctx, conn); err != nil {
+		return err
+	}
+	return RefreshCategoryAliases(ctx, conn)
+}
+
+// defaultCategoryAliases are the slug -> category-title mismatches that existed
+// before aliases were editable data, seeded so upgrading an existing database
+// does not silently empty four sections.
+//
+// Only applied where category_aliases IS NULL, so "never set" stays
+// distinguishable from an empty array an editor deliberately saved.
+var defaultCategoryAliases = map[string][]string{
+	"entertainment":       {"Arts & Entertainment"},
+	"science-tech":        {"Science & Technology"},
+	"from-the-editor":     {"From the Editor's Desk"},
+	"happening-in-philly": {"What's Happening in Philly"},
+}
+
+func SeedDefaultCategoryAliases(ctx context.Context, conn *sql.DB) error {
+	for slug, aliases := range defaultCategoryAliases {
+		payload, err := MarshalCategoryJSON(aliases)
+		if err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+			UPDATE site_taxonomy
+			SET category_aliases = ?
+			WHERE slug = ? AND category_aliases IS NULL
+		`, payload, slug); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// categoryAliasCache holds site_taxonomy's aliases in memory so
+// CategoryMatchPatterns can stay a pure function of a slug. Reloading it is
+// cheap (the table is ~50 rows) and only happens at startup and after a
+// taxonomy write, which keeps the article-listing path free of an extra query.
+var (
+	categoryAliasMu     sync.RWMutex
+	categoryAliasBySlug = map[string][]string{}
+)
+
+// RefreshCategoryAliases reloads the alias cache from site_taxonomy. Call it
+// after any write to the table, or matching will keep using the old aliases
+// until the process restarts.
+func RefreshCategoryAliases(ctx context.Context, conn *sql.DB) error {
+	rows, err := conn.QueryContext(ctx, `
+		SELECT slug, category_aliases
+		FROM site_taxonomy
+		WHERE category_aliases IS NOT NULL
 	`)
-	return err
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	loaded := make(map[string][]string)
+	for rows.Next() {
+		var slug string
+		var raw sql.NullString
+		if err := rows.Scan(&slug, &raw); err != nil {
+			return err
+		}
+		aliases, err := ParseCategoryAliases(raw.String)
+		if err != nil {
+			// One malformed row must not blank every other section's
+			// aliases, so skip it and keep going.
+			slog.Warn("ignoring malformed taxonomy category_aliases", "slug", slug, "error", err)
+			continue
+		}
+		if len(aliases) > 0 {
+			loaded[strings.ToLower(strings.TrimSpace(slug))] = aliases
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	categoryAliasMu.Lock()
+	categoryAliasBySlug = loaded
+	categoryAliasMu.Unlock()
+	return nil
+}
+
+// ParseCategoryAliases decodes the stored JSON array, dropping blanks. An empty
+// or absent value is not an error -- most rows have no aliases.
+func ParseCategoryAliases(raw string) ([]string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || trimmed == "null" {
+		return nil, nil
+	}
+	var decoded []string
+	if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+		return nil, err
+	}
+	aliases := make([]string, 0, len(decoded))
+	for _, alias := range decoded {
+		if cleaned := strings.TrimSpace(alias); cleaned != "" {
+			aliases = append(aliases, cleaned)
+		}
+	}
+	return aliases, nil
+}
+
+func categoryAliasesFor(slug string) []string {
+	categoryAliasMu.RLock()
+	defer categoryAliasMu.RUnlock()
+	return categoryAliasBySlug[slug]
 }
 
 // CategoryColumnExpr is the SQL expression every category match runs against.
@@ -29,21 +152,6 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 // spelling. FormatTags no longer produces it, but rows written before that fix
 // still carry it.
 const CategoryColumnExpr = "REPLACE(LOWER(`categories`), '\\\\u0026', '&')"
-
-// categoryAliases maps a taxonomy slug to the category titles articles are
-// really filed under, for the cases where the corpus and the slug disagree.
-//
-// These are not spelling variants a rule could derive -- the section is named
-// one thing and the category another -- and before exact matching they were
-// carried accidentally by substring matching ("entertainment" happened to be
-// inside "Arts & Entertainment"). Making them explicit is what lets the match
-// be exact everywhere else.
-var categoryAliases = map[string][]string{
-	"entertainment":       {"arts & entertainment"},
-	"science-tech":        {"science & technology"},
-	"from-the-editor":     {"from the editor's desk"},
-	"happening-in-philly": {"what's happening in philly"},
-}
 
 // CategoryMatchPatterns returns the CategoryColumnExpr LIKE patterns that
 // identify articles filed under a taxonomy slug.
@@ -61,6 +169,11 @@ var categoryAliases = map[string][]string{
 // subsection, and `%men's basketball%` is a substring of "Women's Basketball",
 // which folded the women's team into the men's. Both read as plausible-but-wrong
 // pages rather than as errors, so anchoring is load-bearing, not cosmetic.
+//
+// Because the match is exact, a slug that is not the canonicalized category
+// string resolves to nothing on its own -- it needs an alias row. Those come
+// from the cache, so callers must have run RefreshCategoryAliases first;
+// EnsureTaxonomyTable does it at startup.
 func CategoryMatchPatterns(slug string) []string {
 	normalized := strings.ToLower(strings.TrimSpace(slug))
 	if normalized == "" {
@@ -89,8 +202,8 @@ func CategoryMatchPatterns(slug string) []string {
 			add(possessive)
 		}
 	}
-	for _, alias := range categoryAliases[normalized] {
-		add(alias)
+	for _, alias := range categoryAliasesFor(normalized) {
+		add(strings.ToLower(strings.TrimSpace(alias)))
 	}
 	return patterns
 }
@@ -212,6 +325,16 @@ func RebuildTaxonomyArticleCounts(ctx context.Context, conn *sql.DB) error {
 			return err
 		}
 		counts[slug] = count
+		if count == 0 {
+			// The failure mode this catches: matching is exact, so a slug
+			// that is not the canonicalized category string resolves to
+			// nothing and its page renders empty. That looks like a section
+			// with no content rather than a misconfiguration, which is
+			// exactly how four sections stayed broken until someone noticed
+			// the comics were in the wrong place. Name it out loud.
+			slog.Warn("taxonomy slug matches no articles; it likely needs a category alias",
+				"slug", slug, "matched_slugs", slugs)
+		}
 	}
 
 	tx, err := conn.BeginTx(ctx, nil)

--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -305,36 +305,45 @@ func TaxonomyCountCondition(slugs []string) (string, []any) {
 	return "(" + strings.Join(clauses, " OR ") + ")", args
 }
 
+// countArticlesForSlugs counts the articles a taxonomy row matches, over the
+// same population the public listing shows, so article_count equals the total a
+// reader actually pages through.
+func countArticlesForSlugs(ctx context.Context, conn *sql.DB, slug string, matched []string) (int64, error) {
+	condition, args := TaxonomyCountCondition(matched)
+	if condition == "" {
+		return 0, nil
+	}
+	var count int64
+	query := "SELECT COUNT(*) FROM `articles` WHERE `archived_at` IS NULL AND `pub_date` IS NOT NULL AND `pub_date` <= UTC_TIMESTAMP() AND " + condition
+	if err := conn.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, err
+	}
+	if count == 0 {
+		// The failure mode this catches: matching is exact, so a slug that is
+		// not the canonicalized category string resolves to nothing and its
+		// page renders empty. That looks like a section with no content rather
+		// than a misconfiguration, which is exactly how four sections stayed
+		// broken until someone noticed the comics were in the wrong place.
+		// Name it out loud.
+		slog.Warn("taxonomy slug matches no articles; it likely needs a category alias",
+			"slug", slug, "matched_slugs", matched)
+	}
+	return count, nil
+}
+
 func RebuildTaxonomyArticleCounts(ctx context.Context, conn *sql.DB) error {
 	matchSlugs, err := taxonomyMatchSlugs(ctx, conn)
 	if err != nil {
 		return err
 	}
 
-	// Counted over the same population the public listing shows, so
-	// article_count equals the total a reader actually pages through.
 	counts := make(map[string]int64, len(matchSlugs))
 	for slug, slugs := range matchSlugs {
-		condition, args := TaxonomyCountCondition(slugs)
-		if condition == "" {
-			continue
-		}
-		var count int64
-		query := "SELECT COUNT(*) FROM `articles` WHERE `archived_at` IS NULL AND `pub_date` IS NOT NULL AND `pub_date` <= UTC_TIMESTAMP() AND " + condition
-		if err := conn.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		count, err := countArticlesForSlugs(ctx, conn, slug, slugs)
+		if err != nil {
 			return err
 		}
 		counts[slug] = count
-		if count == 0 {
-			// The failure mode this catches: matching is exact, so a slug
-			// that is not the canonicalized category string resolves to
-			// nothing and its page renders empty. That looks like a section
-			// with no content rather than a misconfiguration, which is
-			// exactly how four sections stayed broken until someone noticed
-			// the comics were in the wrong place. Name it out loud.
-			slog.Warn("taxonomy slug matches no articles; it likely needs a category alias",
-				"slug", slug, "matched_slugs", slugs)
-		}
 	}
 
 	tx, err := conn.BeginTx(ctx, nil)
@@ -368,4 +377,91 @@ func RebuildTaxonomyArticleCounts(ctx context.Context, conn *sql.DB) error {
 	}
 
 	return tx.Commit()
+}
+
+// RebuildTaxonomyArticleCountsFor recounts only the rows a single taxonomy edit
+// can have changed, so a save in the sections screen can refresh the number it
+// just invalidated without paying for a full rebuild.
+//
+// A full rebuild runs one scan of the articles table per taxonomy row -- fine as
+// startup or maintenance work, far too slow to sit inside a save. The blast
+// radius of one edit is small: the row itself, plus its parent section, because
+// a section matches its own slug OR any of its children's. Nothing else moves.
+//
+// Callers pass the slugs they touched; parents are resolved here.
+func RebuildTaxonomyArticleCountsFor(ctx context.Context, conn *sql.DB, slugs ...string) error {
+	matchSlugs, err := taxonomyMatchSlugs(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	parents, err := taxonomyParentsBySlug(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	affected := make(map[string]struct{}, len(slugs)*2)
+	for _, slug := range slugs {
+		normalized := strings.TrimSpace(slug)
+		if normalized == "" {
+			continue
+		}
+		affected[normalized] = struct{}{}
+		if parent := parents[normalized]; parent != "" {
+			affected[parent] = struct{}{}
+		}
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+
+	stmt, err := conn.PrepareContext(ctx, `
+		UPDATE site_taxonomy
+		SET article_count = ?
+		WHERE kind IN ('section', 'subsection') AND slug = ?
+	`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for slug := range affected {
+		matched, ok := matchSlugs[slug]
+		if !ok {
+			// Deleted by the edit that triggered this; nothing to update.
+			continue
+		}
+		count, err := countArticlesForSlugs(ctx, conn, slug, matched)
+		if err != nil {
+			return err
+		}
+		if _, err := stmt.ExecContext(ctx, count, slug); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func taxonomyParentsBySlug(ctx context.Context, conn *sql.DB) (map[string]string, error) {
+	rows, err := conn.QueryContext(ctx, `
+		SELECT slug, COALESCE(parent_slug, '')
+		FROM site_taxonomy
+		WHERE kind = 'subsection'
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	parents := make(map[string]string)
+	for rows.Next() {
+		var slug, parent string
+		if err := rows.Scan(&slug, &parent); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(parent) != "" {
+			parents[slug] = parent
+		}
+	}
+	return parents, rows.Err()
 }

--- a/server/internal/database/taxonomy_integration_test.go
+++ b/server/internal/database/taxonomy_integration_test.go
@@ -1,0 +1,172 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// These need a real MariaDB, because the whole point is the column, the seed
+// and the cache reload agreeing with each other. They skip unless CMS_TEST_DSN
+// is set, so CI without a database stays green.
+//
+//	CMS_TEST_DSN='root:pw@tcp(127.0.0.1:3306)/tax_test?parseTime=true&multiStatements=true' go test ./internal/database/ -run TaxonomyAlias -v
+func taxonomyTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("CMS_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CMS_TEST_DSN not set; skipping taxonomy database integration test")
+	}
+
+	conn, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	if err := conn.Ping(); err != nil {
+		t.Fatalf("ping test database: %v", err)
+	}
+
+	ctx := context.Background()
+	acquireMediaTestLock(ctx, t, conn)
+
+	if _, err := conn.ExecContext(ctx, "DROP TABLE IF EXISTS site_taxonomy"); err != nil {
+		t.Fatalf("drop site_taxonomy: %v", err)
+	}
+	t.Cleanup(func() {
+		categoryAliasMu.Lock()
+		categoryAliasBySlug = map[string][]string{}
+		categoryAliasMu.Unlock()
+	})
+	return conn
+}
+
+func insertTaxonomyRow(t *testing.T, conn *sql.DB, id int64, kind, slug, title string) {
+	t.Helper()
+	if _, err := conn.ExecContext(context.Background(),
+		"INSERT INTO site_taxonomy (id, kind, slug, canonical_title) VALUES (?, ?, ?, ?)",
+		id, kind, slug, title,
+	); err != nil {
+		t.Fatalf("insert %s: %v", slug, err)
+	}
+}
+
+func TestTaxonomyAliasSeedAndCacheRoundTrip(t *testing.T) {
+	conn := taxonomyTestDB(t)
+	ctx := context.Background()
+
+	// A first EnsureTaxonomyTable creates the table; the rows land after, the
+	// way an existing database looks when this version first starts.
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("ensure taxonomy table: %v", err)
+	}
+	insertTaxonomyRow(t, conn, 1, "section", "entertainment", "Entertainment")
+	insertTaxonomyRow(t, conn, 2, "section", "news", "News")
+
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+
+	// entertainment must have picked up its seeded default...
+	patterns := CategoryMatchPatterns("entertainment")
+	if !containsPattern(patterns, `%"arts & entertainment"%`) {
+		t.Errorf("entertainment patterns %v missing the seeded alias", patterns)
+	}
+	// ...and it must not be HTML-escaped in the column, or it would never
+	// match the articles it names.
+	var stored string
+	if err := conn.QueryRowContext(ctx,
+		"SELECT category_aliases FROM site_taxonomy WHERE slug = 'entertainment'",
+	).Scan(&stored); err != nil {
+		t.Fatalf("read stored aliases: %v", err)
+	}
+	if want := `["Arts & Entertainment"]`; stored != want {
+		t.Errorf("stored aliases = %s, want %s", stored, want)
+	}
+
+	// A slug with no default keeps no aliases.
+	if got := CategoryMatchPatterns("news"); len(got) != 1 {
+		t.Errorf("news patterns = %v, want just its own", got)
+	}
+}
+
+func TestTaxonomyAliasSeedDoesNotResurrectClearedAliases(t *testing.T) {
+	conn := taxonomyTestDB(t)
+	ctx := context.Background()
+
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("ensure taxonomy table: %v", err)
+	}
+	insertTaxonomyRow(t, conn, 1, "section", "entertainment", "Entertainment")
+	if err := SeedDefaultCategoryAliases(ctx, conn); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// An editor deliberately clears the aliases. That is [] , not NULL, and a
+	// later startup must leave it alone -- otherwise the defaults come back
+	// every restart and the edit looks like it never saved.
+	if _, err := conn.ExecContext(ctx,
+		"UPDATE site_taxonomy SET category_aliases = '[]' WHERE slug = 'entertainment'",
+	); err != nil {
+		t.Fatalf("clear aliases: %v", err)
+	}
+	if err := SeedDefaultCategoryAliases(ctx, conn); err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+
+	var stored string
+	if err := conn.QueryRowContext(ctx,
+		"SELECT category_aliases FROM site_taxonomy WHERE slug = 'entertainment'",
+	).Scan(&stored); err != nil {
+		t.Fatalf("read stored aliases: %v", err)
+	}
+	if stored != "[]" {
+		t.Errorf("stored aliases = %s, want [] -- the seed overwrote a deliberate clear", stored)
+	}
+}
+
+func TestTaxonomyAliasRefreshPicksUpWrites(t *testing.T) {
+	conn := taxonomyTestDB(t)
+	ctx := context.Background()
+
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("ensure taxonomy table: %v", err)
+	}
+	insertTaxonomyRow(t, conn, 1, "subsection", "movies", "Movies")
+	if err := RefreshCategoryAliases(ctx, conn); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if got := CategoryMatchPatterns("movies"); len(got) != 1 {
+		t.Fatalf("movies patterns = %v, want just its own", got)
+	}
+
+	if _, err := conn.ExecContext(ctx,
+		`UPDATE site_taxonomy SET category_aliases = '["Movies I''ve Seen"]' WHERE slug = 'movies'`,
+	); err != nil {
+		t.Fatalf("write alias: %v", err)
+	}
+	// Still stale until the cache is told, which is why every write path calls
+	// RefreshCategoryAliases.
+	if got := CategoryMatchPatterns("movies"); len(got) != 1 {
+		t.Errorf("patterns changed before a refresh: %v", got)
+	}
+	if err := RefreshCategoryAliases(ctx, conn); err != nil {
+		t.Fatalf("refresh after write: %v", err)
+	}
+	if got := CategoryMatchPatterns("movies"); !containsPattern(got, `%"movies i've seen"%`) {
+		t.Errorf("movies patterns %v missing the written alias", got)
+	}
+}
+
+func containsPattern(patterns []string, want string) bool {
+	for _, pattern := range patterns {
+		if pattern == want {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/database/taxonomy_test.go
+++ b/server/internal/database/taxonomy_test.go
@@ -54,6 +54,22 @@ func TestCategoryMatchPatternsEmpty(t *testing.T) {
 	}
 }
 
+// withCategoryAliases installs aliases in the cache for one test, standing in
+// for what RefreshCategoryAliases loads from site_taxonomy, and restores the
+// previous contents afterwards.
+func withCategoryAliases(t *testing.T, aliases map[string][]string) {
+	t.Helper()
+	categoryAliasMu.Lock()
+	previous := categoryAliasBySlug
+	categoryAliasBySlug = aliases
+	categoryAliasMu.Unlock()
+	t.Cleanup(func() {
+		categoryAliasMu.Lock()
+		categoryAliasBySlug = previous
+		categoryAliasMu.Unlock()
+	})
+}
+
 // escapedAmp is the escape encoding/json emits for "&". Assembled by
 // concatenation so the sequence cannot be folded back into a literal "&" by an
 // editor or a copy-paste, which would make the tests below silently vacuous.
@@ -119,6 +135,12 @@ func TestCategoryMatchDoesNotMatchLongerCategory(t *testing.T) {
 func TestCategoryMatchResolvesAliases(t *testing.T) {
 	// The section is "Entertainment" but every article is filed under "Arts &
 	// Entertainment"; exact matching only works because the alias is explicit.
+	withCategoryAliases(t, map[string][]string{
+		"entertainment":       {"Arts & Entertainment"},
+		"science-tech":        {"Science & Technology"},
+		"from-the-editor":     {"From the Editor's Desk"},
+		"happening-in-philly": {"What's Happening in Philly"},
+	})
 	for slug, categories := range map[string]string{
 		"entertainment":       `["Arts & Entertainment"]`,
 		"science-tech":        `["Science & Technology", "Opinion"]`,
@@ -134,6 +156,7 @@ func TestCategoryMatchResolvesAliases(t *testing.T) {
 func TestCategoryMatchToleratesEscapedAmpersand(t *testing.T) {
 	// Articles saved through the CMS before the FormatTags fix carry the
 	// HTML-escaped ampersand; they must still match their section.
+	withCategoryAliases(t, map[string][]string{"entertainment": {"Arts & Entertainment"}})
 	if !matchesCategories("comics-puzzles", `["Crossword","Comics `+escapedAmp+` Puzzles"]`) {
 		t.Error("an escaped-ampersand row must still match its section")
 	}
@@ -203,10 +226,86 @@ func TestFormatTagsKeepsAmpersandUnescaped(t *testing.T) {
 func TestFormatTagsRoundTripsThroughTheMatcher(t *testing.T) {
 	// The two halves of the fix have to agree: whatever FormatTags writes must
 	// still match the section it names.
+	withCategoryAliases(t, map[string][]string{"entertainment": {"Arts & Entertainment"}})
 	if !matchesCategories("comics-puzzles", FormatTags([]string{"Comics", "Comics & Puzzles"})) {
 		t.Error("a CMS-saved article must match its own section")
 	}
 	if !matchesCategories("entertainment", FormatTags([]string{"Arts & Entertainment"})) {
 		t.Error("a CMS-saved article must match its own section via alias")
+	}
+}
+
+func TestParseCategoryAliases(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"sql null", "null", nil},
+		{"empty array", "[]", []string{}},
+		{"one", `["Arts & Entertainment"]`, []string{"Arts & Entertainment"}},
+		{"trims and drops blanks", `["  Arts & Entertainment  ", "", "   "]`, []string{"Arts & Entertainment"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseCategoryAliases(tc.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("alias %d = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseCategoryAliasesRejectsMalformed(t *testing.T) {
+	// A malformed value must surface as an error rather than resolving to "no
+	// aliases", which would empty the section without saying why.
+	if _, err := ParseCategoryAliases(`{"not":"an array"}`); err == nil {
+		t.Fatal("expected an error for a non-array value")
+	}
+}
+
+func TestCategoryAliasesAreCaseInsensitiveOnTheSlug(t *testing.T) {
+	// Aliases are keyed by lowercased slug, and the stored title's casing must
+	// not matter either -- patterns are matched against a lowercased column.
+	withCategoryAliases(t, map[string][]string{"entertainment": {"ARTS & ENTERTAINMENT"}})
+	if !matchesCategories("Entertainment", `["Arts & Entertainment"]`) {
+		t.Error("alias matching must be case-insensitive")
+	}
+}
+
+func TestCategoryMatchPatternsDeduplicatesAliases(t *testing.T) {
+	// An alias that merely restates a derived pattern must not double the
+	// placeholders in every query that uses the slug.
+	withCategoryAliases(t, map[string][]string{"comics": {"Comics"}})
+	assertPatterns(t, "comics", []string{`%"comics"%`})
+}
+
+func TestDefaultCategoryAliasesCoverTheKnownMismatches(t *testing.T) {
+	// These four sections are named differently from the category their
+	// articles carry. Losing a default silently empties a section on upgrade,
+	// so pin them.
+	want := map[string]string{
+		"entertainment":       "Arts & Entertainment",
+		"science-tech":        "Science & Technology",
+		"from-the-editor":     "From the Editor's Desk",
+		"happening-in-philly": "What's Happening in Philly",
+	}
+	for slug, alias := range want {
+		got, ok := defaultCategoryAliases[slug]
+		if !ok {
+			t.Errorf("missing default alias for %q", slug)
+			continue
+		}
+		if len(got) != 1 || got[0] != alias {
+			t.Errorf("default alias for %q = %v, want [%q]", slug, got, alias)
+		}
 	}
 }

--- a/server/internal/handlers/taxonomy.go
+++ b/server/internal/handlers/taxonomy.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -23,17 +24,70 @@ func isValidTaxonomyType(taxType string) bool {
 	return validTaxonomyTypes[strings.TrimSpace(taxType)]
 }
 
+// taxonomySelectColumns is the column list every taxonomy read shares, kept in
+// one place so a new column cannot be added to some queries and missed by
+// others -- scanTaxonomyRow depends on this exact order.
+const taxonomySelectColumns = "id, kind, slug, canonical_title, parent_slug, article_count, category_aliases"
+
 func scanTaxonomyRow(row interface{ Scan(...any) error }) (models.TaxonomyItem, error) {
 	var item models.TaxonomyItem
 	var parentSlug sql.NullString
-	if err := row.Scan(&item.ID, &item.Type, &item.Slug, &item.CanonicalTitle, &parentSlug, &item.ArticleCount); err != nil {
+	var aliases sql.NullString
+	if err := row.Scan(&item.ID, &item.Type, &item.Slug, &item.CanonicalTitle, &parentSlug, &item.ArticleCount, &aliases); err != nil {
 		return models.TaxonomyItem{}, err
 	}
 	if parentSlug.Valid && parentSlug.String != "" {
 		s := parentSlug.String
 		item.ParentSlug = &s
 	}
+	parsed, err := db.ParseCategoryAliases(aliases.String)
+	if err != nil {
+		return models.TaxonomyItem{}, err
+	}
+	// Always a list, never null, so the editor can bind to it directly.
+	item.CategoryAliases = parsed
+	if item.CategoryAliases == nil {
+		item.CategoryAliases = []string{}
+	}
 	return item, nil
+}
+
+// normalizeCategoryAliases trims and de-duplicates, dropping blanks. Returns
+// the JSON to store; an empty list is stored as [] rather than NULL so it stays
+// distinguishable from "never set", which is what the defaults seed on.
+func normalizeCategoryAliases(aliases []string) (string, error) {
+	cleaned := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		trimmed := strings.TrimSpace(alias)
+		if trimmed == "" {
+			continue
+		}
+		duplicate := false
+		for _, existing := range cleaned {
+			if strings.EqualFold(existing, trimmed) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	return db.MarshalCategoryJSON(cleaned)
+}
+
+// refreshCategoryAliasCache reloads the in-memory aliases after a taxonomy
+// write. A failure here does not fail the request -- the row is already saved,
+// and matching keeps using the previous aliases until the next write or
+// restart -- but it must be loud, because the symptom otherwise is an edit that
+// appears to do nothing.
+func refreshCategoryAliasCache(r *http.Request, conn *sql.DB) {
+	if conn == nil {
+		return
+	}
+	if err := db.RefreshCategoryAliases(r.Context(), conn); err != nil {
+		slog.Error("failed to refresh category alias cache", "error", err)
+	}
 }
 
 func taxonomyItemArticleCount(ctx context.Context, conn *sql.DB, taxType, slug string) (int64, error) {
@@ -117,10 +171,10 @@ func GetTaxonomy(conn *sql.DB) http.HandlerFunc {
 				writeError(w, http.StatusBadRequest, "type must be one of: section, subsection, tag")
 				return
 			}
-			query = "SELECT id, kind, slug, canonical_title, parent_slug, article_count FROM site_taxonomy WHERE kind = ? ORDER BY id ASC"
+			query = "SELECT " + taxonomySelectColumns + " FROM site_taxonomy WHERE kind = ? ORDER BY id ASC"
 			args = []any{taxType}
 		} else {
-			query = "SELECT id, kind, slug, canonical_title, parent_slug, article_count FROM site_taxonomy ORDER BY kind ASC, id ASC"
+			query = "SELECT " + taxonomySelectColumns + " FROM site_taxonomy ORDER BY kind ASC, id ASC"
 		}
 
 		rows, err := conn.QueryContext(r.Context(), query, args...)
@@ -172,7 +226,7 @@ func GetTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 		}
 
 		row := conn.QueryRowContext(r.Context(),
-			"SELECT id, kind, slug, canonical_title, parent_slug, article_count FROM site_taxonomy WHERE kind = ? AND slug = ?",
+			"SELECT "+taxonomySelectColumns+" FROM site_taxonomy WHERE kind = ? AND slug = ?",
 			taxType, slug,
 		)
 		item, err := scanTaxonomyRow(row)
@@ -234,14 +288,21 @@ func PostTaxonomy(conn *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		aliases, err := normalizeCategoryAliases(body.CategoryAliases)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "category_aliases must be a list of strings")
+			return
+		}
+
 		_, err = db.Insert(r.Context(), conn, "site_taxonomy",
-			[]string{"id", "kind", "slug", "canonical_title", "parent_slug", "article_count"},
-			nextID, taxType, slug, title, parentSlug, 0,
+			[]string{"id", "kind", "slug", "canonical_title", "parent_slug", "article_count", "category_aliases"},
+			nextID, taxType, slug, title, parentSlug, 0, aliases,
 		)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+		refreshCategoryAliasCache(r, conn)
 		action := "taxonomy_created"
 		if taxType == string(models.TaxonomyTypeTag) {
 			action = "tag_created"
@@ -330,10 +391,26 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			}
 		}
 
+		// Omitting category_aliases leaves the stored value alone; sending []
+		// clears it. Without that distinction, every edit made from a client
+		// that does not know about aliases would silently wipe them.
+		columns := []string{"slug", "canonical_title", "parent_slug"}
+		values := []any{newSlug, title, parentSlug}
+		if body.CategoryAliases != nil {
+			aliases, err := normalizeCategoryAliases(*body.CategoryAliases)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "category_aliases must be a list of strings")
+				return
+			}
+			columns = append(columns, "category_aliases")
+			values = append(values, aliases)
+		}
+		values = append(values, taxType, slug)
+
 		result, err := db.Update(r.Context(), conn, "site_taxonomy",
-			[]string{"slug", "canonical_title", "parent_slug"},
+			columns,
 			"kind = ? AND slug = ?",
-			newSlug, title, parentSlug, taxType, slug,
+			values...,
 		)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -352,6 +429,7 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 		if taxType == string(models.TaxonomyTypeTag) {
 			action = "tag_updated"
 		}
+		refreshCategoryAliasCache(r, conn)
 		activity.LogRequest(r, action, fmt.Sprintf("%s: %s", taxType, title), "old_slug", slug, "new_slug", newSlug)
 		w.WriteHeader(http.StatusNoContent)
 	}
@@ -421,6 +499,7 @@ func DeleteTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusNotFound, "taxonomy item not found")
 			return
 		}
+		refreshCategoryAliasCache(r, conn)
 		action := "taxonomy_deleted"
 		if taxType == string(models.TaxonomyTypeTag) {
 			action = "tag_deleted"

--- a/server/internal/handlers/taxonomy.go
+++ b/server/internal/handlers/taxonomy.go
@@ -76,18 +76,41 @@ func normalizeCategoryAliases(aliases []string) (string, error) {
 	return db.MarshalCategoryJSON(cleaned)
 }
 
-// refreshCategoryAliasCache reloads the in-memory aliases after a taxonomy
-// write. A failure here does not fail the request -- the row is already saved,
-// and matching keeps using the previous aliases until the next write or
-// restart -- but it must be loud, because the symptom otherwise is an edit that
-// appears to do nothing.
-func refreshCategoryAliasCache(r *http.Request, conn *sql.DB) {
+// refreshTaxonomyDerivedState brings everything downstream of a taxonomy write
+// back in line: the in-memory aliases that article matching reads, and the
+// stored article_count the sections screen shows.
+//
+// Both matter for the same reason. Matching updates the moment the cache
+// reloads, but article_count is a stored number, so without recounting an
+// editor who fixes a section sees it start working on the site while the screen
+// still shows 0 -- a successful fix that looks like a failed one. Only the
+// touched rows are recounted; see RebuildTaxonomyArticleCountsFor.
+//
+// Neither failure fails the request: the row is already saved, and both are
+// recoverable at the next write or restart. They are logged loudly instead,
+// because the symptom otherwise is an edit that appears to do nothing.
+//
+// Callers pass every slug the write touched, INCLUDING a parent whose row is
+// about to disappear -- parents cannot be resolved once the child is deleted.
+func refreshTaxonomyDerivedState(r *http.Request, conn *sql.DB, slugs ...string) {
 	if conn == nil {
 		return
 	}
 	if err := db.RefreshCategoryAliases(r.Context(), conn); err != nil {
 		slog.Error("failed to refresh category alias cache", "error", err)
 	}
+	if err := db.RebuildTaxonomyArticleCountsFor(r.Context(), conn, slugs...); err != nil {
+		slog.Error("failed to recount taxonomy articles after a write", "slugs", slugs, "error", err)
+	}
+}
+
+// parentSlugForRecount narrows validateTaxonomyParent's any-typed result to the
+// slug string, or "" for a section.
+func parentSlugForRecount(parentSlug any) string {
+	if parent, ok := parentSlug.(string); ok {
+		return parent
+	}
+	return ""
 }
 
 func taxonomyItemArticleCount(ctx context.Context, conn *sql.DB, taxType, slug string) (int64, error) {
@@ -323,7 +346,7 @@ func PostTaxonomy(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		refreshCategoryAliasCache(r, conn)
+		refreshTaxonomyDerivedState(r, conn, slug, parentSlugForRecount(parentSlug))
 		action := "taxonomy_created"
 		if taxType == string(models.TaxonomyTypeTag) {
 			action = "tag_created"
@@ -450,7 +473,7 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 		if taxType == string(models.TaxonomyTypeTag) {
 			action = "tag_updated"
 		}
-		refreshCategoryAliasCache(r, conn)
+		refreshTaxonomyDerivedState(r, conn, slug, newSlug, parentSlugForRecount(parentSlug))
 		activity.LogRequest(r, action, fmt.Sprintf("%s: %s", taxType, title), "old_slug", slug, "new_slug", newSlug)
 		w.WriteHeader(http.StatusNoContent)
 	}
@@ -479,6 +502,20 @@ func DeleteTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "slug must be canonical")
 			return
 		}
+		// Captured before the row goes away: once it is deleted its parent can
+		// no longer be looked up, and the parent's count changes because a
+		// section matches its own slug OR any of its children's.
+		var deletedParentSlug string
+		if conn != nil {
+			var parent sql.NullString
+			if err := conn.QueryRowContext(r.Context(),
+				"SELECT parent_slug FROM site_taxonomy WHERE kind = ? AND slug = ? LIMIT 1",
+				taxType, slug,
+			).Scan(&parent); err == nil && parent.Valid {
+				deletedParentSlug = strings.TrimSpace(parent.String)
+			}
+		}
+
 		if conn != nil {
 			// Existence check only -- the count it returns is the cached one.
 			if _, err := taxonomyItemArticleCount(r.Context(), conn, taxType, slug); err == sql.ErrNoRows {
@@ -530,7 +567,7 @@ func DeleteTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusNotFound, "taxonomy item not found")
 			return
 		}
-		refreshCategoryAliasCache(r, conn)
+		refreshTaxonomyDerivedState(r, conn, slug, deletedParentSlug)
 		action := "taxonomy_deleted"
 		if taxType == string(models.TaxonomyTypeTag) {
 			action = "tag_deleted"

--- a/server/internal/handlers/taxonomy.go
+++ b/server/internal/handlers/taxonomy.go
@@ -99,6 +99,27 @@ func taxonomyItemArticleCount(ctx context.Context, conn *sql.DB, taxType, slug s
 	return count, err
 }
 
+// liveTaxonomyArticleCount counts what the item matches RIGHT NOW, rather than
+// trusting the stored article_count.
+//
+// The stored count is only as fresh as the last rebuild, so it reads 0 both for
+// an item that is genuinely empty and for one whose articles simply have not
+// been counted yet -- after a reseed, or after an alias was just added. Deletion
+// is guarded on "nothing uses this", so it has to ask the articles table, not a
+// cached number. Everything else can keep using the cheap stored value.
+func liveTaxonomyArticleCount(ctx context.Context, conn *sql.DB, slug string) (int64, error) {
+	condition, args := db.TaxonomyCountCondition([]string{slug})
+	if condition == "" {
+		return 0, nil
+	}
+	var count int64
+	query := "SELECT COUNT(*) FROM `articles` WHERE `archived_at` IS NULL AND " + condition
+	if err := conn.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 func taxonomyItemExists(ctx context.Context, conn *sql.DB, taxType, slug string) (bool, error) {
 	var exists int
 	err := conn.QueryRowContext(ctx,
@@ -459,19 +480,17 @@ func DeleteTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			return
 		}
 		if conn != nil {
-			count, err := taxonomyItemArticleCount(r.Context(), conn, taxType, slug)
-			if err == sql.ErrNoRows {
+			// Existence check only -- the count it returns is the cached one.
+			if _, err := taxonomyItemArticleCount(r.Context(), conn, taxType, slug); err == sql.ErrNoRows {
 				writeError(w, http.StatusNotFound, "taxonomy item not found")
 				return
-			}
-			if err != nil {
+			} else if err != nil {
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			if count > 0 {
-				writeError(w, http.StatusBadRequest, "taxonomy item cannot be deleted while articles use it")
-				return
-			}
+			// Children first: it is an indexed lookup on one small table, and
+			// it is the more specific reason to refuse, so it should not be
+			// preempted by a scan of every article.
 			if taxType == string(models.TaxonomyTypeSection) {
 				hasChildren, err := taxonomySectionHasChildren(r.Context(), conn, slug)
 				if err != nil {
@@ -482,6 +501,18 @@ func DeleteTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 					writeError(w, http.StatusBadRequest, "section cannot be deleted while subsections use it")
 					return
 				}
+			}
+			// Deletion is irreversible and editors can do it, so ask the
+			// articles table rather than a number that may predate the last
+			// reseed or alias change.
+			count, err := liveTaxonomyArticleCount(r.Context(), conn, slug)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if count > 0 {
+				writeError(w, http.StatusBadRequest, "taxonomy item cannot be deleted while articles use it")
+				return
 			}
 		}
 

--- a/server/internal/handlers/taxonomy_integration_test.go
+++ b/server/internal/handlers/taxonomy_integration_test.go
@@ -57,6 +57,21 @@ func taxonomyHTTPTestDB(t *testing.T) *sql.DB {
 	if err := db.EnsureTaxonomyTable(ctx, conn); err != nil {
 		t.Fatalf("ensure taxonomy table: %v", err)
 	}
+	// Deletion asks the articles table for a live count, so every test needs
+	// one even when it files no articles.
+	if _, err := conn.ExecContext(ctx, "DROP TABLE IF EXISTS articles"); err != nil {
+		t.Fatalf("drop articles: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, `
+		CREATE TABLE articles (
+			id BIGINT PRIMARY KEY,
+			categories JSON NULL,
+			archived_at DATETIME NULL,
+			pub_date DATETIME NULL
+		)`); err != nil {
+		t.Fatalf("create articles: %v", err)
+	}
+	t.Cleanup(func() { _, _ = conn.ExecContext(context.Background(), "DROP TABLE IF EXISTS articles") })
 	return conn
 }
 
@@ -256,5 +271,87 @@ func TestTaxonomyHTTPAliasesAreNotHTMLEscaped(t *testing.T) {
 	}
 	if want := `["Arts & Entertainment"]`; stored != want {
 		t.Fatalf("stored %s, want %s -- an escaped ampersand matches no article", stored, want)
+	}
+}
+
+// TestTaxonomyHTTPDeleteRefusesWhenArticlesExist covers the guard that keeps
+// deletion safe now that editors can do it.
+func TestTaxonomyHTTPDeleteRefusesWhenArticlesExist(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+	ctx := context.Background()
+
+	if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":            "section",
+		"slug":            "sports",
+		"canonical_title": "Sports",
+	}).Code; code != http.StatusCreated {
+		t.Fatalf("POST = %d", code)
+	}
+
+	// An empty section deletes fine.
+	empty := taxonomyRequest(t, DeleteTaxonomyItem(conn), http.MethodDelete, "/v1/taxonomy/section/sports", nil)
+	if empty.Code != http.StatusNoContent {
+		t.Fatalf("delete of an empty section = %d: %s", empty.Code, empty.Body.String())
+	}
+
+	// Recreate it, this time with an article filed under it. site_taxonomy's
+	// article_count is still 0 -- nothing has rebuilt it -- so this is exactly
+	// the stale-count case the live count exists to catch.
+	if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":            "section",
+		"slug":            "sports",
+		"canonical_title": "Sports",
+	}).Code; code != http.StatusCreated {
+		t.Fatalf("re-POST = %d", code)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO articles (id, categories, pub_date) VALUES (1, '["Sports"]', UTC_TIMESTAMP())`,
+	); err != nil {
+		t.Fatalf("insert article: %v", err)
+	}
+
+	var storedCount int64
+	if err := conn.QueryRowContext(ctx,
+		"SELECT article_count FROM site_taxonomy WHERE slug = 'sports'",
+	).Scan(&storedCount); err != nil {
+		t.Fatalf("read stored count: %v", err)
+	}
+	if storedCount != 0 {
+		t.Fatalf("stored count = %d, want a stale 0 for this test to mean anything", storedCount)
+	}
+
+	refused := taxonomyRequest(t, DeleteTaxonomyItem(conn), http.MethodDelete, "/v1/taxonomy/section/sports", nil)
+	if refused.Code != http.StatusBadRequest {
+		t.Fatalf("delete of a section with articles = %d, want 400: %s", refused.Code, refused.Body.String())
+	}
+
+	var remaining int
+	if err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM site_taxonomy WHERE slug = 'sports'",
+	).Scan(&remaining); err != nil {
+		t.Fatalf("count remaining: %v", err)
+	}
+	if remaining != 1 {
+		t.Error("the section was deleted despite having articles")
+	}
+}
+
+// TestTaxonomyHTTPDeleteRefusesSectionWithSubsections keeps the other half of
+// "empty" honest: a section that still parents subsections is not empty.
+func TestTaxonomyHTTPDeleteRefusesSectionWithSubsections(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+
+	for _, body := range []map[string]any{
+		{"type": "section", "slug": "sports", "canonical_title": "Sports"},
+		{"type": "subsection", "slug": "squash", "canonical_title": "Squash", "parent_slug": "sports"},
+	} {
+		if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", body).Code; code != http.StatusCreated {
+			t.Fatalf("POST %v = %d", body, code)
+		}
+	}
+
+	refused := taxonomyRequest(t, DeleteTaxonomyItem(conn), http.MethodDelete, "/v1/taxonomy/section/sports", nil)
+	if refused.Code != http.StatusBadRequest {
+		t.Fatalf("delete of a parent section = %d, want 400: %s", refused.Code, refused.Body.String())
 	}
 }

--- a/server/internal/handlers/taxonomy_integration_test.go
+++ b/server/internal/handlers/taxonomy_integration_test.go
@@ -355,3 +355,130 @@ func TestTaxonomyHTTPDeleteRefusesSectionWithSubsections(t *testing.T) {
 		t.Fatalf("delete of a parent section = %d, want 400: %s", refused.Code, refused.Body.String())
 	}
 }
+
+// TestTaxonomyHTTPAliasSaveUpdatesTheDisplayedCount closes the loop the sections
+// screen actually shows. Matching goes live the moment the alias cache reloads,
+// but article_count is stored, so without a recount the editor's fix works on
+// the site while the screen still reads 0 -- a successful fix that looks failed.
+func TestTaxonomyHTTPAliasSaveUpdatesTheDisplayedCount(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+	ctx := context.Background()
+
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO articles (id, categories, pub_date) VALUES
+			(1, '["Restaurant Reviews"]', UTC_TIMESTAMP()),
+			(2, '["Restaurant Reviews"]', UTC_TIMESTAMP()),
+			(3, '["News"]', UTC_TIMESTAMP())`,
+	); err != nil {
+		t.Fatalf("insert articles: %v", err)
+	}
+
+	if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":            "section",
+		"slug":            "food",
+		"canonical_title": "Food",
+	}).Code; code != http.StatusCreated {
+		t.Fatalf("POST = %d", code)
+	}
+
+	// Nothing is filed under "Food", so the screen shows 0 and flags it.
+	if got := findItem(t, getTaxonomyItems(t, conn), "food").ArticleCount; got != 0 {
+		t.Fatalf("count before the fix = %d, want 0", got)
+	}
+
+	// The editor supplies the real category name.
+	if code := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/food", map[string]any{
+		"slug":             "food",
+		"canonical_title":  "Food",
+		"parent_slug":      nil,
+		"category_aliases": []string{"Restaurant Reviews"},
+	}).Code; code != http.StatusNoContent {
+		t.Fatalf("PUT = %d", code)
+	}
+
+	// ...and the number must be right on the very next load, with no rebuild
+	// and no restart.
+	if got := findItem(t, getTaxonomyItems(t, conn), "food").ArticleCount; got != 2 {
+		t.Errorf("count after the fix = %d, want 2 -- the save did not recount", got)
+	}
+}
+
+// TestTaxonomyHTTPSubsectionSaveRecountsItsParent covers the blast radius: a
+// section matches its own slug OR any child's, so fixing a child moves the
+// parent's number too.
+func TestTaxonomyHTTPSubsectionSaveRecountsItsParent(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+	ctx := context.Background()
+
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO articles (id, categories, pub_date) VALUES
+			(1, '["Beer Reviews"]', UTC_TIMESTAMP())`,
+	); err != nil {
+		t.Fatalf("insert articles: %v", err)
+	}
+
+	for _, body := range []map[string]any{
+		{"type": "section", "slug": "food", "canonical_title": "Food"},
+		{"type": "subsection", "slug": "drinks", "canonical_title": "Drinks", "parent_slug": "food"},
+	} {
+		if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", body).Code; code != http.StatusCreated {
+			t.Fatalf("POST %v = %d", body, code)
+		}
+	}
+
+	if code := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/subsection/drinks", map[string]any{
+		"slug":             "drinks",
+		"canonical_title":  "Drinks",
+		"parent_slug":      "food",
+		"category_aliases": []string{"Beer Reviews"},
+	}).Code; code != http.StatusNoContent {
+		t.Fatalf("PUT = %d", code)
+	}
+
+	items := getTaxonomyItems(t, conn)
+	if got := findItem(t, items, "drinks").ArticleCount; got != 1 {
+		t.Errorf("subsection count = %d, want 1", got)
+	}
+	if got := findItem(t, items, "food").ArticleCount; got != 1 {
+		t.Errorf("parent section count = %d, want 1 -- the parent was not recounted", got)
+	}
+}
+
+// TestTaxonomyHTTPDeleteRecountsTheParent covers the case where the parent
+// cannot be resolved after the fact, because the child row is gone by then.
+//
+// Deleting an EMPTY child cannot move a correct parent count -- an empty child
+// contributes nothing -- so the parent's stored count is staled first. If the
+// delete recounts it, the stale number is corrected; if it does not, the stale
+// number survives.
+func TestTaxonomyHTTPDeleteRecountsTheParent(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+	ctx := context.Background()
+
+	for _, body := range []map[string]any{
+		{"type": "section", "slug": "food", "canonical_title": "Food"},
+		{"type": "subsection", "slug": "drinks", "canonical_title": "Drinks", "parent_slug": "food"},
+	} {
+		if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", body).Code; code != http.StatusCreated {
+			t.Fatalf("POST %v = %d", body, code)
+		}
+	}
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO articles (id, categories, pub_date) VALUES (1, '["Food"]', UTC_TIMESTAMP())`,
+	); err != nil {
+		t.Fatalf("insert article: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		"UPDATE site_taxonomy SET article_count = 99 WHERE slug = 'food'",
+	); err != nil {
+		t.Fatalf("stale the parent count: %v", err)
+	}
+
+	if code := taxonomyRequest(t, DeleteTaxonomyItem(conn), http.MethodDelete, "/v1/taxonomy/subsection/drinks", nil).Code; code != http.StatusNoContent {
+		t.Fatalf("DELETE = %d", code)
+	}
+
+	if got := findItem(t, getTaxonomyItems(t, conn), "food").ArticleCount; got != 1 {
+		t.Errorf("parent count after deleting a child = %d, want 1 -- the parent was not recounted", got)
+	}
+}

--- a/server/internal/handlers/taxonomy_integration_test.go
+++ b/server/internal/handlers/taxonomy_integration_test.go
@@ -1,0 +1,260 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	db "server/internal/database"
+	"server/internal/models"
+)
+
+// Exercises the sections management screen end to end against a real MariaDB:
+// the alias a section is saved with has to reach the article matcher, or the
+// screen looks like it works while the section stays empty.
+//
+//	CMS_TEST_DSN='root:pw@tcp(127.0.0.1:3306)/tax_test?parseTime=true&multiStatements=true' go test ./internal/handlers/ -run TaxonomyHTTP -v
+func taxonomyHTTPTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := os.Getenv("CMS_TEST_DSN")
+	if dsn == "" {
+		t.Skip("CMS_TEST_DSN not set; skipping taxonomy handler integration test")
+	}
+
+	conn, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	if err := conn.Ping(); err != nil {
+		t.Fatalf("ping test database: %v", err)
+	}
+
+	ctx := context.Background()
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 60)", "cms_integration_test_shared_tables").Scan(&acquired); err != nil {
+		t.Fatalf("acquire test lock: %v", err)
+	}
+	if !acquired.Valid || acquired.Int64 != 1 {
+		t.Fatal("timed out waiting for the taxonomy test lock")
+	}
+	t.Cleanup(func() {
+		_, _ = conn.ExecContext(context.Background(), "SELECT RELEASE_LOCK(?)", "cms_integration_test_shared_tables")
+		_ = conn.Close()
+	})
+
+	if _, err := conn.ExecContext(ctx, "DROP TABLE IF EXISTS site_taxonomy"); err != nil {
+		t.Fatalf("drop site_taxonomy: %v", err)
+	}
+	if err := db.EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("ensure taxonomy table: %v", err)
+	}
+	return conn
+}
+
+func taxonomyRequest(t *testing.T, handler http.HandlerFunc, method, target string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *strings.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		reader = strings.NewReader(string(payload))
+	} else {
+		reader = strings.NewReader("")
+	}
+	req := httptest.NewRequest(method, target, reader)
+	req.SetPathValue("type", pathSegment(target, 2))
+	req.SetPathValue("slug", pathSegment(target, 3))
+	recorder := httptest.NewRecorder()
+	handler(recorder, req)
+	return recorder
+}
+
+func pathSegment(target string, index int) string {
+	parts := strings.Split(strings.TrimPrefix(target, "/"), "/")
+	if index < len(parts) {
+		return parts[index]
+	}
+	return ""
+}
+
+func getTaxonomyItems(t *testing.T, conn *sql.DB) []models.TaxonomyItem {
+	t.Helper()
+	recorder := taxonomyRequest(t, GetTaxonomy(conn), http.MethodGet, "/v1/taxonomy", nil)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /v1/taxonomy = %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var items []models.TaxonomyItem
+	if err := json.Unmarshal(recorder.Body.Bytes(), &items); err != nil {
+		t.Fatalf("decode taxonomy list: %v", err)
+	}
+	return items
+}
+
+func findItem(t *testing.T, items []models.TaxonomyItem, slug string) models.TaxonomyItem {
+	t.Helper()
+	for _, item := range items {
+		if item.Slug == slug {
+			return item
+		}
+	}
+	t.Fatalf("no taxonomy item with slug %q in %v", slug, items)
+	return models.TaxonomyItem{}
+}
+
+// TestTaxonomyHTTPAliasFixesAnEmptySection is the whole point of the sections
+// screen: an editor sees a section matching nothing, types the real category
+// name, saves, and the section starts matching. If any link in that chain is
+// broken the screen still "works" while the section stays empty.
+func TestTaxonomyHTTPAliasFixesAnEmptySection(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+
+	// A section whose slug is not the category its articles carry -- the
+	// Entertainment situation, which is the case that motivated aliases.
+	created := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":            "section",
+		"slug":            "food",
+		"canonical_title": "Food",
+	})
+	if created.Code != http.StatusCreated {
+		t.Fatalf("POST /v1/taxonomy = %d: %s", created.Code, created.Body.String())
+	}
+
+	// Nothing matches "Food" yet, because the articles say "Restaurant Reviews".
+	if got := db.CategoryMatchPatterns("food"); len(got) != 1 {
+		t.Fatalf("patterns = %v, want only the slug's own", got)
+	}
+
+	// The editor saves the real category name. This is the exact payload the
+	// sections screen sends.
+	updated := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/food", map[string]any{
+		"slug":             "food",
+		"canonical_title":  "Food",
+		"parent_slug":      nil,
+		"category_aliases": []string{"Restaurant Reviews", "Beer Reviews"},
+	})
+	if updated.Code != http.StatusNoContent {
+		t.Fatalf("PUT = %d: %s", updated.Code, updated.Body.String())
+	}
+
+	// The matcher must see it immediately -- no restart. This is what the
+	// cache refresh on write buys.
+	patterns := db.CategoryMatchPatterns("food")
+	for _, want := range []string{`%"restaurant reviews"%`, `%"beer reviews"%`} {
+		found := false
+		for _, pattern := range patterns {
+			if pattern == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("patterns %v missing %q right after the save", patterns, want)
+		}
+	}
+
+	// And the screen must read them back, or the editor's next save wipes them.
+	item := findItem(t, getTaxonomyItems(t, conn), "food")
+	if len(item.CategoryAliases) != 2 || item.CategoryAliases[0] != "Restaurant Reviews" {
+		t.Errorf("GET returned aliases %v, want the two just saved", item.CategoryAliases)
+	}
+}
+
+// TestTaxonomyHTTPOmittedAliasesSurviveAnEdit guards the compatibility rule: a
+// client that predates this field (or any edit that does not touch aliases)
+// must not silently clear them.
+func TestTaxonomyHTTPOmittedAliasesSurviveAnEdit(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+
+	if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":             "section",
+		"slug":             "food",
+		"canonical_title":  "Food",
+		"category_aliases": []string{"Restaurant Reviews"},
+	}).Code; code != http.StatusCreated {
+		t.Fatalf("POST = %d", code)
+	}
+
+	// Rename only -- no category_aliases key at all.
+	updated := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/food", map[string]any{
+		"slug":            "food",
+		"canonical_title": "Food & Drink",
+		"parent_slug":     nil,
+	})
+	if updated.Code != http.StatusNoContent {
+		t.Fatalf("PUT = %d: %s", updated.Code, updated.Body.String())
+	}
+
+	item := findItem(t, getTaxonomyItems(t, conn), "food")
+	if len(item.CategoryAliases) != 1 || item.CategoryAliases[0] != "Restaurant Reviews" {
+		t.Errorf("aliases = %v, want them untouched by an unrelated edit", item.CategoryAliases)
+	}
+}
+
+// TestTaxonomyHTTPExplicitEmptyClearsAliases is the other half of that rule:
+// an editor who empties the field must actually get an empty field.
+func TestTaxonomyHTTPExplicitEmptyClearsAliases(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+
+	if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":             "section",
+		"slug":             "food",
+		"canonical_title":  "Food",
+		"category_aliases": []string{"Restaurant Reviews"},
+	}).Code; code != http.StatusCreated {
+		t.Fatalf("POST = %d", code)
+	}
+
+	updated := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/food", map[string]any{
+		"slug":             "food",
+		"canonical_title":  "Food",
+		"parent_slug":      nil,
+		"category_aliases": []string{},
+	})
+	if updated.Code != http.StatusNoContent {
+		t.Fatalf("PUT = %d: %s", updated.Code, updated.Body.String())
+	}
+
+	item := findItem(t, getTaxonomyItems(t, conn), "food")
+	if len(item.CategoryAliases) != 0 {
+		t.Errorf("aliases = %v, want cleared", item.CategoryAliases)
+	}
+	if got := db.CategoryMatchPatterns("food"); len(got) != 1 {
+		t.Errorf("patterns = %v, want the alias gone from matching too", got)
+	}
+}
+
+// TestTaxonomyHTTPAliasesAreNotHTMLEscaped pins the escaping rule at the layer
+// editors actually touch: an ampersand typed into the sections screen must be
+// stored as an ampersand, or the alias silently matches nothing.
+func TestTaxonomyHTTPAliasesAreNotHTMLEscaped(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+
+	if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":             "section",
+		"slug":             "entertainment",
+		"canonical_title":  "Entertainment",
+		"category_aliases": []string{"Arts & Entertainment"},
+	}).Code; code != http.StatusCreated {
+		t.Fatalf("POST = %d", code)
+	}
+
+	var stored string
+	if err := conn.QueryRowContext(context.Background(),
+		"SELECT category_aliases FROM site_taxonomy WHERE slug = 'entertainment'",
+	).Scan(&stored); err != nil {
+		t.Fatalf("read stored aliases: %v", err)
+	}
+	if want := `["Arts & Entertainment"]`; stored != want {
+		t.Fatalf("stored %s, want %s -- an escaped ampersand matches no article", stored, want)
+	}
+}

--- a/server/internal/handlers/taxonomy_test.go
+++ b/server/internal/handlers/taxonomy_test.go
@@ -32,3 +32,41 @@ func TestValidateTaxonomyParent_NormalizesSubsectionParent(t *testing.T) {
 		t.Fatalf("parent = %v, want columns", got)
 	}
 }
+
+func TestNormalizeCategoryAliases(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"nil becomes an empty array", nil, `[]`},
+		{"empty stays an empty array", []string{}, `[]`},
+		{"trims", []string{"  Arts & Entertainment  "}, `["Arts & Entertainment"]`},
+		{"drops blanks", []string{"Movies", "", "   "}, `["Movies"]`},
+		{"drops case-insensitive duplicates", []string{"Movies", "movies", "MOVIES"}, `["Movies"]`},
+		{"keeps order", []string{"B", "A"}, `["B","A"]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeCategoryAliases(tc.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("normalizeCategoryAliases(%v) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCategoryAliasesNeverReturnsNull(t *testing.T) {
+	// NULL means "never set" and is what the defaults seed on, so a write must
+	// store [] instead -- otherwise clearing aliases would silently restore the
+	// seeded defaults on the next startup.
+	got, err := normalizeCategoryAliases(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == "null" || got == "" {
+		t.Fatalf("got %q, want an empty JSON array", got)
+	}
+}

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -150,3 +150,16 @@ func RequireAdmin(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+// RequireEditor allows editors as well as admins, for the things editors run
+// day to day. Same predicate as requireArticleWriteRole, at the route layer.
+func RequireEditor(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, ok := UserFromContext(r.Context())
+		if !ok || (user.Role != models.RoleAdmin && user.Role != models.RoleEditor) {
+			jsonError(w, http.StatusForbidden, "forbidden")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"server/internal/models"
+)
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestRequireEditorAllowsEditorsAndAdmins(t *testing.T) {
+	// Sections management sits behind this: editors run the newsroom day to
+	// day, so locking section config to admins meant the person who noticed a
+	// broken section was not the person who could fix it.
+	for name, tc := range map[string]struct {
+		user     *models.User
+		wantCode int
+	}{
+		"editor":       {&models.User{Role: models.RoleEditor}, http.StatusOK},
+		"admin":        {&models.User{Role: models.RoleAdmin}, http.StatusOK},
+		"blank role":   {&models.User{Role: models.Role("")}, http.StatusForbidden},
+		"unknown role": {&models.User{Role: models.Role("viewer")}, http.StatusForbidden},
+	} {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/taxonomy", nil)
+			req = req.WithContext(ContextWithUser(req.Context(), tc.user))
+			rec := httptest.NewRecorder()
+			RequireEditor(okHandler()).ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Errorf("%s = %d, want %d", name, rec.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestRequireEditorRejectsAnonymous(t *testing.T) {
+	rec := httptest.NewRecorder()
+	RequireEditor(okHandler()).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/taxonomy", nil))
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("anonymous = %d, want 403", rec.Code)
+	}
+}
+
+func TestRequireAdminStillExcludesEditors(t *testing.T) {
+	// Widening sections must not have widened account administration with it.
+	req := httptest.NewRequest(http.MethodPatch, "/v1/users/1", nil)
+	req = req.WithContext(ContextWithUser(req.Context(), &models.User{Role: models.RoleEditor}))
+	rec := httptest.NewRecorder()
+	RequireAdmin(okHandler()).ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("editor against RequireAdmin = %d, want 403", rec.Code)
+	}
+}

--- a/server/internal/models/types.go
+++ b/server/internal/models/types.go
@@ -269,17 +269,26 @@ type TaxonomyItem struct {
 	CanonicalTitle string  `json:"canonical_title"`
 	ParentSlug     *string `json:"parent_slug,omitempty"`
 	ArticleCount   int64   `json:"article_count"`
+	// CategoryAliases are extra category titles whose articles belong to this
+	// item, for when the corpus disagrees with the slug (the Entertainment
+	// section is filed under "Arts & Entertainment"). Article matching is
+	// exact, so a slug that is not the category string needs one of these.
+	CategoryAliases []string `json:"category_aliases"`
 }
 
 type TaxonomyInput struct {
-	Type           string  `json:"type"`
-	Slug           string  `json:"slug"`
-	CanonicalTitle string  `json:"canonical_title"`
-	ParentSlug     *string `json:"parent_slug,omitempty"`
+	Type            string   `json:"type"`
+	Slug            string   `json:"slug"`
+	CanonicalTitle  string   `json:"canonical_title"`
+	ParentSlug      *string  `json:"parent_slug,omitempty"`
+	CategoryAliases []string `json:"category_aliases,omitempty"`
 }
 
 type TaxonomyPut struct {
 	Slug           string  `json:"slug,omitempty"`
 	CanonicalTitle string  `json:"canonical_title"`
 	ParentSlug     *string `json:"parent_slug,omitempty"`
+	// Pointer so an omitted field leaves the stored aliases alone, while an
+	// explicit [] clears them.
+	CategoryAliases *[]string `json:"category_aliases,omitempty"`
 }

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -29,6 +29,10 @@ func Register(mux *http.ServeMux, conn *sql.DB, verifier *oidc.IDTokenVerifier, 
 		authMW = middleware.RequireAuth(verifier, conn, oidcCfg)
 	}
 	adminOnly := middleware.RequireAdmin
+	// Sections are editorial configuration, not account administration, so
+	// editors manage them. Deletion is still limited to items nothing uses --
+	// that guard lives in the handler and applies to admins too.
+	editorOrAdmin := middleware.RequireEditor
 
 	// Public, but identity-aware: these endpoints serve the public site and must
 	// answer anonymous callers, while an authenticated editor gets the wider
@@ -138,9 +142,9 @@ func Register(mux *http.ServeMux, conn *sql.DB, verifier *oidc.IDTokenVerifier, 
 	mux.Handle("PATCH /v1/settings/homepage-carousel", authMW(adminOnly(handlers.PatchHomepageCarousel(conn))))
 	mux.Handle("PATCH /v1/settings/footer", authMW(adminOnly(handlers.PatchFooterSettings(conn))))
 	mux.Handle("POST /v1/settings/taxonomy/rebuild", authMW(adminOnly(handlers.PostRebuildTaxonomyCounts(conn))))
-	mux.Handle("POST /v1/taxonomy", authMW(adminOnly(handlers.PostTaxonomy(conn))))
-	mux.Handle("PUT /v1/taxonomy/{type}/{slug}", authMW(adminOnly(handlers.PutTaxonomyItem(conn))))
-	mux.Handle("DELETE /v1/taxonomy/{type}/{slug}", authMW(adminOnly(handlers.DeleteTaxonomyItem(conn))))
+	mux.Handle("POST /v1/taxonomy", authMW(editorOrAdmin(handlers.PostTaxonomy(conn))))
+	mux.Handle("PUT /v1/taxonomy/{type}/{slug}", authMW(editorOrAdmin(handlers.PutTaxonomyItem(conn))))
+	mux.Handle("DELETE /v1/taxonomy/{type}/{slug}", authMW(editorOrAdmin(handlers.DeleteTaxonomyItem(conn))))
 
 	if verifier != nil {
 		mux.Handle("POST /v1/authors", authMW(adminOnly(handlers.PostAuthors(conn))))


### PR DESCRIPTION
Follow-on to #174, which was merged while it still contained only its first commit. That commit — the substring→whole-category matcher fix — is in `main` and self-contained (it carries the alias map in Go, so nothing is broken). These are the four commits that didn't make it in.

The theme: #174 fixed the bug, this makes the *class* of bug fixable by the newsroom instead of by a developer.

---

## 1. Aliases became editable data, and the failure became loud

Exact matching left one sharp edge: a slug that isn't the canonicalized category string resolves to **zero** articles. Four sections already needed that exception, and substring matching had been carrying them *by accident* — Entertainment is the loud one, since its articles are filed under `"Arts & Entertainment"` (2634 → 92 without an alias).

Those live in a hardcoded Go map today, which means the next one needs a developer who knows the map exists.

- **`site_taxonomy.category_aliases`**, editable from the sections screen. Aliases travel with the taxonomy, which is restored from a dump rather than regenerated, so they survive a reseed like the rows they annotate.
- **Seeded only where the column IS NULL**, so "never set" stays distinguishable from an array an editor deliberately emptied. `PUT` follows the same rule: omitted leaves the stored value alone, explicit `[]` clears it — so a client predating this field can't wipe aliases by saving an unrelated edit.
- **`CategoryMatchPatterns` stays a pure function of a slug**, reading a small in-memory cache refreshed at startup and after every taxonomy write. No per-request query on the article-listing path.
- **The failure is now loud**: the count rebuild logs a warning naming any slug matching no articles, and the sections table flags a zero count with the likely cause. That was the missing signal — an empty section reads as "no articles yet" rather than as a misconfiguration, which is how this stayed wrong long enough for the comics to end up in puzzles.

A test caught the alias writer being written with `json.Marshal`, which HTML-escapes `&` — the exact bug #174 fixed in `FormatTags`, reintroduced in new code. Both writers now share one `MarshalCategoryJSON`, so the rule lives in one place instead of being something you have to remember twice.

## 2. End-to-end cover for the sections screen

The plumbing had unit tests on each piece but nothing asserting the editor's actual workflow: see a section matching nothing, type the real category name, save, and have the section start matching. Every link in that chain can break while the screen still appears to work and the section stays empty.

## 3. Editors can manage sections, and deletion checks emptiness for real

Sections are editorial configuration, not account administration, but managing them was admin-only — which put the "add the category name" guidance in front of exactly the people who couldn't act on it. `POST`/`PUT`/`DELETE /v1/taxonomy` now accept editors via a `RequireEditor` middleware matching the predicate `requireArticleWriteRole` already uses. Account administration, settings and the full count rebuild stay admin-only.

Deletion is still limited to items nothing uses, but that guard was reading the **stored** `article_count` — only as fresh as the last rebuild, so it reads 0 both for a genuinely empty item and for one whose articles simply haven't been counted yet. Tolerable when only admins could delete; not now, and a reseed or a just-added alias is enough to make it wrong. It now counts against the articles table directly. The children check runs first: indexed lookup, more specific refusal, shouldn't be preempted by a full scan.

## 4. A section is recounted as soon as it is edited

Matching goes live the moment the alias cache reloads, but `article_count` is stored — so an editor who fixed a section would see it start working on the site while the screen still read 0 and still flagged it as broken. A successful fix that looks like a failed one is close to no fix at all, and the only way out was an admin-only full rebuild.

Writes now recount just the rows the edit can have changed: the row itself plus its parent section, because a section matches its own slug OR any child's. That narrowness is the point — a full rebuild runs one scan of the articles table per taxonomy row (~50 here), fine at startup and far too slow inside a save. Two scans isn't. `DELETE` captures the parent slug before removing the row, since a parent can't be resolved from a child that no longer exists.

---

## Verification

**Twelve integration tests run against a real MariaDB 11.7, not just compiled** — the ALTER, seed semantics, cache reload, the full editor workflow end to end, both delete guards, and the recount of a row and its parent.

Two of those caught real problems while being written: the alias writer's escaping (above), and a delete test of mine that tried to remove a subsection with articles — the guard correctly refused, and the test now stales the parent's stored count deliberately so it proves the recount happened rather than passing vacuously.

Unit tests additionally cover alias parsing and normalization and the role middleware. `go vet`, the full server suite, `tsc` and the frontend build all pass on this branch rebased onto current `main`.

## Deploy notes

- Column and seed apply automatically at startup via `EnsureTaxonomyTable`. No manual DB step.
- Two slugs will start logging the new zero-match warning: `sudoku` and `the-rectangle`. Both genuinely have no articles.
- Swagger regeneration picks up unrelated pre-existing drift in the committed docs (a `/v1/search` block and an `author` query param added without regenerating).

## Still outstanding

The empty **Sudoku** subsection is a separate cause — the ETL dropped every post whose *body* contained "sudoku", so there are zero to match. Fixed in DrexelTriangle/wordpress-etl#59, but it needs a reseed to populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)