### PR TITLE
Collect logs through the Docker API, and expose Loki to the Triangle Grafana

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,6 +19,118 @@ Delta does not run MariaDB, MaxScale, Grafana, Loki, or Promtail in the CMS
 deployment Compose project. The backend connects to the external database/proxy
 endpoint supplied by `DB_HOST` and `DB_PORT` in the host-only `cms.env`.
 
+Loki and Promtail do run on Delta, but in the separate `triangle-observability`
+Compose project (`compose.observability.yml`). Nothing in CI/CD starts it: the
+deploy scripts pin `COMPOSE_FILE` to `compose.cms.yml` so that a CMS deploy can
+never tear the log stack down. It is brought up by hand, once, and `restart:
+unless-stopped` keeps it up across deploys.
+
+## Exposing Loki to the Triangle Grafana
+
+The Triangle Grafana queries Delta's Loki as a datasource. Loki has no
+authentication of its own in any configuration, so it is published only to
+`127.0.0.1:13100` and fronted by the `nginx/triangle-loki.conf` site on port
+3100, which adds basic auth, blocks the write path, and 404s everything that is
+not a query.
+
+1. Install the stack into a stable directory on Delta. Do **not** run it out of
+   the runner's checkout at
+   `/home/triangle-runner/actions-runner/_work/triangle-cms/triangle-cms`: that
+   is the only checkout on the host that contains `observability/`, but
+   `actions/checkout` resets it on every deploy, which would yank the bind-mount
+   sources out from under a long-lived stack. Copy the files to a path the
+   runner never touches:
+
+   ```
+   mkdir -p ~/triangle-observability
+   cd ~/triangle-observability
+   sudo cp -r /home/triangle-runner/actions-runner/_work/triangle-cms/triangle-cms/observability .
+   sudo cp /home/triangle-runner/actions-runner/_work/triangle-cms/triangle-cms/deploy/compose.observability.yml .
+   sudo chown -R "$USER:$USER" observability compose.observability.yml
+   ```
+
+   The Compose file resolves its mounts as `../observability/`, so move it into
+   a `deploy/` subdirectory alongside the copied tree, or adjust the paths to
+   match wherever you put it. Then:
+
+   ```
+   docker compose -f compose.observability.yml --env-file ~/triangle-deploy/cms.env up -d
+   docker compose -f compose.observability.yml ps
+   ```
+
+   `cms.env` must define `GRAFANA_ADMIN_USER` and `GRAFANA_ADMIN_PASSWORD` or
+   the stack refuses to start. Re-copy `observability/` after any change to
+   those configs lands on main — this copy does not update itself.
+
+2. Create the datasource credentials and install the Nginx site:
+
+   ```
+   sudo htpasswd -B -c /etc/nginx/triangle-loki.htpasswd triangle-grafana
+   sudo chown root:www-data /etc/nginx/triangle-loki.htpasswd
+   sudo chmod 0640 /etc/nginx/triangle-loki.htpasswd
+   sudo cp nginx/triangle-loki.conf /etc/nginx/sites-available/
+   sudo ln -s ../sites-available/triangle-loki.conf /etc/nginx/sites-enabled/
+   sudo nginx -t && sudo nginx -s reload
+   ```
+
+   Note that `htpasswd` is not installed on Delta by default; it ships in
+   `apache2-utils` on Debian/Ubuntu and `httpd-tools` on RHEL-family hosts.
+
+3. Verify from Delta before handing the details over. Expect `401` then `200`:
+
+   ```
+   curl -s -o /dev/null -w '%{http_code}\n' localhost:3100/loki/api/v1/labels
+   curl -s -o /dev/null -w '%{http_code}\n' -u triangle-grafana \
+     localhost:3100/loki/api/v1/labels
+   ```
+
+   `curl -s localhost:3100/ready` reports `Pattern Ingester not ready: waiting
+   for 15s after being ready` indefinitely, and that is expected rather than a
+   fault: `loki-config.yml` enables `pattern_ingester`, whose readiness never
+   latches in a single-binary deployment. Loki serves queries normally. Use the
+   authenticated `/loki/api/v1/labels` call above as the real health signal.
+
+   Then confirm logs are actually arriving, which is the check that catches a
+   log-driver mismatch. This must return a non-empty list of container names:
+
+   ```
+   curl -s -u triangle-grafana \
+     'localhost:3100/loki/api/v1/label/container/values'
+   ```
+
+4. In the Triangle Grafana, add a Loki datasource with URL
+   `http://<delta-vpn-ip>:3100`, Basic auth enabled, and those credentials. No
+   path prefix or extra headers are needed.
+
+Delta's own Grafana (`127.0.0.1:3000`, admin credentials from `cms.env`) stays
+as a local fallback and is reachable only over an SSH tunnel. Basic auth here
+travels in cleartext; fold this endpoint into TLS when TLS lands on Delta.
+
+### Reading blue/green logs in Grafana
+
+Both slots run all the time. Only one receives traffic, and **nothing in the log
+stream says which one** -- the idle slot goes on emitting healthchecks
+indefinitely, so it is entirely possible to read the wrong slot's logs and
+conclude the site is idle. The active slot is whatever Nginx currently points
+at:
+
+```
+sudo cat /etc/nginx/triangle-cms/active-upstreams.conf   # set $triangle_cms_slot blue;
+```
+
+Filter by slot in Grafana with the `compose_service` label
+(`backend-blue`, `frontend-green`, ...) or `container`
+(`triangle-cms-backend-blue-1`). Two consequences of how Compose names things:
+
+- Container names are reused across deploys, so labels do not churn and
+  cardinality stays flat. But the pre-deploy and post-deploy containers for a
+  slot land in the *same* stream, so a deploy boundary is only visible by
+  timestamp, not by label.
+- A slot's logs are captured from the moment its container starts, including
+  startup and crash output, even though discovery only refreshes every 15s.
+  Promtail backfills from the beginning of a newly discovered container's log,
+  so a container that dies during a deploy still gets its logs shipped.
+
 Nginx serves whichever frontend slot is active and proxies `/v1`, `/swagger`,
 and `/swagger/` to the matching backend slot. The initial Nginx config listens on
 HTTP with `server_name _`, so it works through Delta's VPN IP or hostname before
