### PR TITLE
File the remaining orphaned categories

### DIFF
--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -36,32 +36,40 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 	return RefreshCategoryAliases(ctx, conn)
 }
 
-// defaultCategoryAliases are the slug -> category-title mismatches that existed
-// before aliases were editable data, seeded so upgrading an existing database
-// does not silently empty four sections.
+// defaultCategoryAliases are the categories a section has to answer to beyond
+// its own name, seeded so upgrading an existing database does not silently
+// empty a section.
 //
 // Only applied where category_aliases IS NULL, so "never set" stays
-// distinguishable from an empty array an editor deliberately saved.
-// The sports entries are a different case from the other four. Those four are
-// one section under two names; these are the sports that never became
-// subsections. WordPress category archives roll a parent up over its child
-// terms automatically, so /category/sports/ listed every article tagged "Men's
-// Lacrosse" without anyone configuring it. Matching here is flat -- a section
-// finds itself plus the subsections that have a row -- so a sport with no row
-// rolls up into nothing and its articles appear on no section page at all.
+// distinguishable from an empty array an editor deliberately saved. A row that
+// already holds aliases is therefore never topped up from here: adding an entry
+// for such a row also needs that row updated in the sections screen, or the
+// addition applies to new databases only.
 //
-// Most sports articles also carry a literal "Sports" tag and were never
-// affected, which is why this surfaced as a handful of arbitrary-looking gaps
-// rather than as a whole missing sport.
+// Two kinds of entry live here. The first four are one section under two names.
+// Everything after them is a category that never became a subsection: WordPress
+// category archives roll a parent up over its child terms automatically, so
+// /category/sports/ listed every article tagged "Men's Lacrosse" without anyone
+// configuring it. Matching here is flat -- a section finds itself plus the
+// subsections that have a row -- so a category with no row rolls up into
+// nothing and its articles appear on no section page at all. That stranded 469
+// published articles, 4.7% of the archive.
 //
-// Aliases rather than subsection rows: these need to rejoin Sports, not to
+// It stayed invisible because most articles also carry their section's literal
+// tag and were never affected, so the gaps looked arbitrary rather than
+// systematic. ReportOrphanedArticles now names the remainder out loud.
+//
+// Aliases rather than subsection rows: these need to rejoin a section, not to
 // acquire a nav entry and a page each. Adding a row is still the right move for
