### PR TITLE
Scrape the CMS slots by container name, not through the host gateway

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -109,8 +109,15 @@ travels in cleartext; fold this endpoint into TLS when TLS lands on Delta.
 ### Metrics and the CMS dashboard
 
 The backend exposes Prometheus metrics on `GET /metrics`, and the stack runs a
-Prometheus that scrapes both slots over the host gateway
-(`observability/prometheus/prometheus.delta.yml`). The "CMS Dashboard" is
+Prometheus that scrapes both slots by container name
+(`observability/prometheus/prometheus.delta.yml`). To do that it attaches to the
+CMS project's network, declared `external` so this stack never owns it. The
+consequence is an ordering dependency: the CMS stack must be up first, or
+Compose refuses to start this one with a missing-network error.
+
+Scraping via the host gateway does not work, and it is worth knowing why before
+"simplifying" it back: the slots publish to `127.0.0.1:8081/8082`, loopback
+only, so a container dialling `172.17.0.1` gets connection refused. The "CMS Dashboard" is
 provisioned from `observability/grafana/provisioning/dashboards/` and appears in
 any Grafana that mounts that directory -- no manual import.
 

--- a/deploy/compose.observability.yml
+++ b/deploy/compose.observability.yml
@@ -100,12 +100,17 @@ services:
     volumes:
       - ../observability/prometheus/prometheus.delta.yml:/etc/prometheus/prometheus.yml:ro,z
       - prometheus_data:/prometheus
-    # The CMS slots publish to host loopback from a different Compose project,
-    # so they are only reachable through the host gateway.
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    # Prometheus joins the CMS project's network read-only so it can scrape the
+    # slots by container name.
+    #
+    # The host gateway does NOT work here, which is easy to get wrong: the CMS
+    # slots publish to 127.0.0.1:8081/8082, loopback only, so a container
+    # reaching for the gateway address (172.17.0.1) gets connection refused.
+    # Joining the network reaches the containers on their own port 8080 instead,
+    # and needs no change to compose.cms.yml and no new host exposure.
     networks:
       - observability_net
+      - cms_net
 
 volumes:
   loki_data:
@@ -116,3 +121,11 @@ volumes:
 networks:
   observability_net:
     driver: bridge
+  # The CMS project's network, created by compose.cms.yml. Declared external so
+  # this stack attaches to it rather than owning it -- nothing here can create,
+  # modify, or remove it. The cost of this is a real ordering dependency: the
+  # CMS stack must be up before this one starts, or Compose fails with a missing
+  # network instead of silently scraping nothing.
+  cms_net:
+    external: true
+    name: triangle-cms_triangle_net

--- a/observability/prometheus/prometheus.delta.yml
+++ b/observability/prometheus/prometheus.delta.yml
@@ -12,9 +12,10 @@
 #      Which one is live is decided by Nginx, not by anything Prometheus can
 #      see -- see the blue/green section in deploy/README.md.
 #
-# The CMS containers sit in a different Compose project on their own network and
-# publish only to host loopback, so targets go via the host gateway rather than
-# by container name.
+# Targets are container names on the CMS project's network, which Prometheus
+# joins (see compose.observability.yml). Going via the host gateway does not
+# work: the slots publish to 127.0.0.1 only, so the gateway address refuses the
+# connection. Port 8080 is the in-container port, not the published one.
 
 global:
   scrape_interval: 15s
@@ -26,9 +27,9 @@ scrape_configs:
     metrics_path: /metrics
     scheme: http
     static_configs:
-      - targets: ["host.docker.internal:8081"]
+      - targets: ["triangle-cms-backend-blue-1:8080"]
         labels:
           slot: blue
-      - targets: ["host.docker.internal:8082"]
+      - targets: ["triangle-cms-backend-green-1:8080"]
         labels:
           slot: green


### PR DESCRIPTION
Follow-up to #178, found while rolling it out to Delta.

## The bug

`prometheus.delta.yml` targeted `host.docker.internal:8081/8082`. That cannot work: the CMS slots publish to **`127.0.0.1`** only, so Prometheus dialling the gateway got:

```
dial tcp 172.17.0.1:8081: connect: connection refused
```

Both targets down. My assumption in #178 that the gateway could reach a loopback-published port was simply wrong.

## The fix

Attach Prometheus to the CMS project's network and scrape the containers on their internal port 8080. No change to `compose.cms.yml`, no new host exposure, and both slots stay individually visible.

The network is declared `external`, so this stack attaches to it and can never create, modify, or remove it — the CMS side stays untouchable from here. The real cost, stated in the compose file and README: an ordering dependency. The CMS stack must be up before this one, or Compose fails with a missing-network error rather than silently scraping nothing. I'd take a loud failure over a quiet one here.

## Verified on Delta

```
slot=blue   triangle-cms-backend-blue-1:8080    health=up
slot=green  triangle-cms-backend-green-1:8080   health=down  404
```

`sum(http_requests_total)` returns 126 — real traffic recorded.

Green 404s because it still runs the pre-merge image without `/metrics`. It resolves the next time a deploy rotates that slot; no action needed.

## Also rolled out

The full stack is now live on Delta: Prometheus running, both datasources provisioned with correct UIDs, "CMS Dashboard" loaded.

One snag worth recording: Grafana crash-looped on `Datasource provisioning error: data source not found`, because its existing volume held a Loki datasource with an auto-generated UID and #178 pins `uid: loki`. Provisioning cannot reconcile that. Fixed by recreating the volume, which was safe here since that Grafana had no user-created content. Anyone pinning a UID on an established Grafana will hit the same and should expect to delete the old datasource first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)