@@ -36,6 +148,7 @@ behind Nginx.
 - `cms.env.example` - sanitized variable-name-only production env template.
 - `nginx/triangle-cms.conf` - host Nginx site template.
 - `nginx/triangle-cms-active-upstreams.conf.example` - generated include seed.
+- `nginx/triangle-loki.conf` - read-only Loki endpoint for the Triangle Grafana.
 - `scripts/deploy.sh` - deploy exact SHA to inactive slot, switch, smoke test.
 - `scripts/rollback.sh` - explicit rollback to the other slot or named slot.
 

--- a/deploy/compose.observability.yml
+++ b/deploy/compose.observability.yml
@@ -18,6 +18,14 @@ services:
     image: grafana/loki:3.5.6
     restart: unless-stopped
     command: ["-config.file=/etc/loki/config.yaml"]
+    # Published on loopback ONLY, and on 13100 rather than 3100, so that host
+    # Nginx can bind the natural :3100 for the outside world (see
+    # nginx/triangle-loki.conf) without a port clash. Loki runs with
+    # auth_enabled: false and has no authentication of its own, so nothing here
+    # may ever be published to a routable address directly -- Nginx is what adds
+    # basic auth and blocks the write path.
+    ports:
+      - "127.0.0.1:13100:3100"
     healthcheck:
       test: ["CMD", "loki", "-verify-config=true", "-config.file=/etc/loki/config.yaml"]
       interval: 20s
@@ -46,7 +54,14 @@ services:
     volumes:
       - ../observability/promtail-config.yml:/etc/promtail/config.yml:ro,z
       - promtail_positions:/tmp
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro,z
+      # Read-only Docker socket: Promtail discovers containers and streams their
+      # logs through the daemon API rather than tailing files, because Delta's
+      # `local` log driver writes binary logs that file-tailing cannot parse.
+      # See the comment in promtail-config.yml. Note that :ro on the socket
+      # limits nothing the daemon does -- the API is fully privileged either
+      # way -- so this container is effectively root on the host, same as any
+      # socket-mounted agent.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - observability_net
 

