### PR TITLE
Let Publish Images be started by hand

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,12 @@
 name: Publish Images
 
+# The automatic path is CI -> Publish Images -> Deploy Delta, chained on
+# workflow_run. That chain has a single point of failure outside our control:
+# when GitHub throttles webhook delivery during an Actions incident, no
+# workflow_run event fires and nothing publishes, so Deploy Delta has no image
+# to deploy and main sits undeployed with no way to force it. workflow_dispatch
+# goes through the REST API instead, which stays up independently, so this is
+# the manual door for exactly that case.
 on:
   workflow_run:
     workflows:
@@ -8,9 +15,14 @@ on:
       - main
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Full commit SHA on main to build (defaults to the tip of main)
+        required: false
 
 concurrency:
-  group: publish-${{ github.event.workflow_run.head_sha }}
+  group: publish-${{ github.event.workflow_run.head_sha || inputs.sha || github.sha }}
   cancel-in-progress: false
 
 permissions:
@@ -19,21 +31,53 @@ permissions:
 
 jobs:
   publish:
+    # Both paths publish only main. The automatic one gets that from the
+    # workflow_run fields; the manual one is pinned to the main ref here and
+    # then has its resolved SHA checked for ancestry below, so a dispatch
+    # cannot publish a commit that never landed on main.
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.name == 'CI' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.event == 'push'
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.name == 'CI' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event == 'push'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Resolve SHA
         id: sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sha="${{ github.event.workflow_run.head_sha }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            sha="${{ inputs.sha }}"
+            if [[ -z "$sha" ]]; then
+              sha="${{ github.sha }}"
+            fi
+          else
+            sha="${{ github.event.workflow_run.head_sha }}"
+          fi
+
           if [[ ! "$sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
             echo "invalid full commit SHA: $sha" >&2
             exit 1
           fi
+
+          # A hand-supplied SHA is the one input here that is not already
+          # constrained to main, so confirm it is on main before we build an
+          # image Deploy Delta would treat as a production release. Comparing
+          # main to the commit reports "identical" when it is the tip and
+          # "behind" when it is an earlier commit on main; anything else means
+          # it lives on some other branch.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.sha }}" ]]; then
+            status="$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${sha}" --jq .status)"
+            if [[ "$status" != "identical" && "$status" != "behind" ]]; then
+              echo "refusing to publish $sha: not a commit on main (compare status: $status)" >&2
+              exit 1
+            fi
+          fi
+
           echo "value=$sha" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why

The automatic chain is CI → Publish Images → Deploy Delta, linked by `workflow_run`. During today's Actions incident GitHub throttled webhook delivery, so no `workflow_run` event fired: CI never chained to Publish, no image was ever built, and Deploy Delta — which *does* accept a `workflow_dispatch` — had nothing to deploy. `main` has been sitting undeployed since 16:16 UTC with no way to force it through.

`workflow_dispatch` is served by the REST API rather than the webhook pipeline, so it stays available when that path is throttled. Scalene's production deploy is already reachable this way and shipped fine this afternoon, while this repo could not.

## What

Adds a `workflow_dispatch` trigger to `publish.yml` with an optional `sha` input, defaulting to the tip of `main`.

## Publishing is still restricted to main

Two guards, because an image published here is what Deploy Delta releases to production:

- The dispatch is pinned to the `main` ref in the job's `if`.
- An explicitly supplied `sha` — the only input not already constrained by that — is checked for ancestry on `main` via the compare API before anything is built. `identical` (it's the tip) and `behind` (an earlier commit on main) pass; anything else means the commit lives on another branch and the run fails.

## Testing

YAML parses and the trigger/input/concurrency keys resolve as intended. The dispatch path itself gets exercised immediately after merge — deploying the backlog from #195 is the reason this is going in today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)