### PR TITLE
Match the dashboard status chips to the articles page

### DIFF
--- a/frontend/src/lib/articleStatus.ts
+++ b/frontend/src/lib/articleStatus.ts
@@ -1,0 +1,17 @@
+// Shared styling for the article status chips so the dashboard and the
+// articles list always render the same colors for the same status.
+const STATUS_CHIP_COLORS: Record<string, string> = {
+  published: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  scheduled: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  draft: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+}
+
+const FALLBACK_CHIP_COLOR = "bg-slate-200 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200"
+
+export const ARTICLE_STATUS_CHIP_BASE =
+  "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+
+export function articleStatusChipClass(status: string) {
+  const color = STATUS_CHIP_COLORS[status.toLowerCase()] ?? FALLBACK_CHIP_COLOR
+  return `${ARTICLE_STATUS_CHIP_BASE} ${color}`
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
+import { articleStatusChipClass } from "../lib/articleStatus"
 
 interface RecentArticle {
   id: number
@@ -450,9 +450,9 @@ export default function DashboardPage() {
                           {article.categories[0]?.name ?? "—"}
                         </td>
                         <td className="px-3 py-2.5">
-                          <Badge variant={article.status === "published" ? "success" : "secondary"} className="text-[11px]">
+                          <span className={articleStatusChipClass(article.status)}>
                             {formatStatusLabel(article.status)}
-                          </Badge>
+                          </span>
                         </td>
                         <td className="px-5 py-2.5 text-xs text-muted-foreground text-right hidden lg:table-cell">
                           {timeAgo(article.published_date)}

--- a/frontend/src/pages/articleView.tsx
+++ b/frontend/src/pages/articleView.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "react-router-dom"
 import { articleUrl } from "../auth/urls"
 import { useApiFetch } from "../hooks/useApiFetch"
 import { copyText } from "../lib/clipboard"
+import { articleStatusChipClass } from "../lib/articleStatus"
 
 type ArticleStatus = "Published" | "Scheduled" | "Draft" | "Archived"
 
@@ -730,15 +731,7 @@ function ArticleView({ pageTitle = "Articles", fixedType, excludeType }: Article
                   </td>
                   <td className="px-4 py-3 text-muted-foreground">{item.authors || "-"}</td>
                   <td className="px-4 py-3">
-                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                      item.status === "Published"
-                        ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-                        : item.status === "Scheduled"
-                          ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
-                          : item.status === "Draft"
-                          ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
-                          : "bg-slate-200 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200"
-                    }`}>
+                    <span className={articleStatusChipClass(item.status)}>
                       {item.status}
                     </span>
                   </td>


### PR DESCRIPTION
The recent-articles table on the dashboard rendered statuses with the shadcn `Badge`, whose variants only distinguish success from secondary — so Scheduled and Draft both came out grey while the articles page showed them blue and yellow.

- New `frontend/src/lib/articleStatus.ts` holds the single status → chip-class map (green Published, blue Scheduled, yellow Draft, slate fallback, with dark-mode variants).
- `articleView.tsx` uses the helper instead of its inline ternary chain.
- `DashboardPage.tsx` renders the same span; the helper lowercases its input, so the dashboard's `"scheduled"` and the articles page's `"Scheduled"` resolve identically.

Not changed here: the articles page relabels a future-dated `published` article as Scheduled, while the dashboard shows the raw API status. Colors now agree per label, but that one mapping can still differ between the two pages.

Verified with `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)