--- a/deploy/nginx/triangle-loki.conf
+++ b/deploy/nginx/triangle-loki.conf
@@ -1,0 +1,87 @@
+# Read-only, password-protected Loki endpoint for the Triangle Grafana.
+#
+# Install as a host Nginx site, for example:
+#   /etc/nginx/sites-available/triangle-loki.conf
+# and symlink into sites-enabled.
+#
+# Why this exists: Loki in compose.observability.yml runs with
+# `auth_enabled: false`. That switch turns off Loki's *multi-tenancy*, not
+# authentication -- Loki has no authentication at all, in any configuration.
+# Publishing container port 3100 to a routable address would therefore hand
+# anyone on the VPN unauthenticated read AND write access to every log line the
+# CMS has ever emitted. So the container is published to 127.0.0.1:13100 and
+# this site is the only way in.
+#
+# Grafana datasource config on the Triangle Grafana side:
+#   Type:  Loki
+#   URL:   http://<delta-vpn-ip>:3100
+#   Auth:  Basic auth, with the user/password from the htpasswd file below
+# No path prefix is needed. Loki's own API paths already start with /loki/
+# (/loki/api/v1/query_range and friends), which is what `location /loki/`
+# below matches.
+#
+# Setup:
+#   1. Create the credentials (htpasswd ships in apache2-utils / httpd-tools):
+#        sudo htpasswd -B -c /etc/nginx/triangle-loki.htpasswd triangle-grafana
+#      Store the password in the team's secret manager alongside the Grafana
+#      admin credentials; it is the only thing protecting this endpoint.
+#   2. sudo chown root:www-data /etc/nginx/triangle-loki.htpasswd
+#      sudo chmod 0640 /etc/nginx/triangle-loki.htpasswd
+#   3. sudo nginx -t && sudo nginx -s reload
+#
+# This listens on a dedicated port rather than adding a /loki/ location to the
+# CMS site, so that a mistake here can never affect the CMS vhost, and so the
+# datasource URL is the port a Grafana admin already expects Loki to be on.
+#
+# When TLS lands on Delta, terminate it here too -- basic auth over plain HTTP
+# sends the password in cleartext on every query, and it is only tolerable
+# while this endpoint is VPN-internal.
+
+server {
+    listen 3100;
+    server_name _;
+
+    # Loki's query responses are large and slow relative to a normal API call;
+    # a wide dashboard range can legitimately take minutes.
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_buffering off;
+
+    # Promtail pushes to Loki over the Compose network, not through Nginx, so
+    # the ingestion path never needs to be reachable from outside. Refuse it
+    # explicitly: a Grafana datasource only ever reads, and leaving push open
+    # would let any holder of the read password forge or flood log lines.
+    location = /loki/api/v1/push {
+        return 403;
+    }
+
+    location /loki/ {
+        auth_basic "Triangle Loki";
+        auth_basic_user_file /etc/nginx/triangle-loki.htpasswd;
+        proxy_pass http://127.0.0.1:13100;
+    }
+
+    # Grafana's "Save & test" probes /loki/api/v1/status/buildinfo for version
+    # detection. That is under the /loki/ prefix above, so it needs no rule of
+    # its own -- verified against Loki 3.5.6, which 404s the unprefixed
+    # /api/v1/status/buildinfo that some docs suggest.
+
+    # Unauthenticated liveness probe for our own use. /ready reports only
+    # whether the ingester is ready; it leaks no log content.
+    location = /ready {
+        access_log off;
+        proxy_pass http://127.0.0.1:13100;
+    }
+
+    # Everything else on this port -- /metrics, /config, the admin and delete
+    # APIs -- stays unreachable. /config in particular echoes the running
+    # configuration back to the caller.
+    location / {
+        return 404;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,13 @@ services:
     read_only: true
     security_opt:
       - no-new-privileges:true
+      # Local-dev only. On SELinux hosts (Fedora) the daemon socket is labelled
+      # container_var_run_t, which a confined container may not connect to: the
+      # mount succeeds, Promtail starts, and every discovery refresh fails with
+      # "permission denied while trying to connect to the Docker daemon socket".
+      # Delta is Ubuntu 24.04 with no SELinux, so compose.observability.yml
+      # deliberately does NOT carry this relaxation.
+      - label:disable
     cap_drop:
       - ALL
     command: ["-config.file=/etc/promtail/config.yml"]
@@ -123,7 +130,9 @@ services:
     volumes:
       - ./observability/promtail-config.yml:/etc/promtail/config.yml:ro,z
       - promtail_positions:/tmp
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro,z
+      # Must match deploy/compose.observability.yml: the shared promtail config
+      # discovers containers over the Docker API rather than tailing files.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - triangle_net
 

--- a/observability/loki-config.yml
+++ b/observability/loki-config.yml
@@ -32,6 +32,24 @@ ruler:
 limits_config:
   allow_structured_metadata: true
   volume_enabled: true
+  # Two weeks. Without this Loki keeps every line forever: the chunks live on a
+  # local filesystem volume on Delta, so unbounded growth is a disk-full
+  # incident on the host that also runs the CMS, not just a large bill.
+  retention_period: 336h
+
+# Retention is enforced by the compactor, and ONLY by the compactor -- setting
+# retention_period alone changes nothing at all. `retention_enabled: true` is
+# what actually deletes expired chunks; leaving it false is the usual reason a
+# configured retention silently never takes effect.
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  # Grace period between a chunk being marked for deletion and the delete
+  # happening, so a mistaken retention change can be reverted before data is
+  # actually gone.
+  retention_delete_delay: 2h
+  delete_request_store: filesystem
 
 pattern_ingester:
   enabled: true

--- a/observability/promtail-config.yml
+++ b/observability/promtail-config.yml
@@ -9,19 +9,43 @@ clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
+  # Logs are collected through the Docker API, not by tailing files.
+  #
+  # This is not a stylistic choice. Delta's /etc/docker/daemon.json sets
+  # `"log-driver": "local"`, so container logs are written as a binary protobuf
+  # stream to /var/lib/docker/containers/<id>/local-logs/container.log. The
+  # obvious file-tailing setup globs for `*-json.log`, which the `local` driver
+  # never produces: Promtail starts cleanly, reports itself healthy, matches
+  # zero targets, and ships nothing. Nothing in Loki or Grafana surfaces that as
+  # an error -- it looks exactly like an application that never logs.
+  #
+  # docker_sd_configs reads through the daemon's log API instead, which is
+  # driver-agnostic, so this keeps working whether the host is on `local` or
+  # `json-file`. It also discovers containers as they appear, which matters
+  # here: blue/green deploys replace containers on every release.
   - job_name: docker
-    static_configs:
-      - targets: [localhost]
-        labels:
-          job: docker
-          __path__: /var/lib/docker/containers/*/*-json.log
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        # Blue/green cutovers create containers mid-deploy; a short refresh
+        # keeps the window where a new slot's logs go uncollected small.
+        refresh_interval: 15s
+    relabel_configs:
+      # Docker reports names with a leading slash ("/triangle-cms-backend-blue-1").
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/?(.*)"
+        target_label: container
+      - source_labels: ["__meta_docker_container_log_stream"]
+        target_label: stream
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_project"]
+        target_label: compose_project
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: compose_service
+      - target_label: job
+        replacement: docker
     pipeline_stages:
-      - docker: {}
+      # The backend tags its structured lines with a service field; promote it
+      # to a label so Grafana can filter on it.
       - regex:
           expression: ".*(?:service=|\\\"service\\\":\\\")(?P<service>[a-zA-Z0-9_-]+).*"
       - labels:
           service:
-    relabel_configs:
-      - source_labels: [__path__]
-        regex: /var/lib/docker/containers/([a-f0-9]{64})/.*-json.log
-        target_label: container


### PR DESCRIPTION
Loki had never actually run on Delta. Bringing it up surfaced a config bug that would have made it look like it was working while collecting nothing.

## The bug

`promtail-config.yml` tailed `/var/lib/docker/containers/*/*-json.log`. Delta's `/etc/docker/daemon.json` sets `"log-driver": "local"`, which writes binary protobuf to `local-logs/container.log` — that glob matches **zero files** on the host. Promtail starts cleanly, passes its healthcheck, discovers no targets, and ships nothing. In Grafana it is indistinguishable from a CMS that never logs.

Fixed by switching to `docker_sd_configs` over the daemon socket. Driver-agnostic, and it discovers the containers blue/green deploys create instead of depending on a glob to keep up.

## Blue/green behaviour

Verified with a probe container running the `local` driver, not assumed:

- Lines emitted at container start **do** arrive despite the 15s discovery interval — Promtail backfills from the beginning of a newly discovered container's log. A slot that dies mid-deploy keeps its logs, which is when you need them most.
- Compose reuses container names per slot, so labels don't churn and cardinality stays flat. The tradeoff is that a slot's pre- and post-deploy containers share one stream, so deploy boundaries are visible by timestamp only.
- Both slots log continuously and nothing in the stream says which is live. Documented in the README, along with the `compose_service` / `container` labels to filter on and where the active slot is actually recorded.

## Exposing Loki

`nginx/triangle-loki.conf` fronts Loki for the Triangle Grafana. Loki has no authentication in any configuration — `auth_enabled` controls multi-tenancy, not authn — so the container publishes to `127.0.0.1:13100` only and Nginx adds basic auth, returns 403 on the push path (a datasource only reads), and 404s everything else including `/config`, which otherwise echoes the running configuration back to the caller.

## Retention

Two weeks. Retention is enforced *only* by the compactor, so `retention_enabled: true` is required — `retention_period` alone silently does nothing, and these chunks share a disk with the CMS.

## Verified on Delta

The stack is running at `~/triangle-observability/` and collecting from all 8 containers. `401` unauthenticated, `200` authenticated, `403` on push, `404` on `/config`; real CMS log lines queryable; running config confirms `retention_period: 2w` with the compactor ACTIVE.

**Note:** Delta is currently running these files copied from a working tree. Merging this makes the deployed config match main. Until then, re-copying from the runner checkout would silently regress log collection.

## Not addressed

- Basic auth is cleartext over HTTP and `ufw` is inactive on Delta. Fine while VPN-internal; should join the TLS work.
- Nothing in CI/CD starts this stack. That is deliberate — a CMS deploy must never tear it down — but it does mean the config on Delta is updated by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)