### PR TITLE
Stop flagging a blank seo_title when the article title covers it

### DIFF
--- a/server/internal/database/seo.go
+++ b/server/internal/database/seo.go
@@ -118,9 +118,18 @@ func auditArticle(id int64, slug, title, seoTitle, metaDesc, focusKeyword, photo
 	metaDesc = strings.TrimSpace(metaDesc)
 	focusKeyword = strings.TrimSpace(focusKeyword)
 
-	if seoTitle == "" {
+	// A blank seo_title is not a defect: the public site renders the article
+	// title in its place (ArticleLayout.astro), so the page ships a correct
+	// <title> either way. Only the effective title's length matters, because
+	// that is what search results actually truncate.
+	effectiveTitle := seoTitle
+	if effectiveTitle == "" {
+		effectiveTitle = strings.TrimSpace(title)
+	}
+	switch {
+	case effectiveTitle == "":
 		add("warning", "Missing SEO title")
-	} else if utf8.RuneCountInString(seoTitle) > seoTitleMaxLen {
+	case utf8.RuneCountInString(effectiveTitle) > seoTitleMaxLen:
 		add("warning", "SEO title exceeds 60 characters")
 	}
 

--- a/server/internal/database/seo_test.go
+++ b/server/internal/database/seo_test.go
@@ -89,6 +89,44 @@ func TestAuditArticleFlagsMissingFeaturedImage(t *testing.T) {
 	}
 }
 
+func TestAuditArticleFallsBackToTitleForSEOTitle(t *testing.T) {
+	longEnoughDesc := strings.Repeat("a", 100)
+	photoURL := "https://example.com/a.jpg"
+
+	// The public site renders the article title when seo_title is blank, so a
+	// blank column with a usable title is not an issue worth reporting.
+	issues := auditArticle(1, "some-slug", "A short headline", "", longEnoughDesc, "keyword", photoURL, "An excerpt")
+	messages := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		messages = append(messages, issue.Issue)
+	}
+	if containsSubstring(messages, "Missing SEO title") {
+		t.Errorf("a blank seo_title with a title to fall back on should not be flagged, got %v", messages)
+	}
+
+	// The length check has to follow the fallback, because an over-long
+	// headline is what gets truncated in search results.
+	longTitle := strings.Repeat("a", seoTitleMaxLen+1)
+	issues = auditArticle(1, "some-slug", longTitle, "", longEnoughDesc, "keyword", photoURL, "An excerpt")
+	messages = messages[:0]
+	for _, issue := range issues {
+		messages = append(messages, issue.Issue)
+	}
+	if !containsSubstring(messages, "SEO title exceeds") {
+		t.Errorf("an over-long fallback title should be flagged, got %v", messages)
+	}
+
+	// With neither, the page has no title at all.
+	issues = auditArticle(1, "some-slug", "   ", "", longEnoughDesc, "keyword", photoURL, "An excerpt")
+	messages = messages[:0]
+	for _, issue := range issues {
+		messages = append(messages, issue.Issue)
+	}
+	if !containsSubstring(messages, "Missing SEO title") {
+		t.Errorf("expected a missing-SEO-title issue when there is no title either, got %v", messages)
+	}
+}
+
 func TestAuditArticleFlagsNoDescriptionAndNoExcerpt(t *testing.T) {
 	// The public site falls back to the excerpt when meta_description is blank,
 	// so only the combination leaves the page with no description at all.


### PR DESCRIPTION
## Problem

The SEO audit warned "Missing SEO title" whenever the `seo_title` column was empty. But blank is the normal, working state: the public site renders the article title in its place ([Scalene `ArticleLayout.astro:63`](https://github.com/DrexelTriangle/Scalene/blob/CMS-Testing/src/layouts/ArticleLayout.astro#L63)), and the editor previews the same fallback — its input placeholder even says "Defaults to the article title." Nothing ever persists that default, so the column stays empty and the page still ships a correct `<title>`.

The result was a warning firing on articles whose output was already fine — essentially the whole legacy WordPress import. At ~1,900 total issues it buried the `error`-level findings (missing meta description, missing featured image) that do reflect broken output.

## Change

Resolve the effective title the way the renderer does, then audit that:

- Blank `seo_title` + a usable article title → no longer reported.
- The 60-character check now runs against the effective title, so an over-long headline on an article with no explicit SEO title is caught. **This is new behavior** — a few long-headline articles that were previously silent will start showing this warning. Intended: that truncation is real in SERPs.
- "Missing SEO title" survives only when there is neither, which is a genuinely broken `<title>`.

## Testing

`TestAuditArticleFallsBackToTitleForSEOTitle` covers all three branches. Package tests and `go vet` pass.

## Notes

The 49-error count on the dashboard won't move — this only touched a `warning`. What drops is the 1,932 total. I haven't measured the new number against prod; happy to run that count if it's worth knowing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)