### PR TITLE
Expose Prometheus to the Triangle Grafana, sharing Loki's credentials

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -65,13 +65,18 @@ not a query.
 2. Create the datasource credentials and install the Nginx site:
 
    ```
-   sudo htpasswd -B -c /etc/nginx/triangle-loki.htpasswd triangle-grafana
-   sudo chown root:www-data /etc/nginx/triangle-loki.htpasswd
-   sudo chmod 0640 /etc/nginx/triangle-loki.htpasswd
-   sudo cp nginx/triangle-loki.conf /etc/nginx/sites-available/
+   sudo htpasswd -B -c /etc/nginx/triangle-observability.htpasswd triangle-grafana
+   sudo chown root:www-data /etc/nginx/triangle-observability.htpasswd
+   sudo chmod 0640 /etc/nginx/triangle-observability.htpasswd
+   sudo cp nginx/triangle-loki.conf nginx/triangle-prometheus.conf \
+     /etc/nginx/sites-available/
    sudo ln -s ../sites-available/triangle-loki.conf /etc/nginx/sites-enabled/
+   sudo ln -s ../sites-available/triangle-prometheus.conf /etc/nginx/sites-enabled/
    sudo nginx -t && sudo nginx -s reload
    ```
+
+   Both endpoints share one htpasswd file, so the Triangle Grafana uses the same
+   credentials for its Loki and Prometheus datasources.
 
    Note that `htpasswd` is not installed on Delta by default; it ships in
    `apache2-utils` on Debian/Ubuntu and `httpd-tools` on RHEL-family hosts.
@@ -98,9 +103,16 @@ not a query.
      'localhost:3100/loki/api/v1/label/container/values'
    ```
 
-4. In the Triangle Grafana, add a Loki datasource with URL
-   `http://<delta-vpn-ip>:3100`, Basic auth enabled, and those credentials. No
-   path prefix or extra headers are needed.
+4. In the Triangle Grafana, add two datasources, both with Basic auth enabled
+   and the same credentials. No path prefix or extra headers are needed:
+
+   | Type | URL |
+   | --- | --- |
+   | Loki | `http://<delta-vpn-ip>:3100` |
+   | Prometheus | `http://<delta-vpn-ip>:9090` |
+
+   The CMS dashboard needs both: 14 of its 18 panels query Prometheus and only
+   3 query Loki, so a Loki-only setup renders a mostly empty dashboard.
 
 Delta's own Grafana (`127.0.0.1:3000`, admin credentials from `cms.env`) stays
 as a local fallback and is reachable only over an SSH tunnel. Basic auth here

--- a/deploy/compose.observability.yml
+++ b/deploy/compose.observability.yml
@@ -97,6 +97,14 @@ services:
       # cover the same window and neither outgrows the disk it shares with the
       # CMS.
       - "--storage.tsdb.retention.time=14d"
+    # Loopback only, on 19090 so host Nginx can bind the natural 9090 for the
+    # Triangle Grafana (see nginx/triangle-prometheus.conf). Prometheus has no
+    # authentication of its own, so this must never be published to a routable
+    # address directly. Note that --web.enable-admin-api and
+    # --web.enable-lifecycle are deliberately absent above: without them the
+    # delete-series, reload and quit endpoints do not exist at all.
+    ports:
+      - "127.0.0.1:19090:9090"
     volumes:
       - ../observability/prometheus/prometheus.delta.yml:/etc/prometheus/prometheus.yml:ro,z
       - prometheus_data:/prometheus

--- a/deploy/nginx/triangle-loki.conf
+++ b/deploy/nginx/triangle-loki.conf
@@ -12,6 +12,8 @@
 # CMS has ever emitted. So the container is published to 127.0.0.1:13100 and
 # this site is the only way in.
 #
+# One credential pair covers this and the Prometheus endpoint (triangle-prometheus.conf).
+#
 # Grafana datasource config on the Triangle Grafana side:
 #   Type:  Loki
 #   URL:   http://<delta-vpn-ip>:3100
@@ -22,11 +24,11 @@
 #
 # Setup:
 #   1. Create the credentials (htpasswd ships in apache2-utils / httpd-tools):
-#        sudo htpasswd -B -c /etc/nginx/triangle-loki.htpasswd triangle-grafana
+#        sudo htpasswd -B -c /etc/nginx/triangle-observability.htpasswd triangle-grafana
 #      Store the password in the team's secret manager alongside the Grafana
 #      admin credentials; it is the only thing protecting this endpoint.
