### PR TITLE
Point "View Live" links at production

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 # Baked in at build time (Vite inlines import.meta.env), so this is the origin
 # every "View Live" link and permalink preview in the published image points at.
 # Override with --build-arg to publish an image aimed at another site.
-ARG VITE_PUBLIC_SITE_URL="https://dev.thetriangle.org"
+ARG VITE_PUBLIC_SITE_URL="https://www.thetriangle.org"
 ENV VITE_PUBLIC_SITE_URL=${VITE_PUBLIC_SITE_URL}
 
 COPY package.json package-lock.json ./

--- a/frontend/src/auth/urls.ts
+++ b/frontend/src/auth/urls.ts
@@ -12,11 +12,11 @@ export function authBaseUrl() {
 
 // Public-facing site origin, used for article permalinks (e.g. so Yoast can
 // tell internal links from outbound ones) and for the "View Live" links.
-// Defaults to the dev site: the CMS is not yet driving production, so an
-// unconfigured build pointing at www would send editors to pages that do not
-// reflect what they just saved.
+// Defaults to www now that the CMS drives production: an unconfigured build
+// pointing at dev would send editors to a copy of the site their readers never
+// see. Override with VITE_PUBLIC_SITE_URL to aim a build at dev instead.
 export function publicSiteUrl() {
-  return trimTrailingSlashes(import.meta.env.VITE_PUBLIC_SITE_URL ?? "https://dev.thetriangle.org")
+  return trimTrailingSlashes(import.meta.env.VITE_PUBLIC_SITE_URL ?? "https://www.thetriangle.org")
 }
 
 // The public permalink for a slug. The URL is fully determined by the slug, so


### PR DESCRIPTION
Part of the dev → production cutover.

The published frontend image bakes in `https://dev.thetriangle.org` as the origin behind every "View Live" link and article permalink. That was correct while the CMS was not driving production — an unconfigured build aimed at www would have sent editors to pages that didn't reflect what they'd just saved.

Cutover reverses it. With the CMS behind www, a "View Live" link pointing at dev sends editors to a copy of the site their readers never see, and dev sits behind Cloudflare Access, so for anyone without access it doesn't resolve at all.

Vite inlines the value at build time and `publish.yml` passes no `--build-arg`, so the **Dockerfile default is what actually ships**. The TypeScript fallback in `auth/urls.ts` is updated to match so the two can't drift. Aim a build at dev with `--build-arg VITE_PUBLIC_SITE_URL=https://dev.thetriangle.org`.

**Merge order:** this one is independent of the Scalene flip and safe to land whenever. It only changes where editors' preview links point, not what the CMS serves.

Verified: `tsc -b && vite build` clean, vitest 8/8, eslint clean apart from one pre-existing warning this branch doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)