### PR TITLE
Edit alt text without leaving the article

### DIFF
--- a/frontend/src/components/MediaPicker.test.tsx
+++ b/frontend/src/components/MediaPicker.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import MediaPicker, { type MediaPickerItem } from "./MediaPicker"
+
+// Alt text is edited from the picker so an author never has to leave a
+// half-written article for the Media library to describe an image. These tests
+// pin the two things that makes it worth having: the edit reaches the library
+// record, and the grid stops warning about the image it just described.
+
+type ApiCall = { url: string; method: string; body: Record<string, unknown> | null }
+
+let apiCalls: ApiCall[] = []
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+
+const GALLERY_ITEM: MediaPickerItem = {
+  id: 42,
+  url: "/media/2026/07/protest.jpg",
+  file_name: "protest.jpg",
+  mime_type: "image/jpeg",
+}
+
+let patchStatus = 200
+
+const apiFetchStub = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+  const method = (init?.method ?? "GET").toUpperCase()
+  apiCalls.push({
+    url,
+    method,
+    body: typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null,
+  })
+
+  if (method === "PATCH") {
+    return patchStatus === 200
+      ? jsonResponse({ ...GALLERY_ITEM, alt_text: "Students marching on Market Street" })
+      : jsonResponse({ error: "media not found" }, patchStatus)
+  }
+  return jsonResponse({ media: [GALLERY_ITEM] })
+})
+
+vi.mock("../hooks/useApiFetch", () => ({
+  useApiFetch: () => apiFetchStub,
+}))
+
+const renderPicker = async () => {
+  const onSelect = vi.fn()
+  const user = userEvent.setup()
+  render(<MediaPicker onClose={vi.fn()} onSelect={onSelect} />)
+  await screen.findByRole("button", { name: /no alt text/i })
+  return { onSelect, user }
+}
+
+describe("MediaPicker alt text", () => {
+  beforeEach(() => {
+    apiCalls = []
+    patchStatus = 200
+    apiFetchStub.mockClear()
+  })
+
+  it("saves alt text to the library record without leaving the picker", async () => {
+    const { user } = await renderPicker()
+
+    await user.click(screen.getByRole("button", { name: /no alt text/i }))
+    await user.type(
+      screen.getByLabelText("Alt text for protest.jpg"),
+      "Students marching on Market Street",
+    )
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(apiCalls.filter((call) => call.method === "PATCH")).toEqual([
+        {
+          url: "/v1/media/42",
+          method: "PATCH",
+          body: { alt_text: "Students marching on Market Street" },
+        },
+      ])
+    })
+
+    // The warning is gone and the saved description is on the tile, so the
+    // author can see the image is now described and pick it.
+    expect(screen.queryByText("No alt text")).not.toBeInTheDocument()
+    expect(await screen.findByText("Students marching on Market Street")).toBeInTheDocument()
+  })
+
+  it("hands the newly saved alt text to the caller on select", async () => {
+    const { onSelect, user } = await renderPicker()
+
+    await user.click(screen.getByRole("button", { name: /no alt text/i }))
+    await user.type(screen.getByLabelText("Alt text for protest.jpg"), "Students marching")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+    await screen.findByText("Students marching")
+
+    await user.click(screen.getByTitle("protest.jpg"))
+
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ alt_text: "Students marching" }))
+  })
+
+  it("keeps the typed text on screen when the save fails", async () => {
+    patchStatus = 404
+    const { user } = await renderPicker()
+
+    await user.click(screen.getByRole("button", { name: /no alt text/i }))
+    const field = screen.getByLabelText("Alt text for protest.jpg")
+    await user.type(field, "Students marching")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(await screen.findByText("media not found")).toBeInTheDocument()
+    expect(field).toHaveValue("Students marching")
+  })
+})

