### PR TITLE
Raise the DB connection pool off its development default

### DIFF
--- a/server/internal/database/database.go
+++ b/server/internal/database/database.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -11,6 +15,36 @@ import (
 
 func buildDSN(dbName, user, password, host string, port int) string {
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true", user, password, host, port, dbName)
+}
+
+// defaultMaxOpenConns is the size of the connection pool.
+//
+// This was 10, which is a development-sized pool: it is not the database that
+// runs out, it is the queue in front of it. Under production traffic every page
+// render calls /v1/settings/site, and with ten connections those requests
+// serialize -- observed at 25-125s per request on the public cutover, while the
+// database itself sat at two running threads and the host at 0.02 load. The
+// symptom reads like a resource shortage everywhere except where the resource
+// actually is.
+//
+// DB1 allows 200 connections. Two blue/green slots at 50 each leaves ample room
+// for MaxScale's monitor, the replica, and an operator session.
+const defaultMaxOpenConns = 50
+
+// maxOpenConns allows the pool to be resized without a rebuild, which matters
+// because the failure mode above is only visible under real traffic.
+func maxOpenConns() int {
+	raw := strings.TrimSpace(os.Getenv("DB_MAX_OPEN_CONNS"))
+	if raw == "" {
+		return defaultMaxOpenConns
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 1 {
+		slog.Warn("ignoring invalid DB_MAX_OPEN_CONNS, using the default",
+			"value", raw, "default", defaultMaxOpenConns)
+		return defaultMaxOpenConns
+	}
+	return parsed
 }
 
 func InitializeConnection(ctx context.Context, dbName, user, password, host string, port int) (*sql.DB, error) {
@@ -21,8 +55,9 @@ func InitializeConnection(ctx context.Context, dbName, user, password, host stri
 	}
 
 	db.SetConnMaxLifetime(time.Minute * 3)
-	db.SetMaxOpenConns(10)
-	db.SetMaxIdleConns(10)
+	maxConns := maxOpenConns()
+	db.SetMaxOpenConns(maxConns)
+	db.SetMaxIdleConns(maxConns)
 
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()


### PR DESCRIPTION
**Production is currently down behind this.** Merging deploys the fix.

## What happened

`database.go` capped the pool at `SetMaxOpenConns(10)`. Scalene calls `/v1/settings/site` on every page render, so under public traffic those requests serialize behind ten connections. On the cutover that endpoint was taking **25–125 seconds**, Scalene's fetches returned Cloudflare **524**, and www timed out entirely.

## Why it was hard to spot

Every host reported idle:

| host | state |
|---|---|
| Delta (CMS) | load **0.02**, 9.6 GB free |
| DB1 | **14 of 200** connections, **2** running threads |
| MaxScale | 3.9 GB of 4 GB free, both nodes in sync |
| .141 (WordPress + Astro) | load 0.57, 10.6 GB of 12 GB free |

The database is idle *because* only ten requests can reach it at once. The contention is in the queue in front of it, and no host metric names that queue — which is what makes this look like a resource shortage on some other machine.

The inactive blue/green slot answered `/v1/health/db` in 0.5 ms throughout, purely because it was serving no traffic. That contrast is the tell.

## The change

Default 50, overridable with `DB_MAX_OPEN_CONNS`. DB1 allows 200 connections, so two slots at 50 leaves headroom for MaxScale's monitor, the replica, and an operator session. The env override exists because this only reproduces under real traffic.

## Follow-up worth doing separately

`/v1/settings/site` is a per-render call on a value that changes rarely; a short TTL cache would cut the query volume by orders of magnitude regardless of pool size. Not in this PR — this one should stay minimal enough to merge while the site is down.

Verified: `go build ./...`, `go vet`, `go test ./internal/database/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)