### PR TITLE
Roll sports with no subsection row back into Sports

### DIFF
--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -41,11 +42,37 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 //
 // Only applied where category_aliases IS NULL, so "never set" stays
 // distinguishable from an empty array an editor deliberately saved.
+// The sports entries are a different case from the other four. Those four are
+// one section under two names; these are the sports that never became
+// subsections. WordPress category archives roll a parent up over its child
+// terms automatically, so /category/sports/ listed every article tagged "Men's
+// Lacrosse" without anyone configuring it. Matching here is flat -- a section
+// finds itself plus the subsections that have a row -- so a sport with no row
+// rolls up into nothing and its articles appear on no section page at all.
+//
+// Most sports articles also carry a literal "Sports" tag and were never
+// affected, which is why this surfaced as a handful of arbitrary-looking gaps
+// rather than as a whole missing sport.
+//
+// Aliases rather than subsection rows: these need to rejoin Sports, not to
+// acquire a nav entry and a page each. Adding a row is still the right move for
+// a sport the desk wants to feature.
 var defaultCategoryAliases = map[string][]string{
 	"entertainment":       {"Arts & Entertainment"},
 	"science-tech":        {"Science & Technology"},
 	"from-the-editor":     {"From the Editor's Desk"},
 	"happening-in-philly": {"What's Happening in Philly"},
+	"sports": {
+		"Men's Lacrosse",
+		"Women's Lacrosse",
+		"Tennis",
+		"Crew",
+		"Golf",
+		"Softball",
+		"Swimming & Diving",
+		"Running",
+		"Athlete of the Week",
+	},
 }
 
 func SeedDefaultCategoryAliases(ctx context.Context, conn *sql.DB) error {
@@ -329,6 +356,76 @@ func countArticlesForSlugs(ctx context.Context, conn *sql.DB, slug string, match
 			"slug", slug, "matched_slugs", matched)
 	}
 	return count, nil
