### PR TITLE
Keep image captions out of the auto-derived excerpt

### DIFF
--- a/server/internal/database/http_models.go
+++ b/server/internal/database/http_models.go
@@ -541,10 +541,25 @@ var slugDelimiterPattern = regexp.MustCompile(`[^a-z0-9]+`)
 
 var htmlTagPattern = regexp.MustCompile(`<[^>]*>`)
 
+// Image captions are markup, not article text. An article normally opens with
+// its featured image, so stripping tags blindly made the caption -- a photo
+// credit line -- the first thing the derived excerpt picked up. This drops the
+// caption-bearing markup first: what the editor writes (trixHtmlToArticle emits
+// <figure class="wp-caption"><figcaption>) and both WordPress import shapes
+// (block: <figure><figcaption>; classic: <div class="wp-caption">…<p
+// class="wp-caption-text">, where removing the caption element is enough since
+// the surrounding div holds only the image).
+var captionMarkupPattern = regexp.MustCompile(
+	`(?is)<figure\b[^>]*>.*?</figure\s*>` +
+		`|<figcaption\b[^>]*>.*?</figcaption\s*>` +
+		`|<[a-z][a-z0-9]*\b[^>]*wp-caption-text[^>]*>.*?</[a-z][a-z0-9]*\s*>`)
+
 // deriveExcerpt builds a plain-text excerpt from HTML article content by
-// stripping tags, collapsing whitespace, and truncating to a word limit.
+// dropping image captions, stripping tags, collapsing whitespace, and
+// truncating to a word limit.
 func deriveExcerpt(content string) string {
-	text := htmlTagPattern.ReplaceAllString(content, " ")
+	text := captionMarkupPattern.ReplaceAllString(content, " ")
+	text = htmlTagPattern.ReplaceAllString(text, " ")
 	text = html.UnescapeString(text)
 	words := strings.Fields(text)
 	if len(words) == 0 {

--- a/server/internal/database/http_models_test.go
+++ b/server/internal/database/http_models_test.go
@@ -181,3 +181,35 @@ func TestArticleToDBFields_StampsModifiedDate(t *testing.T) {
 		t.Errorf("mod_date = %s, want roughly now", raw)
 	}
 }
+
+// An article normally opens with its featured image, so an excerpt derived by
+// stripping tags used to start with the photo credit in the caption instead of
+// the story.
+func TestDeriveExcerpt_SkipsImageCaptions(t *testing.T) {
+	cases := map[string]string{
+		"editor and block-editor figures": `<figure class="wp-caption alignnone">` +
+			`<img src="/x.jpg" alt=""><figcaption class="wp-caption-text">Photo by Jane Doe.</figcaption>` +
+			`</figure><p>The story begins here.</p>`,
+		"classic-editor caption div": `<div class="wp-caption alignnone"><img src="/x.jpg" alt="">` +
+			`<p class="wp-caption-text">Photo by Jane Doe.</p></div><p>The story begins here.</p>`,
+		"bare figcaption": `<figcaption>Photo by Jane Doe.</figcaption><p>The story begins here.</p>`,
+	}
+
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := deriveExcerpt(content); got != "The story begins here." {
+				t.Errorf("deriveExcerpt = %q, want the article text without the caption", got)
+			}
+		})
+	}
+}
+
+// A caption mid-article should not cut the excerpt short either.
+func TestDeriveExcerpt_KeepsTextAroundAnInlineFigure(t *testing.T) {
+	content := `<p>Before.</p><figure class="wp-caption"><img src="/x.jpg" alt="">` +
+		`<figcaption class="wp-caption-text">Credit.</figcaption></figure><p>After.</p>`
+
+	if got := deriveExcerpt(content); got != "Before. After." {
+		t.Errorf("deriveExcerpt = %q, want both paragraphs and no caption", got)
+	}
+}


### PR DESCRIPTION
## Problem

When an author leaves the Excerpt field blank, the server derives one from the article body (`deriveExcerpt`, called from `ArticleInputToDBFields` on create). It stripped every HTML tag and took the first 50 words — and since an article opens with its featured image as `<figure class="wp-caption">…<figcaption>`, the first text it found was the photo credit, not the story.

## Fix

Drop caption-bearing markup before flattening:

- whole `<figure>` blocks
- bare `<figcaption>`
- the classic-WordPress `wp-caption-text` element (its wrapper `div` holds only the image, so it contributes no text)

That covers what the editor writes (`trixHtmlToArticle`) plus both WordPress import shapes. Text before and after an inline figure still joins normally.

## Tests

Added coverage for the three caption shapes and for a mid-article figure. `go test ./internal/database/` passes.

## Note

This only affects newly derived excerpts. Articles already saved with a caption as their excerpt keep it until edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)