--- a/frontend/src/components/MediaPicker.tsx
+++ b/frontend/src/components/MediaPicker.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { ImageOff, Search, Upload, X } from "lucide-react"
+import { ImageOff, Pencil, Search, Upload, X } from "lucide-react"
 import { useApiFetch } from "../hooks/useApiFetch"
 
 export type MediaPickerItem = {
@@ -146,6 +146,13 @@ function MediaPicker({ onSelect, onClose, title = "Insert image", onUseUrl, init
     return () => observer.disconnect()
   }, [sentinel, hasMore, isLoading, isLoadingMore, items.length])
 
+  // Alt text saved from a tile belongs to the library record, so the grid has to
+  // show the new value straight away -- otherwise the "No alt text" warning
+  // stays up on an image that now has some.
+  const updateItem = useCallback((id: number, altText: string) => {
+    setItems((prev) => prev.map((item) => (item.id === id ? { ...item, alt_text: altText } : item)))
+  }, [])
+
   const handleUpload = useCallback(
     async (files: FileList | null) => {
       const file = files?.[0]
@@ -261,29 +268,33 @@ function MediaPicker({ onSelect, onClose, title = "Insert image", onUseUrl, init
           ) : (
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
               {items.map((item) => (
-                <button
-                  className="group flex flex-col overflow-hidden rounded-lg border border-border bg-card text-left transition-colors hover:border-primary"
+                <div
+                  className="group flex flex-col overflow-hidden rounded-lg border border-border bg-card transition-colors focus-within:border-primary hover:border-primary"
                   key={item.id}
-                  onClick={() => onSelect(item)}
-                  title={item.file_name}
-                  type="button"
                 >
-                  <span className="relative block aspect-square overflow-hidden bg-muted">
-                    <img
-                      alt={item.alt_text || item.file_name}
-                      className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-                      loading="lazy"
-                      referrerPolicy="no-referrer"
-                      src={item.url}
-                    />
-                  </span>
-                  <span className="truncate px-2 py-1.5 text-xs text-foreground">{item.file_name}</span>
-                  {!item.alt_text && (
-                    // Surfaced here because this is the moment the choice is
-                    // made: an image with no alt text will publish without any.
-                    <span className="px-2 pb-1.5 text-[11px] text-muted-foreground">No alt text</span>
-                  )}
-                </button>
+                  <button
+                    className="flex flex-col text-left"
+                    onClick={() => onSelect(item)}
+                    title={item.file_name}
+                    type="button"
+                  >
+                    <span className="relative block aspect-square overflow-hidden bg-muted">
+                      <img
+                        alt={item.alt_text || item.file_name}
+                        className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                        loading="lazy"
+                        referrerPolicy="no-referrer"
+                        src={item.url}
+                      />
+                    </span>
+                    <span className="truncate px-2 py-1.5 text-xs text-foreground">{item.file_name}</span>
+                  </button>
+                  {/* Alt text is edited here, next to the image, because this is
+                      the moment the choice is made: an image with no alt text
+                      publishes without any, and sending the author to the Media
+                      library to fix that loses the article they were writing. */}
+                  <AltTextField item={item} onSaved={updateItem} />
+                </div>
               ))}
             </div>
           )}
@@ -319,6 +330,127 @@ function MediaPicker({ onSelect, onClose, title = "Insert image", onUseUrl, init
             </button>
           </div>
         )}
+      </div>
+    </div>
+  )
+}
+
+type AltTextFieldProps = {
+  item: MediaPickerItem
+  onSaved: (id: number, altText: string) => void
+}
+
+/**
+ * Inline alt-text editor for one tile.
+ *
+ * It writes to the library record (PATCH /v1/media/{id}), not to this article,
+ * so an image described once is described everywhere it is used -- the same
+ * contract the picker already relies on when it hands alt_text to the editor.
+ *
+ * Its own error state rather than the picker's banner: a failed save belongs
+ * next to the field that failed, and it must not clear the text the author just
+ * typed.
+ */
+function AltTextField({ item, onSaved }: AltTextFieldProps) {
+  const apiFetch = useApiFetch()
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(item.alt_text ?? "")
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const altText = item.alt_text ?? ""
+
+  const save = async () => {
+    const next = draft.trim()
+    if (next === altText) {
+      setIsEditing(false)
+      return
+    }
+    setIsSaving(true)
+    setError(null)
+    try {
+      const response = await apiFetch(`/v1/media/${String(item.id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ alt_text: next }),
+      })
+      if (!response.ok) {
+        setError(await errorMessage(response, `Save failed (${response.status})`))
+        return
+      }
+      onSaved(item.id, next)
+      setIsEditing(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to save alt text.")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (!isEditing) {
+    return (
+      <button
+        className={`flex items-center gap-1 px-2 pb-1.5 text-left text-[11px] hover:text-foreground ${
+          altText ? "text-muted-foreground" : "text-destructive"
+        }`}
+        onClick={() => {
+          setDraft(altText)
+          setError(null)
+          setIsEditing(true)
+        }}
+        title={altText || "Add alt text"}
+        type="button"
+      >
+        <Pencil className="h-3 w-3 shrink-0" aria-hidden="true" />
+        <span className="truncate">{altText || "No alt text"}</span>
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1 px-2 pb-2">
+      <input
+        aria-label={`Alt text for ${item.file_name}`}
+        autoFocus
+        className="w-full rounded border border-border bg-background px-1.5 py-1 text-[11px] text-foreground focus:border-primary focus:outline-none"
+        disabled={isSaving}
+        onChange={(e) => setDraft(e.target.value)}
+        // Enter saves and Escape abandons, so the whole edit is one gesture
+        // without reaching for the buttons.
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault()
+            void save()
+          }
+          // Stopped from bubbling: the picker closes the whole modal on Escape,
+          // which would throw away the article's insertion point too.
+          if (e.key === "Escape") {
+            e.preventDefault()
+            e.stopPropagation()
+            setIsEditing(false)
+          }
+        }}
+        placeholder="Describe the image"
+        value={draft}
+      />
+      {error && <p className="text-[11px] text-destructive">{error}</p>}
+      <div className="flex gap-1">
+        <button
+          className="rounded bg-primary px-2 py-0.5 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          disabled={isSaving}
+          onClick={() => void save()}
+          type="button"
+        >
+          {isSaving ? "Saving..." : "Save"}
+        </button>
+        <button
+          className="rounded px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground"
+          disabled={isSaving}
+          onClick={() => setIsEditing(false)}
+          type="button"
+        >
+          Cancel
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/components/TrixEditor.css
+++ b/frontend/src/components/TrixEditor.css
@@ -415,6 +415,24 @@ trix-editor.trix-content .attachment__toolbar .trix-button--copy-url .trix-icon 
   height: 14px;
 }
 
+/* Alt text. Called out in the destructive colour when there is none, because an
+   image that publishes undescribed is the failure this button exists to catch
+   and nothing else on the page would say so. */
+trix-editor.trix-content .attachment__toolbar .trix-button--alt {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+trix-editor.trix-content .attachment__toolbar .trix-button--alt-missing {
+  color: hsl(var(--destructive, 0 72% 51%));
+}
+
+trix-editor.trix-content
+  .attachment__toolbar
+  .trix-button--alt-missing:hover:not(:disabled) {
+  background: hsl(var(--destructive, 0 72% 51%) / 0.12);
+}
+
 /* Confirmation tick, matching "Copy article link" going green on success. */
 trix-editor.trix-content .attachment__toolbar .trix-button--copied {
   color: hsl(var(--primary, 243 75% 59%));

--- a/frontend/src/components/TrixEditor.tsx
+++ b/frontend/src/components/TrixEditor.tsx
@@ -129,6 +129,12 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
 
   const [pickerOpen, setPickerOpen] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
+  // The image whose alt text is being edited, identified by attachment id
+  // because the attachment object itself is replaced whenever Trix re-renders.
+  const [altEditor, setAltEditor] = useState<{
+    attachmentId: number;
+    alt: string;
+  } | null>(null);
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -408,7 +414,7 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
 
       if (!item.alt_text) {
         setNotice(
-          `Inserted ${item.file_name}, which has no alt text. Add it in the Media library.`,
+          `Inserted ${item.file_name}, which has no alt text. Click the image and use “Alt” to describe it.`,
         );
       }
     },
@@ -434,6 +440,29 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
       editor.removeEventListener("trix-file-accept", handleFileAccept);
     };
   }, [openBlockForImage]);
+
+  // Write the edited alt text back onto the attachment. It lives in the
+  // attachment's own attributes, which is what Trix serializes into
+  // data-trix-attachment and what trixHtmlToArticle reads to emit <img alt>, so
+  // this is the value that publishes.
+  //
+  // Article-scoped by design: the attachment carries no library id (nothing
+  // survives a reload but the URL), and an image can legitimately want a
+  // different description in a different story. Setting the library's own alt
+  // text -- the value every future insertion starts from -- is the picker's job.
+  const saveAltText = useCallback((attachmentId: number, alt: string) => {
+    setAltEditor(null);
+    const editor = editorRef.current;
+    if (!editor) return;
+    const attachment = editor.editor
+      .getDocument()
+      .getAttachments()
+      .find((candidate) => candidate.id === attachmentId);
+    // Gone: the image was deleted while the dialog was open.
+    if (!attachment) return;
+    attachment.setAttributes({ alt });
+    editor.focus();
+  }, []);
 
   const openPicker = useCallback(() => {
     const editor = editorRef.current;
@@ -1035,6 +1064,36 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
         toolbar.querySelector(".trix-button-row")?.appendChild(copyGroup);
       }
 
+      // Alt text, editable from here rather than only from the Media library.
+      // The caption is already editable in place (Trix's own caption field), so
+      // alt text was the one thing about an image an author had to leave the
+      // article to change -- and the one that has to be right before it
+      // publishes.
+      const altGroup = document.createElement("span");
+      altGroup.className = "trix-button-group trix-button-group--alt";
+
+      const alt =
+        typeof attachment.getAttribute("alt") === "string"
+          ? String(attachment.getAttribute("alt"))
+          : "";
+      const altButton = document.createElement("button");
+      altButton.type = "button";
+      altButton.className = `trix-button trix-button--alt${alt ? "" : " trix-button--alt-missing"}`;
+      altButton.textContent = "Alt";
+      altButton.title = alt ? `Alt text: ${alt}` : "No alt text — add a description";
+      altButton.addEventListener("mousedown", (mouseEvent) => {
+        mouseEvent.preventDefault();
+      });
+      altButton.addEventListener("click", (clickEvent) => {
+        clickEvent.preventDefault();
+        // Only the id travels into React state: the dialog outlives this
+        // toolbar (opening it deselects the attachment, which tears the toolbar
+        // down), so it re-finds the attachment in the document on save.
+        setAltEditor({ attachmentId: attachment.id, alt });
+      });
+      altGroup.appendChild(altButton);
+      toolbar.querySelector(".trix-button-row")?.appendChild(altGroup);
+
       toolbar.querySelector(".trix-button-row")?.appendChild(group);
     };
 
@@ -1531,6 +1590,17 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
         </div>
       )}
 
+      {altEditor && (
+        <AltTextDialog
+          alt={altEditor.alt}
+          onCancel={() => {
+            setAltEditor(null);
+            editorRef.current?.focus();
+          }}
+          onSave={(alt) => saveAltText(altEditor.attachmentId, alt)}
+        />
+      )}
+
       {pickerOpen && (
         <MediaPicker
           onClose={() => {
@@ -1540,6 +1610,88 @@ function TrixEditor({ value, onChange }: TrixEditorProps) {
           onSelect={insertFromLibrary}
         />
       )}
+    </div>
+  );
+}
+
+type AltTextDialogProps = {
+  alt: string;
+  onSave: (alt: string) => void;
+  onCancel: () => void;
+};
+
+/**
+ * Alt-text prompt for the image the author has selected in the article.
+ *
+ * A modal rather than a field on the attachment toolbar: that toolbar is Trix's,
+ * it is destroyed the moment the attachment loses selection, and a text input
+ * living inside the contenteditable competes with Trix for every keystroke --
+ * the same reason the caption field is Trix's own and not ours.
+ */
+function AltTextDialog({ alt, onSave, onCancel }: AltTextDialogProps) {
+  const [draft, setDraft] = useState(alt);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onCancel}
+      role="presentation"
+    >
+      <div
+        aria-label="Alt text"
+        aria-modal="true"
+        className="flex w-full max-w-md flex-col gap-3 rounded-xl border border-border bg-background p-5"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+      >
+        <h2 className="text-base font-semibold text-foreground">Alt text</h2>
+        <p className="text-sm text-muted-foreground">
+          What a screen reader announces in place of this image. Leave it empty
+          only if the image is decorative.
+        </p>
+        <textarea
+          aria-label="Alt text"
+          autoFocus
+          className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          onChange={(e) => setDraft(e.target.value)}
+          // Enter saves; the field is one sentence, not a paragraph.
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              onSave(draft.trim());
+            }
+          }}
+          placeholder="Describe the image"
+          rows={3}
+          value={draft}
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            className="rounded-lg px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+            onClick={onCancel}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            onClick={() => onSave(draft.trim())}
+            type="button"
+          >
+            Save
+          </button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Captions already edit in place in the body. Alt text was the one thing about an image an author had to open the Media library to change — a round trip out of a half-written article, for the field that has to be right before it publishes.

## Media picker

Each tile gets an alt-text row under the filename: the current description, or a red **No alt text** (replacing the old passive grey label, which said the same thing but offered no way to act on it). Clicking opens an input in place — Enter or **Save** writes `PATCH /v1/media/{id}`, Escape cancels without closing the picker and losing the insertion point.

This edits the **library record**, so an image described once is described everywhere it is used — the contract the picker already relied on when handing `alt_text` to the editor. The grid updates in place, so selecting the image right afterwards inserts it with the new alt.

Tile markup went from a single `<button>` to a container, since a button nested in a button is invalid HTML. Selection behaviour is unchanged.

## Article editor

The attachment toolbar (beside Move and Copy URL) gets an **Alt** button, red when the image has no alt text. It opens a small dialog that writes the attachment's `alt` attribute — what `trixHtmlToArticle` emits as `<img alt>`, i.e. the value that actually publishes.

Deliberately **article-scoped**: a Trix attachment carries no library id (nothing but the URL survives a reload), and the same photo can legitimately want a different description in a different story. Library-level alt stays the picker's job. Both paths are commented to that effect.

The post-insert notice no longer says "Add it in the Media library" — it points at the Alt button.

## Notes

- No server change: `PATCH /v1/media/{id}` already accepts `alt_text` and is open to any signed-in editor.
- New `MediaPicker.test.tsx` covers the PATCH URL/body, the warning clearing with the new alt reaching `onSelect`, and typed text surviving a failed save. Suite 7/7, eslint + `tsc` + build clean.
- The Trix toolbar button is not visually verified — that path needs a browser session behind auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)