+}
+
+// ReportOrphanedArticles logs published articles that match no taxonomy row at
+// all -- the inverse of the zero-match warning in countArticlesForSlugs.
+//
+// That warning catches a slug that finds no articles. This catches the
+// direction that actually loses content: an article whose categories name
+// nothing the taxonomy knows about is still published, still reachable by
+// direct link and by search, and appears on no section page. Nothing in the CMS
+// showed it was gone -- a section that quietly omits some of its articles reads
+// as a normal section -- so it took an editor noticing that men's lacrosse had
+// stopped appearing under Sports, months after the categories diverged.
+//
+// Diagnostic only: it names the gap and leaves the fix (an alias or a
+// subsection row) to a person, because which section an orphan belongs to is an
+// editorial call.
+func ReportOrphanedArticles(ctx context.Context, conn *sql.DB) error {
+	matchSlugs, err := taxonomyMatchSlugs(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	slugs := make([]string, 0, len(matchSlugs))
+	for slug := range matchSlugs {
+		slugs = append(slugs, slug)
+	}
+	condition, args := TaxonomyCountCondition(slugs)
+	if condition == "" {
+		return nil
+	}
+
+	const published = "`archived_at` IS NULL AND `pub_date` IS NOT NULL AND `pub_date` <= UTC_TIMESTAMP()"
+
+	var orphaned int64
+	if err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM `articles` WHERE "+published+" AND NOT "+condition, args...,
+	).Scan(&orphaned); err != nil {
+		return err
+	}
+	if orphaned == 0 {
+		return nil
+	}
+
+	// The category sets are what a person needs to act: they say which
+	// spellings to alias, which is not recoverable from a bare count.
+	rows, err := conn.QueryContext(ctx,
+		"SELECT `categories`, COUNT(*) AS c FROM `articles` WHERE "+published+
+			" AND NOT "+condition+" GROUP BY `categories` ORDER BY c DESC LIMIT 10", args...,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	samples := make([]string, 0, 10)
+	for rows.Next() {
+		var categories sql.NullString
+		var count int64
+		if err := rows.Scan(&categories, &count); err != nil {
+			return err
+		}
+		samples = append(samples, fmt.Sprintf("%s (%d)", strings.TrimSpace(categories.String), count))
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	slog.Warn("published articles match no section or subsection and appear on no section page; they likely need a category alias",
+		"count", orphaned, "top_category_sets", strings.Join(samples, "; "))
+	return nil
 }
 
 func RebuildTaxonomyArticleCounts(ctx context.Context, conn *sql.DB) error {

--- a/server/internal/database/taxonomy_test.go
+++ b/server/internal/database/taxonomy_test.go
@@ -309,3 +309,59 @@ func TestDefaultCategoryAliasesCoverTheKnownMismatches(t *testing.T) {
 		}
 	}
 }
+
+func TestSportsAliasesRollUpSportsWithNoSubsectionRow(t *testing.T) {
+	// The reported bug: an article tagged only "Men's Lacrosse" carries no
+	// literal "Sports", and lacrosse has no subsection row to be matched
+	// through, so it appeared on no section page at all. WordPress rolled a
+	// parent category up over its child terms for free; flat matching does not.
+	withCategoryAliases(t, map[string][]string{"sports": defaultCategoryAliases["sports"]})
+
+	for _, categories := range []string{
+		`["Men's Lacrosse"]`,
+		`["TV","Men's Lacrosse"]`,
+		`["Women's Lacrosse"]`,
+		`["Tennis"]`,
+		`["Swimming & Diving"]`,
+		`["Athlete of the Week"]`,
+	} {
+		if !matchesCategories("sports", categories) {
+			t.Errorf("%s should roll up into sports", categories)
+		}
+	}
+}
+
+func TestSportsAliasesStayWholeCategoryMatches(t *testing.T) {
+	// Aliases go through the same anchored patterns as everything else, so
+	// adding them must not reintroduce the substring merging that put every
+	// comic in Puzzles. "Mark and Jair Explain Sports" is the live example:
+	// it ends in the section's own name and is not a sports article.
+	withCategoryAliases(t, map[string][]string{"sports": defaultCategoryAliases["sports"]})
+
+	for _, categories := range []string{
+		`["Mark and Jair Explain Sports"]`,
+		`["Table Tennis"]`,
+		`["Golfing"]`,
+	} {
+		if matchesCategories("sports", categories) {
+			t.Errorf("%s must not be pulled into sports", categories)
+		}
+	}
+}
+
+func TestDefaultSportsAliasesAreNotSubsectionSlugs(t *testing.T) {
+	// A sport that already has its own subsection row is matched through that
+	// row, so aliasing it onto the parent as well would only add a duplicate
+	// pattern to every sports query.
+	rows := map[string]struct{}{
+		"mens-basketball": {}, "womens-basketball": {}, "mens-soccer": {},
+		"womens-soccer": {}, "field-hockey": {}, "squash": {},
+		"philly-sports": {}, "big-5": {}, "nil": {},
+	}
+	for _, alias := range defaultCategoryAliases["sports"] {
+		slug := strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(alias), "'", ""), " ", "-")
+		if _, clash := rows[slug]; clash {
+			t.Errorf("%q duplicates the existing subsection %q", alias, slug)
+		}
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -202,6 +202,11 @@ func main() {
 			os.Exit(1)
 		}
 		slog.Info("rebuilt taxonomy article counts at startup")
+
+		// Diagnostic, so a failure here must not keep the server down.
+		if err := database.ReportOrphanedArticles(context.Background(), db); err != nil {
+			slog.Error("failed to check for articles matching no section", "error", err)
+		}
 	}
 	if err := database.EnsurePollSettings(context.Background(), db); err != nil {
 		slog.Error("failed to seed poll settings", "error", err)


### PR DESCRIPTION
Reported by Janine: men's lacrosse articles are not showing up in Sports.

## What's actually wrong

**469 of 10,025 published articles (4.7%) match no section or subsection at all.** They're published and reachable by direct link and search, but they appear on no section page.

WordPress category archives roll a parent up over its child terms automatically, so `/category/sports/` listed everything tagged "Men's Lacrosse" without anyone configuring it. Matching in the CMS is flat — a section finds itself plus the subsections that have a `site_taxonomy` row — and there is no lacrosse row anywhere in the table. Nine sports are in that position: both lacrosses, tennis, crew, golf, softball, swimming & diving, running, athlete of the week.

It read as arbitrary rather than as a broken section because **164 of the 175 lacrosse articles also carry a literal "Sports" tag** and were never affected. Only the ones tagged solely with the sport went missing.

## The fix

Aliases on the `sports` row, not new subsection rows: these need to rejoin Sports, not to acquire a nav entry and a page each. Adding a row is still right for a sport the desk wants to feature.

Aliases go through the same anchored patterns as every other match, so this does not reintroduce the substring merging that once filed every comic under Puzzles — `"Mark and Jair Explain Sports"` ends in the section's own name, is not a sports article, and stays out. There's a test for exactly that.

`sports.category_aliases` is `NULL` in production, and the seed only writes where the column IS NULL, so this applies on the next restart without touching a deliberate edit.

## The other half

`ReportOrphanedArticles` warns in the direction that actually loses content. `countArticlesForSlugs` already warns when a *slug* finds no articles; nothing warned when an *article* matches no slug. A section that quietly omits some of its articles reads as a perfectly normal section, which is why this went unnoticed for months until an editor happened to miss one sport.

Diagnostic only — which section an orphan belongs to is an editorial call — and its failure can't keep the server down.

## Still needs the desk

The remaining orphans are editorial decisions, not mine: **style (207)**, **editorial (103)**, **podcasts (75)**, plus column series like "Mark and Jair Explain Sports" (31) and "Ain't That Something with Brandon & Liz" (24). After this merges the startup WARN will name them on every boot.

## Testing

`go build`, `go vet`, and the full suite pass. Three new tests: the rollup works, anchoring still holds, and no alias duplicates an existing subsection row. Expect sports to go 2148 → ~2181 on the next count rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)