-#   2. sudo chown root:www-data /etc/nginx/triangle-loki.htpasswd
-#      sudo chmod 0640 /etc/nginx/triangle-loki.htpasswd
+#   2. sudo chown root:www-data /etc/nginx/triangle-observability.htpasswd
+#      sudo chmod 0640 /etc/nginx/triangle-observability.htpasswd
 #   3. sudo nginx -t && sudo nginx -s reload
 #
 # This listens on a dedicated port rather than adding a /loki/ location to the
@@ -62,7 +64,7 @@ server {
 
     location /loki/ {
         auth_basic "Triangle Loki";
-        auth_basic_user_file /etc/nginx/triangle-loki.htpasswd;
+        auth_basic_user_file /etc/nginx/triangle-observability.htpasswd;
         proxy_pass http://127.0.0.1:13100;
     }
 

--- a/deploy/nginx/triangle-prometheus.conf
+++ b/deploy/nginx/triangle-prometheus.conf
@@ -1,0 +1,60 @@
+# Read-only, password-protected Prometheus endpoint for the Triangle Grafana.
+#
+# Install as a host Nginx site, for example:
+#   /etc/nginx/sites-available/triangle-prometheus.conf
+# and symlink into sites-enabled.
+#
+# Same shape and same reasoning as triangle-loki.conf: Prometheus has no
+# authentication of its own, so the container publishes to 127.0.0.1:19090 and
+# this site is the only way in. It shares triangle-observability.htpasswd with
+# the Loki endpoint, so one credential pair covers both datasources.
+#
+# Grafana datasource config on the Triangle Grafana side:
+#   Type:  Prometheus
+#   URL:   http://<delta-vpn-ip>:9090
+#   Auth:  Basic auth, same credentials as the Loki datasource
+#
+# The container is published on 19090 so Nginx can bind the natural 9090 that a
+# Grafana admin expects, without a port clash.
+
+server {
+    listen 9090;
+    server_name _;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+
+    # The admin API can delete series and wipe the TSDB. It is already off --
+    # neither --web.enable-admin-api nor --web.enable-lifecycle is passed in
+    # compose.observability.yml -- but deny it here too so that turning either
+    # flag on later for local debugging does not silently expose destructive
+    # endpoints to everything that can reach this port.
+    location /api/v1/admin/ {
+        return 403;
+    }
+
+    # Query API. This is everything a Grafana datasource needs: query,
+    # query_range, series, labels, label values, metadata, buildinfo.
+    location /api/ {
+        auth_basic "Triangle Prometheus";
+        auth_basic_user_file /etc/nginx/triangle-observability.htpasswd;
+        proxy_pass http://127.0.0.1:19090;
+    }
+
+    # Unauthenticated liveness probe for our own use. Reports readiness only.
+    location = /-/ready {
+        access_log off;
+        proxy_pass http://127.0.0.1:19090;
+    }
+
+    # Everything else stays unreachable: the web UI, /metrics, /config (which
+    # echoes the running scrape configuration), /-/reload and /-/quit.
+    location / {
+        return 404;
+    }
+}


### PR DESCRIPTION
The CMS dashboard is **14 Prometheus panels to 3 Loki ones**, so exposing only Loki left the Triangle Grafana rendering a mostly empty dashboard. Prometheus was reachable from inside Delta only.

## What this does

Fronts Prometheus with Nginx the same way as Loki: container published to `127.0.0.1:19090`, Nginx on `9090` adding basic auth.

Only the query API is reachable — that is everything a Grafana datasource needs. Everything else 404s: the web UI, `/metrics`, and `/config`, which echoes the running scrape configuration.

`/api/v1/admin/` is denied outright. Those endpoints don't exist today because neither `--web.enable-admin-api` nor `--web.enable-lifecycle` is passed, but the deny means turning a flag on later for debugging can't silently expose delete-series to everything that can reach the port.

Both sites now read a single `triangle-observability.htpasswd`, so the Triangle Grafana uses **one credential pair for both datasources** instead of two.

## Verified on Delta

| Check | Result |
|---|---|
| Unauthenticated `/api/v1/labels` | `401` |
| Authenticated `/api/v1/labels` | `200` |
| `/api/v1/admin/tsdb/delete_series` | `403` |
| Web UI `/` | `404` |
| `/api/v1/status/buildinfo` | `200` |
| Loki endpoint after htpasswd move | `200` |

`sum(http_requests_total)` through Nginx returns `765` — real traffic.

## Note

This adds a second cleartext basic-auth endpoint on a host where `ufw` is inactive. Same tradeoff as the Loki endpoint and acceptable while VPN-internal, but it doubles what wants folding into the TLS work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)