-// a sport the desk wants to feature.
+// a category the desk wants to feature.
 var defaultCategoryAliases = map[string][]string{
-	"entertainment":       {"Arts & Entertainment"},
-	"science-tech":        {"Science & Technology"},
 	"from-the-editor":     {"From the Editor's Desk"},
 	"happening-in-philly": {"What's Happening in Philly"},
+
+	// Most sports articles also carry a literal "Sports" tag and were never
+	// affected, which is why this surfaced as a handful of arbitrary-looking
+	// gaps rather than as a whole missing sport. This is the report that
+	// exposed the rest.
 	"sports": {
 		"Men's Lacrosse",
 		"Women's Lacrosse",
@@ -73,6 +81,45 @@ var defaultCategoryAliases = map[string][]string{
 		"Running",
 		"Athlete of the Week",
 	},
+
+	// The rest of the orphans, filed by what the articles actually are. The
+	// same WordPress hierarchy that carried the sports carried these, and
+	// losing it stranded 436 published articles on no section page at all.
+	//
+	// Style is the large one: 306 articles across the beat and its recurring
+	// features. It sits under Entertainment rather than Opinion's Lifestyle
+	// because it is culture coverage, not opinion writing.
+	"entertainment": {
+		"Arts & Entertainment",
+		"Style", "Street Style", "DIY", "Inside Her Bag", "Store Profile",
+		"Beauty Guide", "Style Guide", "Designer Profile", "Fashion Week",
+		"TV", "Exhibits", "Reel2Reel", "Features",
+		"Restaurant Reviews", "Beer Reviews", "Last Call",
+	},
+
+	// Editorials and letters are the section's own voice, so they belong to
+	// Opinion even though neither is filed under it.
+	"opinion": {"Editorial", "Letters to the Editor", "Commentary"},
+
+	// Columns is where recurring bylined series live, which is what the
+	// podcasts are -- "Mark and Jair Explain Sports" is a show, not a sports
+	// article. Anchored matching keeps it out of Sports despite the name.
+	"columns": {
+		"Podcasts",
+		"Mark and Jair Explain Sports",
+		"Ain't That Something With Brandon & Liz",
+		"You, Me, Buscemi",
+		"Polkadot Tea.Pot",
+		"Where's Mario",
+		"Student Snapshot",
+	},
+
+	"comics-puzzles": {"Word Search"},
+	"science-tech":   {"Science & Technology", "Technically Speaking"},
+
+	// Sponsored content, and the weakest of these calls: it is not news, but
+	// an advertiser paid for it to be visible and no section fits it better.
+	"news": {"Paid Post"},
 }
 
 func SeedDefaultCategoryAliases(ctx context.Context, conn *sql.DB) error {

--- a/server/internal/database/taxonomy_test.go
+++ b/server/internal/database/taxonomy_test.go
@@ -290,8 +290,9 @@ func TestCategoryMatchPatternsDeduplicatesAliases(t *testing.T) {
 
 func TestDefaultCategoryAliasesCoverTheKnownMismatches(t *testing.T) {
 	// These four sections are named differently from the category their
-	// articles carry. Losing a default silently empties a section on upgrade,
-	// so pin them.
+	// articles carry. Losing one silently empties a section on upgrade, so pin
+	// them. Checked by containment, not equality: these rows also carry the
+	// orphaned categories that never became subsections, and that list grows.
 	want := map[string]string{
 		"entertainment":       "Arts & Entertainment",
 		"science-tech":        "Science & Technology",
@@ -304,8 +305,15 @@ func TestDefaultCategoryAliasesCoverTheKnownMismatches(t *testing.T) {
 			t.Errorf("missing default alias for %q", slug)
 			continue
 		}
-		if len(got) != 1 || got[0] != alias {
-			t.Errorf("default alias for %q = %v, want [%q]", slug, got, alias)
+		found := false
+		for _, candidate := range got {
+			if candidate == alias {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("default aliases for %q = %v, must include %q", slug, got, alias)
 		}
 	}
 }
@@ -419,5 +427,59 @@ func TestTaxonomySlugForCategoryReportsNothingWhenUnknown(t *testing.T) {
 	withCategorySlugsByTitle(t, map[string]string{"sports": "sports"})
 	if got := TaxonomySlugForCategory("Men's Lacrosse"); got != "" {
 		t.Errorf("got %q, want empty for a category with no page", got)
+	}
+}
+
+func TestOrphanAliasesRollUpIntoTheirSection(t *testing.T) {
+	// The 436 articles that matched no section at all. Each carried a category
+	// that WordPress rolled up through hierarchy and flat matching does not.
+	withCategoryAliases(t, defaultCategoryAliases)
+
+	for _, tc := range []struct{ slug, categories string }{
+		{"entertainment", `["Style"]`},
+		{"entertainment", `["Style", "Street Style"]`},
+		{"entertainment", `["Restaurant Reviews"]`},
+		{"opinion", `["Editorial"]`},
+		{"opinion", `["Letters to the Editor"]`},
+		{"columns", `["Podcasts", "Mark and Jair Explain Sports"]`},
+		{"columns", `["Ain't That Something With Brandon & Liz"]`},
+		{"comics-puzzles", `["Word Search"]`},
+		{"science-tech", `["Technically Speaking"]`},
+	} {
+		if !matchesCategories(tc.slug, tc.categories) {
+			t.Errorf("%s should roll up into %s", tc.categories, tc.slug)
+		}
+	}
+}
+
+func TestPodcastNamedForASectionStaysOutOfIt(t *testing.T) {
+	// "Mark and Jair Explain Sports" is a show, not a sports article. Under the
+	// old substring matching it was one of the 31 articles wrongly counted into
+	// Sports; it must reach Columns and only Columns.
+	withCategoryAliases(t, defaultCategoryAliases)
+
+	const categories = `["Podcasts", "Mark and Jair Explain Sports"]`
+	if matchesCategories("sports", categories) {
+		t.Error("a podcast named for Sports must not be filed under Sports")
+	}
+	if !matchesCategories("columns", categories) {
+		t.Error("it belongs to Columns")
+	}
+}
+
+func TestNoCategoryIsAliasedToTwoSections(t *testing.T) {
+	// An alias claimed by two sections puts the same article on both section
+	// pages, which reads as a duplicate rather than as a misconfiguration --
+	// the same way the original bug read as a normal section.
+	owner := map[string]string{}
+	for slug, aliases := range defaultCategoryAliases {
+		for _, alias := range aliases {
+			key := strings.ToLower(alias)
+			if previous, taken := owner[key]; taken {
+				t.Errorf("%q is aliased to both %q and %q", alias, previous, slug)
+				continue
+			}
+			owner[key] = slug
+		}
 	}
 }


### PR DESCRIPTION
Follow-on to #199, which fixed the sports half of the same bug.

## What's left

#199 left **436 published articles matching no section or subsection** — still published, still reachable by direct link and by search, on no section page. Same cause: WordPress rolled a parent category up over its child terms, and flat matching has nothing to roll up through. The `ReportOrphanedArticles` warning added in #199 has been naming them at every boot since.

## The calls

Filed by what the articles actually are:

| Section | Categories |
|---|---|
| **Entertainment** | Style and its features (306 articles), TV, Exhibits, Reel2Reel, Features, Restaurant/Beer Reviews, Last Call |
| **Opinion** | Editorial (103), Letters to the Editor, Commentary |
| **Columns** | Podcasts (75) and the recurring shows |
| **Comics & Puzzles** | Word Search |
| **Science & Tech** | Technically Speaking |
| **News** | Paid Post |

Two worth stating out loud:

- **Style → Entertainment**, not Opinion's Lifestyle. It's culture coverage, not opinion writing, and it's the single biggest bucket at 306 articles.
- **Paid Post → News** is the weakest call here. It isn't news; it's sponsored content. But an advertiser paid for it to be visible and nothing fits better. Happy to move it if the desk disagrees.

## The one to watch

`"Mark and Jair Explain Sports"` is a show, not a sports article — and it was one of the 31 articles that unanchored matching wrongly counted into Sports before the exact-match fix. Anchored patterns keep it out of Sports while the alias puts it in Columns. `TestPodcastNamedForASectionStaysOutOfIt` pins both halves.

`TestNoCategoryIsAliasedToTwoSections` is also new: an alias claimed by two sections would put one article on both section pages, which reads as a duplicate rather than as a misconfiguration — the same way the original bug read as a normal section.

## Needs a data edit too

`entertainment` and `science-tech` already hold aliases, and `SeedDefaultCategoryAliases` only writes where the column IS NULL — deliberately, so an editor's clear isn't resurrected on every restart. So those two rows will **not** be topped up by this merge and must be updated directly (SQL in the PR discussion, or the sections screen). The map stays the source of truth for a database built from scratch; the comment on it now says so.

Without that edit, the Style family — 306 of the 436 — stays orphaned.

## Testing

`go build`, `go vet`, full suite green. Expect the startup warning to drop from 436 to near zero once both the merge and the data edit are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)