### PR TITLE
Fix category chips: dead links, and the wrong category on the card

### DIFF
--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -99,16 +99,24 @@ func SeedDefaultCategoryAliases(ctx context.Context, conn *sql.DB) error {
 var (
 	categoryAliasMu     sync.RWMutex
 	categoryAliasBySlug = map[string][]string{}
+
+	// categorySlugByTitle is the reverse direction: the category text an
+	// article carries -> the taxonomy slug whose page lists it. It backs
+	// TaxonomySlugForCategory and is loaded by the same refresh.
+	categorySlugByTitle = map[string]string{}
 )
 
 // RefreshCategoryAliases reloads the alias cache from site_taxonomy. Call it
 // after any write to the table, or matching will keep using the old aliases
 // until the process restarts.
 func RefreshCategoryAliases(ctx context.Context, conn *sql.DB) error {
+	// Every section and subsection, not just the rows carrying aliases: the
+	// title -> slug direction needs the rows that have no alias at all, which
+	// is most of them.
 	rows, err := conn.QueryContext(ctx, `
-		SELECT slug, category_aliases
+		SELECT slug, canonical_title, category_aliases
 		FROM site_taxonomy
-		WHERE category_aliases IS NOT NULL
+		WHERE kind IN ('section', 'subsection')
 	`)
 	if err != nil {
 		return err
@@ -116,11 +124,24 @@ func RefreshCategoryAliases(ctx context.Context, conn *sql.DB) error {
 	defer rows.Close()
 
 	loaded := make(map[string][]string)
+	titles := make(map[string]string)
+	aliasTitles := make(map[string]string)
 	for rows.Next() {
-		var slug string
+		var slug, canonicalTitle string
 		var raw sql.NullString
-		if err := rows.Scan(&slug, &raw); err != nil {
+		if err := rows.Scan(&slug, &canonicalTitle, &raw); err != nil {
 			return err
+		}
+		normalizedSlug := strings.ToLower(strings.TrimSpace(slug))
+		if normalizedSlug == "" {
+			continue
+		}
+		if title := strings.ToLower(strings.TrimSpace(canonicalTitle)); title != "" {
+			titles[title] = normalizedSlug
+		}
+
+		if !raw.Valid {
+			continue
 		}
 		aliases, err := ParseCategoryAliases(raw.String)
 		if err != nil {
@@ -129,18 +150,71 @@ func RefreshCategoryAliases(ctx context.Context, conn *sql.DB) error {
 			slog.Warn("ignoring malformed taxonomy category_aliases", "slug", slug, "error", err)
 			continue
 		}
-		if len(aliases) > 0 {
-			loaded[strings.ToLower(strings.TrimSpace(slug))] = aliases
+		if len(aliases) == 0 {
+			continue
+		}
+		loaded[normalizedSlug] = aliases
+		for _, alias := range aliases {
+			if normalized := strings.ToLower(strings.TrimSpace(alias)); normalized != "" {
+				// First writer wins, so a duplicated alias cannot make the
+				// resolved slug depend on row order.
+				if _, taken := aliasTitles[normalized]; !taken {
+					aliasTitles[normalized] = normalizedSlug
+				}
+			}
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
 
+	// A row's own title outranks any alias: an alias is how a section absorbs
+	// somebody else's category, so it must never displace that category's own
+	// page when one exists.
+	for title, slug := range aliasTitles {
+		if _, exists := titles[title]; !exists {
+			titles[title] = slug
+		}
+	}
+
 	categoryAliasMu.Lock()
 	categoryAliasBySlug = loaded
+	categorySlugByTitle = titles
 	categoryAliasMu.Unlock()
 	return nil
+}
+
+// TaxonomySlugForCategory resolves the category text an article carries to the
+// slug of the page that lists it, or "" when nothing does.
+//
+// The category chip on an article card is a link, and its target used to be
+// derived from the category NAME alone. That silently produced URLs no page
+// answers: "Men's Basketball" canonicalizes to "men-s-basketball" while the
+// subsection lives at "mens-basketball", so every chip on both basketballs and
+// both soccers -- the four apostrophe subsections -- was a 404. The apostrophe
+// is the same thing possessiveVariant exists to absorb on the matching side;
+// this is that fix applied to the link.
+//
+// Resolving through the taxonomy also means a category that only reaches a
+// section by alias links to that section rather than to nothing.
+func TaxonomySlugForCategory(name string) string {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		return ""
+	}
+	categoryAliasMu.RLock()
+	defer categoryAliasMu.RUnlock()
+	return categorySlugByTitle[normalized]
+}
+
+// CategoryLinkSlug is what an article's category chip should point at: the
+// taxonomy slug when a page exists, and the name-derived slug otherwise so the
+// value is never empty.
+func CategoryLinkSlug(name string) string {
+	if slug := TaxonomySlugForCategory(name); slug != "" {
+		return slug
+	}
+	return CanonicalizeSlug(name)
 }
 
 // ParseCategoryAliases decodes the stored JSON array, dropping blanks. An empty

--- a/server/internal/database/taxonomy_integration_test.go
+++ b/server/internal/database/taxonomy_integration_test.go
@@ -40,6 +40,7 @@ func taxonomyTestDB(t *testing.T) *sql.DB {
 	t.Cleanup(func() {
 		categoryAliasMu.Lock()
 		categoryAliasBySlug = map[string][]string{}
+		categorySlugByTitle = map[string]string{}
 		categoryAliasMu.Unlock()
 	})
 	return conn
@@ -169,4 +170,47 @@ func containsPattern(patterns []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestRefreshLoadsCategoryTitlesAndPrefersARealPage(t *testing.T) {
+	conn := taxonomyTestDB(t)
+	ctx := context.Background()
+
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("ensure taxonomy table: %v", err)
+	}
+	insertTaxonomyRow(t, conn, 1, "section", "sports", "Sports")
+	insertTaxonomyRow(t, conn, 2, "subsection", "mens-basketball", "Men's Basketball")
+	if err := RefreshCategoryAliases(ctx, conn); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	// A row with no alias at all still has to resolve, which is why the
+	// refresh reads every section and subsection rather than only the rows
+	// carrying aliases.
+	if got, want := CategoryLinkSlug("Men's Basketball"), "mens-basketball"; got != want {
+		t.Errorf("CategoryLinkSlug = %q, want %q", got, want)
+	}
+
+	// Now let Sports absorb the subsection's own category by alias. The
+	// subsection has a page of its own, so the alias must not take the link
+	// away from it -- a chip should reach the most specific page that lists
+	// the article.
+	if _, err := conn.ExecContext(ctx,
+		`UPDATE site_taxonomy SET category_aliases = ? WHERE slug = 'sports'`,
+		`["Men's Basketball","Men's Lacrosse"]`,
+	); err != nil {
+		t.Fatalf("write aliases: %v", err)
+	}
+	if err := RefreshCategoryAliases(ctx, conn); err != nil {
+		t.Fatalf("second refresh: %v", err)
+	}
+
+	if got, want := CategoryLinkSlug("Men's Basketball"), "mens-basketball"; got != want {
+		t.Errorf("an alias must not displace a real page: got %q, want %q", got, want)
+	}
+	// A category with no page of its own does reach the section that absorbed it.
+	if got, want := CategoryLinkSlug("Men's Lacrosse"), "sports"; got != want {
+		t.Errorf("aliased-only category = %q, want %q", got, want)
+	}
 }

--- a/server/internal/database/taxonomy_test.go
+++ b/server/internal/database/taxonomy_test.go
@@ -365,3 +365,59 @@ func TestDefaultSportsAliasesAreNotSubsectionSlugs(t *testing.T) {
 		}
 	}
 }
+
+// withCategorySlugsByTitle installs the title -> slug cache for one test,
+// standing in for what RefreshCategoryAliases loads from site_taxonomy.
+func withCategorySlugsByTitle(t *testing.T, titles map[string]string) {
+	t.Helper()
+	categoryAliasMu.Lock()
+	previous := categorySlugByTitle
+	categorySlugByTitle = titles
+	categoryAliasMu.Unlock()
+	t.Cleanup(func() {
+		categoryAliasMu.Lock()
+		categorySlugByTitle = previous
+		categoryAliasMu.Unlock()
+	})
+}
+
+func TestCategoryLinkSlugUsesTheTaxonomySlug(t *testing.T) {
+	// The bug: the chip's link was derived from the category NAME, so
+	// "Men's Basketball" pointed at /men-s-basketball while the subsection
+	// page is /mens-basketball. All four apostrophe subsections 404'd.
+	withCategorySlugsByTitle(t, map[string]string{
+		"men's basketball": "mens-basketball",
+		"women's soccer":   "womens-soccer",
+	})
+
+	if got := CanonicalizeSlug("Men's Basketball"); got == "mens-basketball" {
+		t.Fatal("precondition: name-derived slug is supposed to differ from the taxonomy slug")
+	}
+	for name, want := range map[string]string{
+		"Men's Basketball": "mens-basketball",
+		"women's soccer":   "womens-soccer",
+	} {
+		if got := CategoryLinkSlug(name); got != want {
+			t.Errorf("CategoryLinkSlug(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestCategoryLinkSlugFallsBackToTheDerivedSlug(t *testing.T) {
+	// A category no section lists still needs a non-empty slug; it just has
+	// nowhere useful to point, exactly as before.
+	withCategorySlugsByTitle(t, map[string]string{})
+	if got, want := CategoryLinkSlug("Some Retired Column"), "some-retired-column"; got != want {
+		t.Errorf("CategoryLinkSlug = %q, want %q", got, want)
+	}
+	if got := CategoryLinkSlug("   "); got != "" {
+		t.Errorf("blank category = %q, want empty", got)
+	}
+}
+
+func TestTaxonomySlugForCategoryReportsNothingWhenUnknown(t *testing.T) {
+	withCategorySlugsByTitle(t, map[string]string{"sports": "sports"})
+	if got := TaxonomySlugForCategory("Men's Lacrosse"); got != "" {
+		t.Errorf("got %q, want empty for a category with no page", got)
+	}
+}

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -400,7 +400,7 @@ func articleListItems(articles []models.Article, excerptWords int) []models.Arti
 			if name == "" {
 				continue
 			}
-			categories = append(categories, models.CategorySummary{Name: name, Slug: db.CanonicalizeSlug(name)})
+			categories = append(categories, models.CategorySummary{Name: name, Slug: db.CategoryLinkSlug(name)})
 		}
 
 		authors := make([]models.AuthorSummary, 0, len(article.Authors))
@@ -1451,7 +1451,7 @@ func GetSearch(conn *sql.DB, embedder QueryEmbedder) http.HandlerFunc {
 				if name == "" {
 					continue
 				}
-				categories = append(categories, models.CategorySummary{Name: name, Slug: db.CanonicalizeSlug(name)})
+				categories = append(categories, models.CategorySummary{Name: name, Slug: db.CategoryLinkSlug(name)})
 			}
 
 			authors := make([]models.AuthorSummary, 0, len(article.Authors))
@@ -1544,7 +1544,7 @@ func GetArticle(conn *sql.DB) http.HandlerFunc {
 			if name == "" {
 				continue
 			}
-			categories = append(categories, models.CategorySummary{Name: name, Slug: db.CanonicalizeSlug(name)})
+			categories = append(categories, models.CategorySummary{Name: name, Slug: db.CategoryLinkSlug(name)})
 		}
 
 		seoTags := make([]models.CategorySummary, 0, len(a.Tags))
@@ -1578,7 +1578,7 @@ func GetArticle(conn *sql.DB) http.HandlerFunc {
 				if name == "" {
 					continue
 				}
-				relatedCategories = append(relatedCategories, models.CategorySummary{Name: name, Slug: db.CanonicalizeSlug(name)})
+				relatedCategories = append(relatedCategories, models.CategorySummary{Name: name, Slug: db.CategoryLinkSlug(name)})
 			}
 
 			relatedAuthors := make([]models.AuthorSummary, 0, len(relatedArticle.Authors))

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -391,7 +392,53 @@ func listParams(r *http.Request, defaultLimit int) (page, limit, offset int) {
 	return page, limit, offset
 }
 
-func articleListItems(articles []models.Article, excerptWords int) []models.ArticleListItem {
+// orderCategoriesForSection moves the categories belonging to the section being
+// rendered to the front, so the first one is the one that explains why this
+// article is in this list.
+//
+// The card shows a single category as its kicker and takes the first. Without
+// this it takes whichever the article happens to list first, which is how the
+// Columns block came to label a column "MEN'S LACROSSE": the article is
+// ["Men's Lacrosse", "From the Playbook", "Sports"], it is in Columns because
+// of From the Playbook, and it announced itself as a sport. Ordering here
+// rather than in the card fixes every surface at once, and it is the only place
+// that knows which section was asked for.
+//
+// A stable partition, so the article's own order still decides between two
+// categories that are both in the section.
+func orderCategoriesForSection(categories []models.CategorySummary, preferSlugs []string) {
+	if len(preferSlugs) == 0 || len(categories) < 2 {
+		return
+	}
+	preferred := make(map[string]struct{}, len(preferSlugs))
+	for _, slug := range preferSlugs {
+		if normalized := strings.ToLower(strings.TrimSpace(slug)); normalized != "" {
+			preferred[normalized] = struct{}{}
+		}
+	}
+	sort.SliceStable(categories, func(i, j int) bool {
+		_, iPreferred := preferred[strings.ToLower(categories[i].Slug)]
+		_, jPreferred := preferred[strings.ToLower(categories[j].Slug)]
+		return iPreferred && !jPreferred
+	})
+}
+
+// categoryPreferenceSlugs is which slugs explain a listing, for ordering each
+// article's categories. A subsection stands on its own: on a subsection page
+// the subsection is the reason the article is there, not the parent section it
+// also carries. Empty when the listing has no section context at all.
+func categoryPreferenceSlugs(params ArticleParams) []string {
+	if params.Subsection != "" {
+		return []string{params.Subsection}
+	}
+	return params.SectionMatchSlugs
+}
+
+// articleListItems converts articles for a listing. preferSlugs is the section
+// and subsections the listing was asked for, empty when there is no section
+// context -- an author page or an unfiltered listing -- where no category is
+// more relevant than another and the article's own order stands.
+func articleListItems(articles []models.Article, excerptWords int, preferSlugs ...string) []models.ArticleListItem {
 	items := make([]models.ArticleListItem, 0, len(articles))
 	for _, article := range articles {
 		categories := make([]models.CategorySummary, 0, len(article.Categories))
@@ -402,6 +449,7 @@ func articleListItems(articles []models.Article, excerptWords int) []models.Arti
 			}
 			categories = append(categories, models.CategorySummary{Name: name, Slug: db.CategoryLinkSlug(name)})
 		}
+		orderCategoriesForSection(categories, preferSlugs)
 
 		authors := make([]models.AuthorSummary, 0, len(article.Authors))
 		for _, author := range article.Authors {
@@ -1004,7 +1052,7 @@ func GetArticles(conn *sql.DB) http.HandlerFunc {
 		}
 
 		writeJSON(w, http.StatusOK, models.ArticlesResponse{
-			Articles:   articleListItems(articles, excerptWords),
+			Articles:   articleListItems(articles, excerptWords, categoryPreferenceSlugs(params)...),
 			Pagination: paginationResponse(page, limit, offset, hasMore, totalCount),
 		})
 	}
@@ -1078,7 +1126,7 @@ func GetSectionArticles(conn *sql.DB) http.HandlerFunc {
 				CanonicalTitle: sectionCanonicalTitle,
 			},
 			Subsections: subsections,
-			Articles:    articleListItems(articles, excerptWords),
+			Articles:    articleListItems(articles, excerptWords, categoryPreferenceSlugs(params)...),
 			Pagination:  paginationResponse(page, limit, offset, hasMore, totalCount),
 		})
 	}
@@ -1157,7 +1205,7 @@ func GetSubsectionArticles(conn *sql.DB) http.HandlerFunc {
 				Name:           subsectionCanonicalTitle,
 				CanonicalTitle: subsectionCanonicalTitle,
 			},
-			Articles:   articleListItems(articles, excerptWords),
+			Articles:   articleListItems(articles, excerptWords, categoryPreferenceSlugs(params)...),
 			Pagination: paginationResponse(page, limit, offset, hasMore, totalCount),
 		})
 	}
@@ -2592,17 +2640,17 @@ func GetHomepage(conn *sql.DB) http.HandlerFunc {
 				}
 				switch section.key {
 				case "news":
-					sectionArticles.News = articleListItems(articles, excerptWords)
+					sectionArticles.News = articleListItems(articles, excerptWords, matchSlugs...)
 				case "opinion":
-					sectionArticles.Opinion = articleListItems(articles, excerptWords)
+					sectionArticles.Opinion = articleListItems(articles, excerptWords, matchSlugs...)
 				case "sports":
-					sectionArticles.Sports = articleListItems(articles, excerptWords)
+					sectionArticles.Sports = articleListItems(articles, excerptWords, matchSlugs...)
 				case "entertainment":
-					sectionArticles.Entertainment = articleListItems(articles, excerptWords)
+					sectionArticles.Entertainment = articleListItems(articles, excerptWords, matchSlugs...)
 				case "candp":
-					sectionArticles.CAndP = articleListItems(articles, excerptWords)
+					sectionArticles.CAndP = articleListItems(articles, excerptWords, matchSlugs...)
 				case "columns":
-					sectionArticles.Columns = articleListItems(articles, excerptWords)
+					sectionArticles.Columns = articleListItems(articles, excerptWords, matchSlugs...)
 				}
 				return nil
 			}(section); err != nil {

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -521,3 +521,90 @@ func TestArticleOrderByClause(t *testing.T) {
 		t.Fatalf("anonymous sort must be unchanged, got %q", got)
 	}
 }
+
+func TestArticleListItems_LeadsWithTheSectionsOwnCategory(t *testing.T) {
+	// The reported bug: the Columns block labelled a column "MEN'S LACROSSE".
+	// The card shows one category and takes the first; this article is in
+	// Columns because of From the Playbook, but announced itself as a sport.
+	article := models.Article{
+		ID:         10075,
+		Title:      "Continuing the momentum with men's lacrosse",
+		Slug:       "continuing-the-momentum-with-mens-lacross",
+		Categories: []string{"Men's Lacrosse", "From the Playbook", "Sports"},
+	}
+
+	items := articleListItems([]models.Article{article}, 50, "columns", "from-the-playbook", "jack-of-all-takes")
+	if len(items) != 1 || len(items[0].Categories) == 0 {
+		t.Fatalf("got %+v, want one item with categories", items)
+	}
+	if got := items[0].Categories[0].Name; got != "From the Playbook" {
+		t.Errorf("Columns kicker = %q, want %q", got, "From the Playbook")
+	}
+
+	// The same mechanism in the Sports block. Field Hockey rather than a
+	// possessive subsection, because a possessive only resolves to its slug
+	// through the taxonomy cache, which a unit test has no way to load.
+	items = articleListItems([]models.Article{{
+		ID:         2,
+		Categories: []string{"From the Playbook", "Field Hockey", "Sports"},
+	}}, 50, "sports", "field-hockey")
+	if got := items[0].Categories[0].Name; got != "Field Hockey" {
+		t.Errorf("Sports kicker = %q, want %q", got, "Field Hockey")
+	}
+}
+
+func TestArticleListItems_KeepsOrderWithoutSectionContext(t *testing.T) {
+	// An author page or an unfiltered listing has no section to be relevant
+	// to, so the article's own order stands rather than being shuffled.
+	items := articleListItems([]models.Article{{
+		ID:         1,
+		Categories: []string{"Men's Lacrosse", "From the Playbook", "Sports"},
+	}}, 50)
+
+	want := []string{"Men's Lacrosse", "From the Playbook", "Sports"}
+	for i, expected := range want {
+		if got := items[0].Categories[i].Name; got != expected {
+			t.Errorf("category %d = %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestOrderCategoriesForSectionIsStable(t *testing.T) {
+	// Two categories both in the section keep the article's own order between
+	// them, so the kicker does not change for unrelated reasons.
+	categories := []models.CategorySummary{
+		{Name: "Sports", Slug: "sports"},
+		{Name: "Men's Basketball", Slug: "mens-basketball"},
+		{Name: "Big 5", Slug: "big-5"},
+	}
+	orderCategoriesForSection(categories, []string{"sports", "mens-basketball", "big-5"})
+
+	for i, want := range []string{"Sports", "Men's Basketball", "Big 5"} {
+		if got := categories[i].Name; got != want {
+			t.Errorf("category %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestCategoryPreferenceSlugsPrefersTheSubsection(t *testing.T) {
+	got := categoryPreferenceSlugs(ArticleParams{
+		Section:           "sports",
+		SectionMatchSlugs: []string{"sports", "mens-basketball"},
+		Subsection:        "mens-basketball",
+	})
+	if len(got) != 1 || got[0] != "mens-basketball" {
+		t.Errorf("got %v, want just the subsection", got)
+	}
+
+	got = categoryPreferenceSlugs(ArticleParams{
+		Section:           "sports",
+		SectionMatchSlugs: []string{"sports", "mens-basketball"},
+	})
+	if len(got) != 2 {
+		t.Errorf("got %v, want the section and its children", got)
+	}
+
+	if got = categoryPreferenceSlugs(ArticleParams{AuthorSlug: "janine-gin"}); len(got) != 0 {
+		t.Errorf("got %v, want nothing for a listing with no section", got)
+	}
+}


### PR DESCRIPTION
Two defects behind Janine's screenshot of a men's lacrosse article showing under Columns. The second is what she reported; the first I found alongside it and is live right now.

## 1. Chips link to pages that don't exist

The chip is a link, and its target was derived from the category **name** alone via `CanonicalizeSlug`, independent of `site_taxonomy`:

```
/mens-basketball    200   ← the real subsection page
/men-s-basketball   404   ← what the chip linked to
```

**Both basketballs and both soccers — the four apostrophe subsections — have had dead chips this whole time.** Same apostrophe `possessiveVariant` already absorbs on the matching side; the link never got the same treatment. Nobody reported it because a chip is a small target and the article underneath works.

Now resolved through `site_taxonomy`, falling back to the derived slug so the value is never empty. A category that only reaches a section by alias — men's lacrosse after #199 — links to that section instead of nowhere.

Two things to review:

- `RefreshCategoryAliases` loads every section and subsection now, not just rows with aliases, because a row with no alias still has to resolve. That's most of them.
- **A row's own title outranks any alias.** Otherwise #199's `"Men's Basketball"` alias on `sports` would have sent the basketball chip to `/sports` instead of its own page. A chip should reach the most specific page listing the article.

Tags are deliberately untouched: no taxonomy rows, so derived slugs are all they have.

## 2. The card shows the wrong category

The card takes `categories[0]`. That article is `["Men's Lacrosse", "From the Playbook", "Sports"]` — it's in Columns because of From the Playbook, but it announced itself as a sport.

Ordered in the handler rather than taught to the card: the handler is the only place that knows which section was asked for, so doing it there fixes **every surface at once** — homepage blocks, section pages, subsection pages, filtered listings — with no component changes.

The two fixes are coupled, which is why they're one PR: matching a category against the section's slugs only works once the category carries the slug the section knows it by. Fix 1 is what makes fix 2 possible.

Rules:

- **A subsection stands on its own** — on a subsection page the subsection is the reason the article is there, not the parent it also carries.
- **No section context, no reordering** — author pages and unfiltered feeds keep the article's own order, since no category is more relevant there. Single articles untouched for the same reason.
- **Stable partition** — two categories both in the section keep the article's order between them, so the kicker doesn't move for unrelated reasons.

## Testing

`go build`, `go vet`, full suite green. The database integration tests were **run against a real MariaDB 11.7** rather than left to skip on a missing `CMS_TEST_DSN`, including the new alias-vs-own-page precedence case.

One thing the unit tests can't cover: a possessive category only resolves to its slug through the taxonomy cache, which lives in the database package and can't be loaded from a handlers test. The ordering tests use Field Hockey instead, and the comment says why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)