### PR TITLE
Offer and search the tags the desk already uses

### DIFF
--- a/frontend/src/pages/editArticleView.test.tsx
+++ b/frontend/src/pages/editArticleView.test.tsx
@@ -20,9 +20,11 @@ let articlePublishedDate: string | undefined
 // Slugs belonging to other articles, so a GET for them answers 200 the way the
 // API would rather than the 404 that means "free".
 let takenSlugs: Set<string>
-// SEO tags the article already carries, and what /v1/tags/popular offers.
+// SEO tags the article already carries, what /v1/tags offers unfiltered, and
+// what a search over the archive can turn up.
 let articleTags: string[]
 let popularTagsPayload: Array<{ name: string; uses: number }>
+let archiveTagsPayload: Array<{ name: string; uses: number }>
 
 const jsonResponse = (payload: unknown, status = 200) =>
   new Response(JSON.stringify(payload), {
@@ -66,8 +68,14 @@ const apiFetchStub = vi.fn(async (url: string, init?: RequestInit): Promise<Resp
       seo: { tags: articleTags.map((name) => ({ name, slug: name })) },
     })
   }
-  if (url.startsWith("/v1/tags/popular")) {
-    return jsonResponse(popularTagsPayload)
+  if (url.startsWith("/v1/tags")) {
+    const query = new URL(url, "http://cms.test").searchParams.get("q")?.trim().toLowerCase() ?? ""
+    if (!query) {
+      return jsonResponse(popularTagsPayload)
+    }
+    // Stands in for the server's search over the whole archive: the archive
+    // holds tags the popular list does not.
+    return jsonResponse(archiveTagsPayload.filter((tag) => tag.name.toLowerCase().includes(query)))
   }
   if (method === "GET" && url.startsWith("/v1/articles/")) {
     const candidate = decodeURIComponent(url.slice("/v1/articles/".length))
@@ -125,6 +133,7 @@ describe("EditArticleView autosave", () => {
     takenSlugs = new Set()
     articleTags = []
     popularTagsPayload = []
+    archiveTagsPayload = []
     apiFetchStub.mockClear()
     // shouldAdvanceTime keeps Testing Library's own waitFor polling alive while
     // the autosave debounce stays under our control.
@@ -274,6 +283,10 @@ describe("EditArticleView SEO tag suggestions", () => {
       { name: "drexel triangle", uses: 400 },
       { name: "civil rights", uses: 20 },
     ]
+    // The archive is everything, popular or not. "Men's Lacrosse" is the case
+    // that matters: nobody retypes that spelling correctly, and it is nowhere
+    // near the popular list.
+    archiveTagsPayload = [...popularTagsPayload, { name: "Men's Lacrosse", uses: 46 }]
     apiFetchStub.mockClear()
     vi.useFakeTimers({ shouldAdvanceTime: true })
   })
@@ -329,5 +342,52 @@ describe("EditArticleView SEO tag suggestions", () => {
 
     expect(screen.queryByRole("button", { name: "Remove tag drex" })).not.toBeInTheDocument()
     expect(patchCalls()[0].body?.tags).toEqual(["drexel"])
+  })
+  // The reason the search exists: the tag is in the archive, but it is not
+  // popular enough to be offered, and retyping "Men's Lacrosse" from memory is
+  // how a near-duplicate of it gets coined.
+  it("finds a tag that is in the archive but not in the popular list", async () => {
+    const user = await renderEditor()
+    await waitFor(() => expect(suggestion("triangle")).toBeInTheDocument())
+
+    await user.type(screen.getByPlaceholderText(/Type a tag, press Enter/), "lacrosse")
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    await waitFor(() => expect(suggestion("Men's Lacrosse")).toBeInTheDocument())
+    await user.click(suggestion("Men's Lacrosse"))
+    await waitOutAutosave()
+
+    expect(patchCalls()[0].body?.tags).toEqual(["Men's Lacrosse"])
+  })
+
+  // Typing a whole word must not be a request per keystroke.
+  it("searches once for a word typed in one go", async () => {
+    const user = await renderEditor()
+    await waitFor(() => expect(suggestion("triangle")).toBeInTheDocument())
+
+    await user.type(screen.getByPlaceholderText(/Type a tag, press Enter/), "lacrosse")
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    const searches = apiCalls.filter((call) => call.url.includes("q="))
+    expect(searches).toHaveLength(1)
+    expect(searches[0].url).toContain("q=lacrosse")
+  })
+
+  // A tag nobody has used is still a tag worth adding -- but the editor should
+  // be told that is what they are doing.
+  it("says so when nothing in the archive matches", async () => {
+    const user = await renderEditor()
+    await waitFor(() => expect(suggestion("triangle")).toBeInTheDocument())
+
+    await user.type(screen.getByPlaceholderText(/Type a tag, press Enter/), "quidditch")
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(screen.getByText(/No existing tag matches/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/editArticleView.test.tsx
+++ b/frontend/src/pages/editArticleView.test.tsx
@@ -20,6 +20,9 @@ let articlePublishedDate: string | undefined
 // Slugs belonging to other articles, so a GET for them answers 200 the way the
 // API would rather than the 404 that means "free".
 let takenSlugs: Set<string>
+// SEO tags the article already carries, and what /v1/tags/popular offers.
+let articleTags: string[]
+let popularTagsPayload: Array<{ name: string; uses: number }>
 
 const jsonResponse = (payload: unknown, status = 200) =>
   new Response(JSON.stringify(payload), {
@@ -60,7 +63,11 @@ const apiFetchStub = vi.fn(async (url: string, init?: RequestInit): Promise<Resp
       featured_image_alt: "",
       categories: [{ name: "News", slug: "news" }],
       authors: [{ id: 7, name: "Reporter" }],
+      seo: { tags: articleTags.map((name) => ({ name, slug: name })) },
     })
+  }
+  if (url.startsWith("/v1/tags/popular")) {
+    return jsonResponse(popularTagsPayload)
   }
   if (method === "GET" && url.startsWith("/v1/articles/")) {
     const candidate = decodeURIComponent(url.slice("/v1/articles/".length))
@@ -116,6 +123,8 @@ describe("EditArticleView autosave", () => {
     articleStatus = "draft"
     articlePublishedDate = undefined
     takenSlugs = new Set()
+    articleTags = []
+    popularTagsPayload = []
     apiFetchStub.mockClear()
     // shouldAdvanceTime keeps Testing Library's own waitFor polling alive while
     // the autosave debounce stays under our control.
@@ -246,5 +255,79 @@ describe("EditArticleView autosave", () => {
     // Once the transition is on file, later autosaves stop warning about it.
     await waitOutAutosave()
     expect(screen.queryByText(/Publish timing is not autosaved/)).not.toBeInTheDocument()
+  })
+})
+
+// The tag box used to be a bare text field, so the boilerplate tags a desk adds
+// to nearly every article were retyped by hand each time. These pin the
+// shortcut that replaced that.
+describe("EditArticleView SEO tag suggestions", () => {
+  beforeEach(() => {
+    apiCalls = []
+    articleStatus = "draft"
+    articlePublishedDate = undefined
+    takenSlugs = new Set()
+    articleTags = []
+    popularTagsPayload = [
+      { name: "triangle", uses: 900 },
+      { name: "drexel", uses: 800 },
+      { name: "drexel triangle", uses: 400 },
+      { name: "civil rights", uses: 20 },
+    ]
+    apiFetchStub.mockClear()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const suggestion = (name: string) => screen.getByRole("button", { name: `Add tag ${name}` })
+
+  it("adds a frequently-used tag when its suggestion is clicked", async () => {
+    const user = await renderEditor()
+    await waitFor(() => expect(suggestion("triangle")).toBeInTheDocument())
+
+    await user.click(suggestion("triangle"))
+    await waitOutAutosave()
+
+    expect(screen.getByRole("button", { name: "Remove tag triangle" })).toBeInTheDocument()
+    expect(patchCalls()[0].body?.tags).toEqual(["triangle"])
+  })
+
+  // A suggestion for a tag the article already carries is a dead control, and
+  // clicking it would look broken -- the add is a no-op against the dedupe.
+  it("does not suggest a tag the article already carries", async () => {
+    articleTags = ["triangle"]
+    await renderEditor()
+    await waitFor(() => expect(suggestion("drexel")).toBeInTheDocument())
+
+    expect(screen.queryByRole("button", { name: "Add tag triangle" })).not.toBeInTheDocument()
+  })
+
+  it("narrows the suggestions to what the editor has typed", async () => {
+    const user = await renderEditor()
+    await waitFor(() => expect(suggestion("civil rights")).toBeInTheDocument())
+
+    await user.type(screen.getByPlaceholderText(/Type a tag, press Enter/), "drex")
+
+    expect(suggestion("drexel")).toBeInTheDocument()
+    expect(suggestion("drexel triangle")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Add tag civil rights" })).not.toBeInTheDocument()
+  })
+
+  // Clicking a suggestion blurs the tag input, and blur commits whatever is in
+  // it. Finishing a half-typed word by clicking must not leave the fragment
+  // behind as a second tag.
+  it("does not also commit the half-typed draft when a suggestion is clicked", async () => {
+    const user = await renderEditor()
+    await waitFor(() => expect(suggestion("drexel")).toBeInTheDocument())
+
+    await user.type(screen.getByPlaceholderText(/Type a tag, press Enter/), "drex")
+    await user.click(suggestion("drexel"))
+    await waitOutAutosave()
+
+    expect(screen.queryByRole("button", { name: "Remove tag drex" })).not.toBeInTheDocument()
+    expect(patchCalls()[0].body?.tags).toEqual(["drexel"])
   })
 })

--- a/frontend/src/pages/editArticleView.tsx
+++ b/frontend/src/pages/editArticleView.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { KeyboardEvent } from "react"
-import { ArrowLeft, Save, Image, Search, X, Copy, Check, RefreshCw } from "lucide-react"
+import { ArrowLeft, Save, Image, Search, X, Copy, Check, RefreshCw, Plus } from "lucide-react"
 import { useNavigate, useParams } from "react-router-dom"
 import { useApiFetch } from "../hooks/useApiFetch"
 import { articleUrl } from "../auth/urls"
@@ -75,6 +75,13 @@ type PatchPayload = {
   noindex: boolean
 }
 
+// A tag the archive already uses, with how many articles carry it. Aggregated
+// server-side from the articles themselves; there is no tags table.
+type PopularTag = {
+  name: string
+  uses: number
+}
+
 type ApiAuthor = {
   id: number
   display_name: string
@@ -140,6 +147,33 @@ const parseSEOTags = (value: string): string[] => {
       seen.add(key)
       return true
     })
+}
+
+// How many suggestions sit under the tag box. The list is a shortcut for the
+// handful of tags a desk adds to nearly every article, so a longer row would
+// cost more to read than typing the tag.
+const SEO_TAG_SUGGESTION_LIMIT = 8
+
+// The suggestions worth showing: tags not already on the article, narrowed to
+// what the editor has started typing. Popularity order is preserved rather than
+// re-ranked by how well the text matches, so the row a person learns the
+// position of does not reshuffle under them as they type.
+const filterTagSuggestions = (
+  popular: PopularTag[],
+  selected: string[],
+  draft: string,
+): string[] => {
+  const taken = new Set(selected.map((tag) => tag.toLowerCase()))
+  const query = draft.trim().toLowerCase()
+  const matches: string[] = []
+  for (const tag of popular) {
+    const name = tag.name.toLowerCase()
+    if (taken.has(name)) continue
+    if (query && !name.includes(query)) continue
+    matches.push(tag.name)
+    if (matches.length === SEO_TAG_SUGGESTION_LIMIT) break
+  }
+  return matches
 }
 
 // Appends whatever tags are in `raw` (Enter commits one, a pasted list commits
@@ -278,6 +312,10 @@ function EditArticleView() {
   // Text sitting in the tag box that has not been committed to a chip yet. It is
   // still saved, so a half-typed tag is not silently dropped by an autosave.
   const [seoTagDraft, setSeoTagDraft] = useState("")
+  // Tag suggestions. A failed fetch leaves this empty and shows nothing: the
+  // suggestions are a shortcut, and an error message next to a working text box
+  // would be noise.
+  const [popularTags, setPopularTags] = useState<PopularTag[]>([])
   const [imagePickerOpen, setImagePickerOpen] = useState(false)
   const [linkCopied, setLinkCopied] = useState(false)
   // Byline order is selection order: the list is sent as-is and rendered in that
@@ -577,6 +615,36 @@ function EditArticleView() {
     }
   }, [apiFetch])
 
+  // Tags the desk already uses, for the suggestions under the tag box. Fetched
+  // once per editor session: the server caches the ranking for minutes anyway,
+  // so re-fetching per keystroke would buy nothing.
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchPopularTags = async () => {
+      try {
+        const response = await apiFetch("/v1/tags/popular")
+        if (!response.ok) {
+          throw new Error(`Popular tags request failed (${response.status})`)
+        }
+        const payload = (await response.json()) as PopularTag[]
+        if (!cancelled) {
+          setPopularTags(Array.isArray(payload) ? payload : [])
+        }
+      } catch {
+        // Silent by design -- see the popularTags declaration.
+        if (!cancelled) {
+          setPopularTags([])
+        }
+      }
+    }
+
+    void fetchPopularTags()
+    return () => {
+      cancelled = true
+    }
+  }, [apiFetch])
+
   const saveArticle = async (nextTiming?: PublishTiming, options: { autosave?: boolean } = {}) => {
     const autosave = options.autosave === true
     const snapshotToSave = currentSnapshotRef.current
@@ -798,6 +866,19 @@ function EditArticleView() {
       return
     }
     setSeoTags((current) => addSEOTags(current, seoTagDraft))
+    setSeoTagDraft("")
+  }
+
+  const tagSuggestions = useMemo(
+    () => filterTagSuggestions(popularTags, seoTags, seoTagDraft),
+    [popularTags, seoTags, seoTagDraft],
+  )
+
+  // Clicking a suggestion also clears the draft: the click is the editor
+  // finishing the word they had started, so leaving "dre" in the box would
+  // commit it as a second tag at the next blur.
+  const addSuggestedSeoTag = (tag: string) => {
+    setSeoTags((current) => addSEOTags(current, tag))
     setSeoTagDraft("")
   }
 
@@ -1513,6 +1594,30 @@ function EditArticleView() {
                   value={seoTagDraft}
                 />
               </div>
+              {tagSuggestions.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1.5 pt-1.5">
+                  <span className="text-[11px] text-muted-foreground">
+                    {seoTagDraft.trim() ? "Matching tags" : "Frequently used"}
+                  </span>
+                  {tagSuggestions.map((tag) => (
+                    <button
+                      aria-label={`Add tag ${tag}`}
+                      className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full border border-dashed border-border text-xs font-medium text-muted-foreground hover:text-foreground hover:border-primary hover:bg-muted transition-colors cursor-pointer"
+                      key={tag.toLowerCase()}
+                      // Keep the caret in the tag box: without this the input's
+                      // blur fires first and commits the half-typed draft, so
+                      // clicking "drexel" after typing "dre" would add both.
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => addSuggestedSeoTag(tag)}
+                      title={`Add the tag "${tag}"`}
+                      type="button"
+                    >
+                      <Plus className="h-3 w-3" />
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
             </label>
 
             <label className={labelClass}>

--- a/frontend/src/pages/editArticleView.tsx
+++ b/frontend/src/pages/editArticleView.tsx
@@ -154,19 +154,28 @@ const parseSEOTags = (value: string): string[] => {
 // cost more to read than typing the tag.
 const SEO_TAG_SUGGESTION_LIMIT = 8
 
-// The suggestions worth showing: tags not already on the article, narrowed to
-// what the editor has started typing. Popularity order is preserved rather than
-// re-ranked by how well the text matches, so the row a person learns the
-// position of does not reshuffle under them as they type.
+// How long the tag box sits still before its contents are searched. Long enough
+// that typing a whole word is one request rather than six; short enough that the
+// results arrive while the editor is still looking at the box.
+const TAG_SEARCH_DEBOUNCE_MS = 200
+
+// The suggestions worth showing, out of whichever set the caller passes -- the
+// popular tags when the box is empty, the search results once it is not.
+//
+// The text filter is applied here as well as on the server, and that is the
+// point: it narrows the tags already on screen on the keystroke, without waiting
+// for the request, and it drops results belonging to an earlier query. The
+// server's ordering is preserved rather than re-ranked, so the row does not
+// reshuffle under a person reaching for it.
 const filterTagSuggestions = (
-  popular: PopularTag[],
+  candidates: PopularTag[],
   selected: string[],
   draft: string,
 ): string[] => {
   const taken = new Set(selected.map((tag) => tag.toLowerCase()))
   const query = draft.trim().toLowerCase()
   const matches: string[] = []
-  for (const tag of popular) {
+  for (const tag of candidates) {
     const name = tag.name.toLowerCase()
     if (taken.has(name)) continue
     if (query && !name.includes(query)) continue
@@ -316,6 +325,10 @@ function EditArticleView() {
   // suggestions are a shortcut, and an error message next to a working text box
   // would be noise.
   const [popularTags, setPopularTags] = useState<PopularTag[]>([])
+  // Matches for what is currently in the tag box, searched over every tag the
+  // archive has rather than only the popular ones -- a beat tag from 2019 is
+  // exactly what nobody remembers the spelling of.
+  const [tagSearchResults, setTagSearchResults] = useState<PopularTag[]>([])
   const [imagePickerOpen, setImagePickerOpen] = useState(false)
   const [linkCopied, setLinkCopied] = useState(false)
   // Byline order is selection order: the list is sent as-is and rendered in that
@@ -623,7 +636,7 @@ function EditArticleView() {
 
     const fetchPopularTags = async () => {
       try {
-        const response = await apiFetch("/v1/tags/popular")
+        const response = await apiFetch("/v1/tags")
         if (!response.ok) {
           throw new Error(`Popular tags request failed (${response.status})`)
         }
@@ -644,6 +657,48 @@ function EditArticleView() {
       cancelled = true
     }
   }, [apiFetch])
+
+  // Search the archive for whatever is in the tag box. Debounced, and dropped
+  // if the box has moved on by the time the answer arrives: responses can land
+  // out of order, and stale matches for a prefix the editor has already typed
+  // past are worse than none.
+  useEffect(() => {
+    const query = seoTagDraft.trim()
+    if (!query) {
+      setTagSearchResults([])
+      return
+    }
+
+    let cancelled = false
+    const timer = setTimeout(() => {
+      const search = async () => {
+        try {
+          const response = await apiFetch(
+            `/v1/tags?limit=${SEO_TAG_SUGGESTION_LIMIT}&q=${encodeURIComponent(query)}`,
+          )
+          if (!response.ok) {
+            throw new Error(`Tag search failed (${response.status})`)
+          }
+          const payload = (await response.json()) as PopularTag[]
+          if (!cancelled) {
+            setTagSearchResults(Array.isArray(payload) ? payload : [])
+          }
+        } catch {
+          // Silent by design -- the popular tags and the text box both still
+          // work, so an error banner would be noise.
+          if (!cancelled) {
+            setTagSearchResults([])
+          }
+        }
+      }
+      void search()
+    }, TAG_SEARCH_DEBOUNCE_MS)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [apiFetch, seoTagDraft])
 
   const saveArticle = async (nextTiming?: PublishTiming, options: { autosave?: boolean } = {}) => {
     const autosave = options.autosave === true
@@ -869,10 +924,18 @@ function EditArticleView() {
     setSeoTagDraft("")
   }
 
-  const tagSuggestions = useMemo(
-    () => filterTagSuggestions(popularTags, seoTags, seoTagDraft),
-    [popularTags, seoTags, seoTagDraft],
-  )
+  // Search results lead, because they are ranked by how well they match and
+  // they cover the whole archive. The popular tags follow as the instant
+  // fallback: they are already in memory, so the row narrows on the keystroke
+  // instead of sitting empty until the search comes back.
+  const tagSuggestions = useMemo(() => {
+    const candidates = seoTagDraft.trim()
+      ? [...tagSearchResults, ...popularTags.filter(
+          (tag) => !tagSearchResults.some((match) => match.name.toLowerCase() === tag.name.toLowerCase()),
+        )]
+      : popularTags
+    return filterTagSuggestions(candidates, seoTags, seoTagDraft)
+  }, [popularTags, tagSearchResults, seoTags, seoTagDraft])
 
   // Clicking a suggestion also clears the draft: the click is the editor
   // finishing the word they had started, so leaving "dre" in the box would
@@ -1594,6 +1657,15 @@ function EditArticleView() {
                   value={seoTagDraft}
                 />
               </div>
+              {tagSuggestions.length === 0 && seoTagDraft.trim() ? (
+                // Worth saying out loud: nothing in the archive matches, so
+                // this tag is a new one. That is allowed, but an editor who
+                // meant to reuse an existing tag wants to know now, not after
+                // they have coined a near-duplicate of it.
+                <p className="pt-1.5 text-[11px] text-muted-foreground">
+                  No existing tag matches. Press Enter to create it.
+                </p>
+              ) : null}
               {tagSuggestions.length > 0 ? (
                 <div className="flex flex-wrap items-center gap-1.5 pt-1.5">
                   <span className="text-[11px] text-muted-foreground">

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -3755,6 +3755,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/tags/popular": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "List the most-used SEO tags",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "How many tags to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/database.PopularTag"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/taxonomy": {
             "get": {
                 "produces": [
@@ -4207,6 +4254,17 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "database.PopularTag": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "uses": {
+                    "type": "integer"
+                }
+            }
+        },
         "handlers.articleEditLockResponse": {
             "type": "object",
             "properties": {
@@ -4355,6 +4413,9 @@ const docTemplate = `{
                 "breaking_news": {
                     "type": "boolean"
                 },
+                "canonical_url": {
+                    "type": "string"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4383,6 +4444,16 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "meta_description": {
+                    "type": "string"
+                },
+                "modified_date": {
+                    "type": "string"
+                },
+                "noindex": {
+                    "type": "boolean"
+                },
+                "photo_alt": {
+                    "description": "PhotoAlt describes the featured image for screen readers. It is\narticle-scoped rather than a lookup into the media library: the same photo\ncan want a different description in a different story, and a featured image\nset by URL has no library record to read one from.",
                     "type": "string"
                 },
                 "photo_url": {
@@ -4455,11 +4526,19 @@ const docTemplate = `{
                 "featured_image": {
                     "type": "string"
                 },
+                "featured_image_alt": {
+                    "description": "FeaturedImageAlt is the article's own description of its featured image.\nEmpty means the public site has nothing to render, which is a defect worth\nsurfacing rather than papering over with the headline: an alt that repeats\nthe adjacent headline tells a screen-reader user nothing new.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "integer"
                 },
                 "is_featured": {
                     "type": "boolean"
+                },
+                "modified_date": {
+                    "description": "ModifiedDate is the article's last-edited time (the ` + "`" + `mod_date` + "`" + ` column the\npublic sitemap already reports as \u003clastmod\u003e). Exposed so the public site's\nNewsArticle dateModified agrees with the sitemap instead of silently\nfalling back to the publish date.",
+                    "type": "string"
                 },
                 "published_date": {
                     "type": "string"
@@ -4496,6 +4575,9 @@ const docTemplate = `{
                 "breaking_news": {
                     "type": "boolean"
                 },
+                "canonical_url": {
+                    "type": "string"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4518,6 +4600,12 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "meta_description": {
+                    "type": "string"
+                },
+                "noindex": {
+                    "type": "boolean"
+                },
+                "photo_alt": {
                     "type": "string"
                 },
                 "photo_url": {
@@ -4609,6 +4697,9 @@ const docTemplate = `{
                 "breaking_news": {
                     "type": "boolean"
                 },
+                "canonical_url": {
+                    "type": "string"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4631,6 +4722,12 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "meta_description": {
+                    "type": "string"
+                },
+                "noindex": {
+                    "type": "boolean"
+                },
+                "photo_alt": {
                     "type": "string"
                 },
                 "photo_url": {
@@ -5712,6 +5809,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "canonical_url": {
+                    "description": "CanonicalURL is the editor-supplied override for syndicated or reprinted\npieces that should credit another publisher. Empty means \"no override\":\nthe public site falls back to its own /article/\u003cslug\u003e URL.",
                     "type": "string"
                 },
                 "focus_keyword": {
@@ -5719,6 +5817,10 @@ const docTemplate = `{
                 },
                 "meta_description": {
                     "type": "string"
+                },
+                "noindex": {
+                    "description": "NoIndex asks the public site to emit robots noindex for this article.",
+                    "type": "boolean"
                 },
                 "seo_title": {
                     "type": "string"

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -3755,7 +3755,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/v1/tags/popular": {
+        "/v1/tags": {
             "get": {
                 "security": [
                     {
@@ -3768,8 +3768,14 @@ const docTemplate = `{
                 "tags": [
                     "articles"
                 ],
-                "summary": "List the most-used SEO tags",
+                "summary": "List or search the SEO tags already in use",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search text; omit for the most-used tags",
+                        "name": "q",
+                        "in": "query"
+                    },
                     {
                         "type": "integer",
                         "description": "How many tags to return (default 50, max 200)",

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -3752,7 +3752,7 @@
                 }
             }
         },
-        "/v1/tags/popular": {
+        "/v1/tags": {
             "get": {
                 "security": [
                     {
@@ -3765,8 +3765,14 @@
                 "tags": [
                     "articles"
                 ],
-                "summary": "List the most-used SEO tags",
+                "summary": "List or search the SEO tags already in use",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search text; omit for the most-used tags",
+                        "name": "q",
+                        "in": "query"
+                    },
                     {
                         "type": "integer",
                         "description": "How many tags to return (default 50, max 200)",

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -3752,6 +3752,53 @@
                 }
             }
         },
+        "/v1/tags/popular": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "List the most-used SEO tags",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "How many tags to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/database.PopularTag"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/taxonomy": {
             "get": {
                 "produces": [
@@ -4204,6 +4251,17 @@
         }
     },
     "definitions": {
+        "database.PopularTag": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "uses": {
+                    "type": "integer"
+                }
+            }
+        },
         "handlers.articleEditLockResponse": {
             "type": "object",
             "properties": {
@@ -4352,6 +4410,9 @@
                 "breaking_news": {
                     "type": "boolean"
                 },
+                "canonical_url": {
+                    "type": "string"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4380,6 +4441,16 @@
                     "type": "boolean"
                 },
                 "meta_description": {
+                    "type": "string"
+                },
+                "modified_date": {
+                    "type": "string"
+                },
+                "noindex": {
+                    "type": "boolean"
+                },
+                "photo_alt": {
+                    "description": "PhotoAlt describes the featured image for screen readers. It is\narticle-scoped rather than a lookup into the media library: the same photo\ncan want a different description in a different story, and a featured image\nset by URL has no library record to read one from.",
                     "type": "string"
                 },
                 "photo_url": {
@@ -4452,11 +4523,19 @@
                 "featured_image": {
                     "type": "string"
                 },
+                "featured_image_alt": {
+                    "description": "FeaturedImageAlt is the article's own description of its featured image.\nEmpty means the public site has nothing to render, which is a defect worth\nsurfacing rather than papering over with the headline: an alt that repeats\nthe adjacent headline tells a screen-reader user nothing new.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "integer"
                 },
                 "is_featured": {
                     "type": "boolean"
+                },
+                "modified_date": {
+                    "description": "ModifiedDate is the article's last-edited time (the `mod_date` column the\npublic sitemap already reports as \u003clastmod\u003e). Exposed so the public site's\nNewsArticle dateModified agrees with the sitemap instead of silently\nfalling back to the publish date.",
+                    "type": "string"
                 },
                 "published_date": {
                     "type": "string"
@@ -4493,6 +4572,9 @@
                 "breaking_news": {
                     "type": "boolean"
                 },
+                "canonical_url": {
+                    "type": "string"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4515,6 +4597,12 @@
                     "type": "boolean"
                 },
                 "meta_description": {
+                    "type": "string"
+                },
+                "noindex": {
+                    "type": "boolean"
+                },
+                "photo_alt": {
                     "type": "string"
                 },
                 "photo_url": {
@@ -4606,6 +4694,9 @@
                 "breaking_news": {
                     "type": "boolean"
                 },
+                "canonical_url": {
+                    "type": "string"
+                },
                 "categories": {
                     "type": "array",
                     "items": {
@@ -4628,6 +4719,12 @@
                     "type": "boolean"
                 },
                 "meta_description": {
+                    "type": "string"
+                },
+                "noindex": {
+                    "type": "boolean"
+                },
+                "photo_alt": {
                     "type": "string"
                 },
                 "photo_url": {
@@ -5709,6 +5806,7 @@
             "type": "object",
             "properties": {
                 "canonical_url": {
+                    "description": "CanonicalURL is the editor-supplied override for syndicated or reprinted\npieces that should credit another publisher. Empty means \"no override\":\nthe public site falls back to its own /article/\u003cslug\u003e URL.",
                     "type": "string"
                 },
                 "focus_keyword": {
@@ -5716,6 +5814,10 @@
                 },
                 "meta_description": {
                     "type": "string"
+                },
+                "noindex": {
+                    "description": "NoIndex asks the public site to emit robots noindex for this article.",
+                    "type": "boolean"
                 },
                 "seo_title": {
                     "type": "string"

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -3616,9 +3616,13 @@ paths:
       summary: List articles by subsection
       tags:
       - articles
-  /v1/tags/popular:
+  /v1/tags:
     get:
       parameters:
+      - description: Search text; omit for the most-used tags
+        in: query
+        name: q
+        type: string
       - description: How many tags to return (default 50, max 200)
         in: query
         name: limit
@@ -3642,7 +3646,7 @@ paths:
             $ref: '#/definitions/models.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: List the most-used SEO tags
+      summary: List or search the SEO tags already in use
       tags:
       - articles
   /v1/taxonomy:

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -1,5 +1,12 @@
 basePath: /
 definitions:
+  database.PopularTag:
+    properties:
+      name:
+        type: string
+      uses:
+        type: integer
+    type: object
   handlers.articleEditLockResponse:
     properties:
       expires_at:
@@ -97,6 +104,8 @@ definitions:
         type: array
       breaking_news:
         type: boolean
+      canonical_url:
+        type: string
       categories:
         items:
           type: string
@@ -116,6 +125,17 @@ definitions:
       is_featured:
         type: boolean
       meta_description:
+        type: string
+      modified_date:
+        type: string
+      noindex:
+        type: boolean
+      photo_alt:
+        description: |-
+          PhotoAlt describes the featured image for screen readers. It is
+          article-scoped rather than a lookup into the media library: the same photo
+          can want a different description in a different story, and a featured image
+          set by URL has no library record to read one from.
         type: string
       photo_url:
         type: string
@@ -163,10 +183,24 @@ definitions:
         type: string
       featured_image:
         type: string
+      featured_image_alt:
+        description: |-
+          FeaturedImageAlt is the article's own description of its featured image.
+          Empty means the public site has nothing to render, which is a defect worth
+          surfacing rather than papering over with the headline: an alt that repeats
+          the adjacent headline tells a screen-reader user nothing new.
+        type: string
       id:
         type: integer
       is_featured:
         type: boolean
+      modified_date:
+        description: |-
+          ModifiedDate is the article's last-edited time (the `mod_date` column the
+          public sitemap already reports as <lastmod>). Exposed so the public site's
+          NewsArticle dateModified agrees with the sitemap instead of silently
+          falling back to the publish date.
+        type: string
       published_date:
         type: string
       related:
@@ -190,6 +224,8 @@ definitions:
         type: array
       breaking_news:
         type: boolean
+      canonical_url:
+        type: string
       categories:
         items:
           type: string
@@ -205,6 +241,10 @@ definitions:
       is_featured:
         type: boolean
       meta_description:
+        type: string
+      noindex:
+        type: boolean
+      photo_alt:
         type: string
       photo_url:
         type: string
@@ -267,6 +307,8 @@ definitions:
         type: array
       breaking_news:
         type: boolean
+      canonical_url:
+        type: string
       categories:
         items:
           type: string
@@ -282,6 +324,10 @@ definitions:
       is_featured:
         type: boolean
       meta_description:
+        type: string
+      noindex:
+        type: boolean
+      photo_alt:
         type: string
       photo_url:
         type: string
@@ -988,11 +1034,19 @@ definitions:
   models.SEOResponse:
     properties:
       canonical_url:
+        description: |-
+          CanonicalURL is the editor-supplied override for syndicated or reprinted
+          pieces that should credit another publisher. Empty means "no override":
+          the public site falls back to its own /article/<slug> URL.
         type: string
       focus_keyword:
         type: string
       meta_description:
         type: string
+      noindex:
+        description: NoIndex asks the public site to emit robots noindex for this
+          article.
+        type: boolean
       seo_title:
         type: string
       tags:
@@ -3560,6 +3614,35 @@ paths:
           schema:
             $ref: '#/definitions/models.ErrorResponse'
       summary: List articles by subsection
+      tags:
+      - articles
+  /v1/tags/popular:
+    get:
+      parameters:
+      - description: How many tags to return (default 50, max 200)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/database.PopularTag'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: List the most-used SEO tags
       tags:
       - articles
   /v1/taxonomy:

--- a/server/internal/database/tags.go
+++ b/server/internal/database/tags.go
@@ -15,32 +15,35 @@ type PopularTag struct {
 	Uses int64  `json:"uses"`
 }
 
-// DefaultPopularTagsLimit is how many suggestions the editor gets when it does
-// not ask for a specific number. The imported WordPress archive has a long tail
-// of tags used exactly once, so the point of the cap is to keep the list to the
-// ones a desk actually reaches for.
-const DefaultPopularTagsLimit = 50
+// DefaultTagsLimit is how many suggestions a caller gets when it does not ask
+// for a number. The imported WordPress archive has a long tail of tags used
+// exactly once, so the point of the cap is to keep the list to the ones a desk
+// actually reaches for.
+const DefaultTagsLimit = 50
 
-// MaxPopularTagsLimit bounds what a caller can ask for, since the whole result
-// is built in memory.
-const MaxPopularTagsLimit = 200
+// MaxTagsLimit bounds what a caller can ask for. It caps the response, not the
+// ranking: search reads every tag the archive has, and only the slice handed
+// back is trimmed.
+const MaxTagsLimit = 200
 
-// popularTagsTTL is how long a computed ranking is served before it is rebuilt.
+// tagRankingTTL is how long a computed ranking is served before it is rebuilt.
 // Counting means scanning every article's tags, and the ranking moves by one
 // article at a time, so a stale-by-minutes list is indistinguishable from a
 // fresh one to the person picking from it.
-const popularTagsTTL = 10 * time.Minute
+const tagRankingTTL = 10 * time.Minute
 
-// popularTagsCache holds the full ranking (MaxPopularTagsLimit entries), which
-// every limit is then sliced from, so varying the limit cannot cause a rebuild.
+// The cached ranking is every distinct tag in the archive, not just the popular
+// ones, because search has to be able to find a tag used twice in 2019.
+// That is ~20k entries against ~9k articles -- a couple of megabytes, and far
+// cheaper than a per-keystroke scan of the article table.
 //
 // The mutex is held across the refresh rather than only around the swap: it
 // serializes concurrent misses so a cold cache costs one scan instead of one
 // per in-flight request.
 var (
-	popularTagsMu      sync.Mutex
-	popularTagsCached  []PopularTag
-	popularTagsFetched time.Time
+	tagRankingMu      sync.Mutex
+	tagRankingCached  []PopularTag
+	tagRankingFetched time.Time
 )
 
 // PopularTags returns the SEO tags most used across the archive, ranked by
@@ -59,33 +62,111 @@ var (
 // is still a tag the desk is using, and suggestions are about what editors
 // type, not about what readers can see.
 func PopularTags(ctx context.Context, conn *sql.DB, limit int) ([]PopularTag, error) {
+	ranking, err := tagRanking(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	return capTags(ranking, limit), nil
+}
+
+// SearchTags finds the tags whose text contains the query, so an editor can
+// reach a tag the archive already has instead of retyping it -- and, more to
+// the point, instead of coining a near-duplicate of one.
+//
+// It searches every tag, not the popular slice PopularTags hands back: a beat
+// tag used twice in 2019 is exactly the kind of thing nobody remembers the
+// exact spelling of, and it is nowhere near the top 50.
+//
+// Matches are ordered by how they match before how popular they are. Somebody
+// typing "lacrosse" means the tag "lacrosse", and burying it under a
+// better-used "Men's Lacrosse" makes the exact tag they asked for the one they
+// have to hunt for.
+func SearchTags(ctx context.Context, conn *sql.DB, query string, limit int) ([]PopularTag, error) {
+	normalized := strings.ToLower(strings.TrimSpace(query))
+	if normalized == "" {
+		return PopularTags(ctx, conn, limit)
+	}
+
+	ranking, err := tagRanking(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	type scored struct {
+		tag  PopularTag
+		rank int
+	}
+	matches := make([]scored, 0, 64)
+	for _, tag := range ranking {
+		if rank := matchRank(strings.ToLower(tag.Name), normalized); rank >= 0 {
+			matches = append(matches, scored{tag: tag, rank: rank})
+		}
+	}
+
+	// Stable within a rank: the ranking is already ordered by uses then name,
+	// so equally-good matches keep that order.
+	sort.SliceStable(matches, func(i, j int) bool { return matches[i].rank < matches[j].rank })
+
+	found := make([]PopularTag, 0, len(matches))
+	for _, match := range matches {
+		found = append(found, match.tag)
+	}
+	return capTags(found, limit), nil
+}
+
+// matchRank scores how a tag matches the query -- lower is better -- or returns
+// -1 for no match. The tiers are the ones a person typing would expect: the
+// tag they typed exactly, then tags starting with it, then tags with a word
+// starting with it, then anything containing it.
+func matchRank(name, query string) int {
+	switch {
+	case name == query:
+		return 0
+	case strings.HasPrefix(name, query):
+		return 1
+	case strings.Contains(name, " "+query):
+		// A word boundary, so "lacrosse" reaches "Men's Lacrosse" ahead of a
+		// tag that merely has the letters somewhere inside it.
+		return 2
+	case strings.Contains(name, query):
+		return 3
+	default:
+		return -1
+	}
+}
+
+// capTags trims a result set to the requested limit, copying so a caller that
+// sorts or truncates the slice cannot corrupt the cache for everyone else.
+func capTags(tags []PopularTag, limit int) []PopularTag {
 	if limit <= 0 {
-		limit = DefaultPopularTagsLimit
+		limit = DefaultTagsLimit
 	}
-	if limit > MaxPopularTagsLimit {
-		limit = MaxPopularTagsLimit
+	if limit > MaxTagsLimit {
+		limit = MaxTagsLimit
 	}
+	if limit > len(tags) {
+		limit = len(tags)
+	}
+	out := make([]PopularTag, limit)
+	copy(out, tags[:limit])
+	return out
+}
 
-	popularTagsMu.Lock()
-	defer popularTagsMu.Unlock()
+// tagRanking returns every tag in the archive, ranked by use, from the cache --
+// rebuilding it when it has expired.
+func tagRanking(ctx context.Context, conn *sql.DB) ([]PopularTag, error) {
+	tagRankingMu.Lock()
+	defer tagRankingMu.Unlock()
 
-	if popularTagsCached == nil || time.Since(popularTagsFetched) > popularTagsTTL {
+	if tagRankingCached == nil || time.Since(tagRankingFetched) > tagRankingTTL {
 		ranked, err := rankArticleTags(ctx, conn)
 		if err != nil {
 			return nil, err
 		}
-		popularTagsCached = ranked
-		popularTagsFetched = time.Now()
+		tagRankingCached = ranked
+		tagRankingFetched = time.Now()
 	}
-
-	if limit > len(popularTagsCached) {
-		limit = len(popularTagsCached)
-	}
-	// Copy, so a caller that sorts or truncates the slice cannot corrupt the
-	// cache for everyone else.
-	out := make([]PopularTag, limit)
-	copy(out, popularTagsCached[:limit])
-	return out, nil
+	return tagRankingCached, nil
 }
 
 // InvalidatePopularTags drops the cached ranking so the next read rebuilds it.
@@ -93,10 +174,10 @@ func PopularTags(ctx context.Context, conn *sql.DB, limit int) ([]PopularTag, er
 // takes a few minutes to enter the suggestion list is not a defect worth a
 // rescan per save.
 func InvalidatePopularTags() {
-	popularTagsMu.Lock()
-	popularTagsCached = nil
-	popularTagsFetched = time.Time{}
-	popularTagsMu.Unlock()
+	tagRankingMu.Lock()
+	tagRankingCached = nil
+	tagRankingFetched = time.Time{}
+	tagRankingMu.Unlock()
 }
 
 // rankArticleTags scans the tag column and builds the full ranking.
@@ -124,7 +205,9 @@ func rankArticleTags(ctx context.Context, conn *sql.DB) ([]PopularTag, error) {
 
 // rankTagValues is the ranking itself, split from the query so the counting
 // rules -- case folding, per-article de-duplication, the tie-break -- are
-// testable without a database.
+// testable without a database. Every tag is kept, not just the top slice:
+// search reads this list, so trimming it here would make older tags
+// unfindable rather than merely unpopular.
 func rankTagValues(values []sql.NullString) []PopularTag {
 	// Keyed by the lowercased tag: the archive carries "Drexel" and "drexel" as
 	// separate strings, and offering both as separate suggestions is exactly the
@@ -175,9 +258,6 @@ func rankTagValues(values []sql.NullString) []PopularTag {
 		return ranked[i].Name < ranked[j].Name
 	})
 
-	if len(ranked) > MaxPopularTagsLimit {
-		ranked = ranked[:MaxPopularTagsLimit]
-	}
 	return ranked
 }
 

--- a/server/internal/database/tags.go
+++ b/server/internal/database/tags.go
@@ -1,0 +1,197 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// PopularTag is one SEO tag and the number of articles carrying it.
+type PopularTag struct {
+	Name string `json:"name"`
+	Uses int64  `json:"uses"`
+}
+
+// DefaultPopularTagsLimit is how many suggestions the editor gets when it does
+// not ask for a specific number. The imported WordPress archive has a long tail
+// of tags used exactly once, so the point of the cap is to keep the list to the
+// ones a desk actually reaches for.
+const DefaultPopularTagsLimit = 50
+
+// MaxPopularTagsLimit bounds what a caller can ask for, since the whole result
+// is built in memory.
+const MaxPopularTagsLimit = 200
+
+// popularTagsTTL is how long a computed ranking is served before it is rebuilt.
+// Counting means scanning every article's tags, and the ranking moves by one
+// article at a time, so a stale-by-minutes list is indistinguishable from a
+// fresh one to the person picking from it.
+const popularTagsTTL = 10 * time.Minute
+
+// popularTagsCache holds the full ranking (MaxPopularTagsLimit entries), which
+// every limit is then sliced from, so varying the limit cannot cause a rebuild.
+//
+// The mutex is held across the refresh rather than only around the swap: it
+// serializes concurrent misses so a cold cache costs one scan instead of one
+// per in-flight request.
+var (
+	popularTagsMu      sync.Mutex
+	popularTagsCached  []PopularTag
+	popularTagsFetched time.Time
+)
+
+// PopularTags returns the SEO tags most used across the archive, ranked by
+// article count, for the editor's tag suggestions.
+//
+// There is no tags table: `articles`.`tags` holds a JSON array per article, so
+// "most used" can only come from aggregating the column. The aggregation runs
+// in Go rather than in SQL (JSON_TABLE) for two reasons. The column is not
+// reliably JSON -- FormatTags falls back to a comma-joined string when
+// marshalling fails, and articles with no tags store "" -- and parseStringListField
+// already absorbs both spellings, so reusing it means the suggestion list cannot
+// disagree with what the article editor itself reads back. Doing it here also
+// makes the case folding below expressible at all.
+//
+// Archived articles are excluded; drafts are not. A tag on an unpublished draft
+// is still a tag the desk is using, and suggestions are about what editors
+// type, not about what readers can see.
+func PopularTags(ctx context.Context, conn *sql.DB, limit int) ([]PopularTag, error) {
+	if limit <= 0 {
+		limit = DefaultPopularTagsLimit
+	}
+	if limit > MaxPopularTagsLimit {
+		limit = MaxPopularTagsLimit
+	}
+
+	popularTagsMu.Lock()
+	defer popularTagsMu.Unlock()
+
+	if popularTagsCached == nil || time.Since(popularTagsFetched) > popularTagsTTL {
+		ranked, err := rankArticleTags(ctx, conn)
+		if err != nil {
+			return nil, err
+		}
+		popularTagsCached = ranked
+		popularTagsFetched = time.Now()
+	}
+
+	if limit > len(popularTagsCached) {
+		limit = len(popularTagsCached)
+	}
+	// Copy, so a caller that sorts or truncates the slice cannot corrupt the
+	// cache for everyone else.
+	out := make([]PopularTag, limit)
+	copy(out, popularTagsCached[:limit])
+	return out, nil
+}
+
+// InvalidatePopularTags drops the cached ranking so the next read rebuilds it.
+// Used by tests; article writes deliberately do not call it, because a tag that
+// takes a few minutes to enter the suggestion list is not a defect worth a
+// rescan per save.
+func InvalidatePopularTags() {
+	popularTagsMu.Lock()
+	popularTagsCached = nil
+	popularTagsFetched = time.Time{}
+	popularTagsMu.Unlock()
+}
+
+// rankArticleTags scans the tag column and builds the full ranking.
+func rankArticleTags(ctx context.Context, conn *sql.DB) ([]PopularTag, error) {
+	rows, err := conn.QueryContext(ctx,
+		"SELECT `tags` FROM `articles` WHERE `archived_at` IS NULL AND `tags` IS NOT NULL AND `tags` <> ''")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	values := make([]sql.NullString, 0, 256)
+	for rows.Next() {
+		var raw sql.NullString
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		values = append(values, raw)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return rankTagValues(values), nil
+}
+
+// rankTagValues is the ranking itself, split from the query so the counting
+// rules -- case folding, per-article de-duplication, the tie-break -- are
+// testable without a database.
+func rankTagValues(values []sql.NullString) []PopularTag {
+	// Keyed by the lowercased tag: the archive carries "Drexel" and "drexel" as
+	// separate strings, and offering both as separate suggestions is exactly the
+	// duplicate-looking list this feature is meant to replace.
+	type tally struct {
+		uses     int64
+		spelling map[string]int64
+	}
+	counts := make(map[string]*tally)
+
+	for _, raw := range values {
+		// Duplicates within one article must not count twice, or a
+		// double-tagged article outranks two genuinely different ones.
+		seen := make(map[string]bool)
+		for _, tag := range parseStringListField(raw) {
+			name := strings.TrimSpace(tag)
+			if name == "" {
+				continue
+			}
+			key := strings.ToLower(name)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			entry := counts[key]
+			if entry == nil {
+				entry = &tally{spelling: make(map[string]int64)}
+				counts[key] = entry
+			}
+			entry.uses++
+			entry.spelling[name]++
+		}
+	}
+
+	ranked := make([]PopularTag, 0, len(counts))
+	for _, entry := range counts {
+		ranked = append(ranked, PopularTag{Name: displaySpelling(entry.spelling), Uses: entry.uses})
+	}
+
+	// Ties break on the name so the list is stable between rebuilds: a
+	// suggestion row that reshuffles on refresh is worse than a slightly
+	// arbitrary order.
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].Uses != ranked[j].Uses {
+			return ranked[i].Uses > ranked[j].Uses
+		}
+		return ranked[i].Name < ranked[j].Name
+	})
+
+	if len(ranked) > MaxPopularTagsLimit {
+		ranked = ranked[:MaxPopularTagsLimit]
+	}
+	return ranked
+}
+
+// displaySpelling picks which casing of a tag to show: the one the archive uses
+// most, falling back to the lexicographically first so the choice is
+// deterministic when two spellings are equally common.
+func displaySpelling(spellings map[string]int64) string {
+	best := ""
+	var bestCount int64
+	for spelling, count := range spellings {
+		if count > bestCount || (count == bestCount && (best == "" || spelling < best)) {
+			best = spelling
+			bestCount = count
+		}
+	}
+	return best
+}

--- a/server/internal/database/tags_test.go
+++ b/server/internal/database/tags_test.go
@@ -115,16 +115,44 @@ func TestRankTagValuesSkipsEmptyAndBlankEntries(t *testing.T) {
 	}
 }
 
-// The imported archive has a long tail of tags used exactly once; the ranking
-// is held in memory, so it is capped before it ever reaches a caller.
-func TestRankTagValuesCapsTheRanking(t *testing.T) {
-	values := make([]sql.NullString, 0, MaxPopularTagsLimit+50)
-	for i := 0; i < MaxPopularTagsLimit+50; i++ {
+// The ranking keeps every tag, because search reads it: a tag used twice in
+// 2019 has to stay findable, and it is nowhere near the popular slice. Only the
+// response is capped.
+func TestRankTagValuesKeepsTheWholeArchive(t *testing.T) {
+	values := make([]sql.NullString, 0, MaxTagsLimit+50)
+	for i := 0; i < MaxTagsLimit+50; i++ {
 		values = append(values, sql.NullString{String: fmt.Sprintf(`["tag-%03d"]`, i), Valid: true})
 	}
 
 	ranked := rankTagValues(values)
-	if len(ranked) != MaxPopularTagsLimit {
-		t.Fatalf("got %d tags, want the cap of %d", len(ranked), MaxPopularTagsLimit)
+	if len(ranked) != MaxTagsLimit+50 {
+		t.Fatalf("got %d tags, want all %d of them", len(ranked), MaxTagsLimit+50)
+	}
+	if capped := capTags(ranked, 0); len(capped) != DefaultTagsLimit {
+		t.Errorf("response was not capped: got %d tags, want %d", len(capped), DefaultTagsLimit)
+	}
+}
+
+// Somebody typing "lacrosse" means the tag "lacrosse". Ordering matches by
+// popularity alone buries it under a better-used "Men's Lacrosse", which makes
+// the exact tag they asked for the one they have to hunt for.
+func TestMatchRankPrefersTheCloserMatch(t *testing.T) {
+	ordered := []string{"lacrosse", "lacrosse team", "men's lacrosse", "collacrosse"}
+	for i := 1; i < len(ordered); i++ {
+		previous := matchRank(ordered[i-1], "lacrosse")
+		current := matchRank(ordered[i], "lacrosse")
+		if previous < 0 || current < 0 {
+			t.Fatalf("%q or %q did not match at all", ordered[i-1], ordered[i])
+		}
+		if previous >= current {
+			t.Errorf("%q ranked %d, %q ranked %d; the closer match must rank lower",
+				ordered[i-1], previous, ordered[i], current)
+		}
+	}
+}
+
+func TestMatchRankRejectsANonMatch(t *testing.T) {
+	if rank := matchRank("drexel", "lacrosse"); rank >= 0 {
+		t.Errorf("got rank %d, want -1 for a tag that does not contain the query", rank)
 	}
 }

--- a/server/internal/database/tags_test.go
+++ b/server/internal/database/tags_test.go
@@ -1,0 +1,130 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+)
+
+func tagRows(values ...string) []sql.NullString {
+	rows := make([]sql.NullString, 0, len(values))
+	for _, value := range values {
+		rows = append(rows, sql.NullString{String: value, Valid: true})
+	}
+	return rows
+}
+
+func TestRankTagValuesRanksByArticleCount(t *testing.T) {
+	ranked := rankTagValues(tagRows(
+		`["triangle","drexel"]`,
+		`["triangle","news"]`,
+		`["triangle"]`,
+		`["drexel"]`,
+	))
+
+	want := []PopularTag{
+		{Name: "triangle", Uses: 3},
+		{Name: "drexel", Uses: 2},
+		{Name: "news", Uses: 1},
+	}
+	if len(ranked) != len(want) {
+		t.Fatalf("got %d tags, want %d: %v", len(ranked), len(want), ranked)
+	}
+	for i, expected := range want {
+		if ranked[i] != expected {
+			t.Errorf("position %d: got %+v, want %+v", i, ranked[i], expected)
+		}
+	}
+}
+
+// The archive carries the same tag under several casings. Folding them is the
+// whole point: two entries reading "Drexel" and "drexel" is the duplicated list
+// the suggestions are meant to replace.
+func TestRankTagValuesFoldsCaseAndShowsTheCommonestSpelling(t *testing.T) {
+	ranked := rankTagValues(tagRows(
+		`["Drexel"]`,
+		`["drexel"]`,
+		`["drexel"]`,
+		`["DREXEL"]`,
+	))
+
+	if len(ranked) != 1 {
+		t.Fatalf("case variants were not folded: %v", ranked)
+	}
+	if ranked[0].Uses != 4 {
+		t.Errorf("got %d uses, want 4", ranked[0].Uses)
+	}
+	if ranked[0].Name != "drexel" {
+		t.Errorf("got display spelling %q, want the commonest one, %q", ranked[0].Name, "drexel")
+	}
+}
+
+// Equally common spellings must not depend on map iteration order, or the
+// suggestion row renames itself every time the cache rebuilds.
+func TestRankTagValuesPicksADeterministicSpellingOnATie(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		ranked := rankTagValues(tagRows(`["Title IX"]`, `["title ix"]`))
+		if len(ranked) != 1 {
+			t.Fatalf("case variants were not folded: %v", ranked)
+		}
+		if ranked[0].Name != "Title IX" {
+			t.Fatalf("got %q, want the lexicographically first spelling %q", ranked[0].Name, "Title IX")
+		}
+	}
+}
+
+func TestRankTagValuesCountsAnArticleOncePerTag(t *testing.T) {
+	ranked := rankTagValues(tagRows(`["drexel","Drexel","drexel"]`))
+
+	if len(ranked) != 1 {
+		t.Fatalf("got %d tags, want 1: %v", len(ranked), ranked)
+	}
+	if ranked[0].Uses != 1 {
+		t.Errorf("got %d uses, want 1 -- one article carrying a tag three times is still one article", ranked[0].Uses)
+	}
+}
+
+// FormatTags falls back to a comma-joined string when marshalling fails, and
+// rows written before the CMS existed are not guaranteed to be JSON either. A
+// tag that the article editor reads back has to be a tag the suggestions count.
+func TestRankTagValuesReadsTheCommaJoinedFallback(t *testing.T) {
+	ranked := rankTagValues(tagRows(`triangle,drexel`, `["triangle"]`))
+
+	want := map[string]int64{"triangle": 2, "drexel": 1}
+	if len(ranked) != len(want) {
+		t.Fatalf("got %v, want %v", ranked, want)
+	}
+	for _, tag := range ranked {
+		if want[tag.Name] != tag.Uses {
+			t.Errorf("tag %q: got %d uses, want %d", tag.Name, tag.Uses, want[tag.Name])
+		}
+	}
+}
+
+func TestRankTagValuesSkipsEmptyAndBlankEntries(t *testing.T) {
+	ranked := rankTagValues(append(
+		tagRows(`[]`, `[""]`, `["   "]`, `null`, `["  drexel  "]`),
+		sql.NullString{},
+	))
+
+	if len(ranked) != 1 {
+		t.Fatalf("got %d tags, want 1: %v", len(ranked), ranked)
+	}
+	if ranked[0].Name != "drexel" {
+		t.Errorf("got %q, want the trimmed tag %q", ranked[0].Name, "drexel")
+	}
+}
+
+// The imported archive has a long tail of tags used exactly once; the ranking
+// is held in memory, so it is capped before it ever reaches a caller.
+func TestRankTagValuesCapsTheRanking(t *testing.T) {
+	values := make([]sql.NullString, 0, MaxPopularTagsLimit+50)
+	for i := 0; i < MaxPopularTagsLimit+50; i++ {
+		values = append(values, sql.NullString{String: fmt.Sprintf(`["tag-%03d"]`, i), Valid: true})
+	}
+
+	ranked := rankTagValues(values)
+	if len(ranked) != MaxPopularTagsLimit {
+		t.Fatalf("got %d tags, want the cap of %d", len(ranked), MaxPopularTagsLimit)
+	}
+}

--- a/server/internal/handlers/tags.go
+++ b/server/internal/handlers/tags.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"database/sql"
+	"net/http"
+	"strconv"
+	"strings"
+
+	db "server/internal/database"
+)
+
+// @Summary List the most-used SEO tags
+// @Tags articles
+// @Produce json
+// @Param limit query int false "How many tags to return (default 50, max 200)"
+// @Success 200 {array} database.PopularTag
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Security BearerAuth
+// @Router /v1/tags/popular [get]
+//
+// Backs the click-to-add suggestions under the article editor's SEO Tags field.
+// Authenticated: it is an editing aid, and the counts describe unpublished
+// drafts as well as live articles.
+func GetPopularTags(conn *sql.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		limit := 0
+		if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+			parsed, err := strconv.Atoi(raw)
+			if err != nil || parsed <= 0 {
+				writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+				return
+			}
+			limit = parsed
+		}
+
+		tags, err := db.PopularTags(r.Context(), conn, limit)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to fetch popular tags")
+			return
+		}
+		writeJSON(w, http.StatusOK, tags)
+	})
+}

--- a/server/internal/handlers/tags.go
+++ b/server/internal/handlers/tags.go
@@ -9,20 +9,25 @@ import (
 	db "server/internal/database"
 )
 
-// @Summary List the most-used SEO tags
+// @Summary List or search the SEO tags already in use
 // @Tags articles
 // @Produce json
+// @Param q query string false "Search text; omit for the most-used tags"
 // @Param limit query int false "How many tags to return (default 50, max 200)"
 // @Success 200 {array} database.PopularTag
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Security BearerAuth
-// @Router /v1/tags/popular [get]
+// @Router /v1/tags [get]
 //
-// Backs the click-to-add suggestions under the article editor's SEO Tags field.
+// Backs the suggestions under the article editor's SEO Tags field: the
+// most-used tags when the box is empty, and a search over every tag the archive
+// has once the editor starts typing. Retyping a tag from memory is how
+// near-duplicates get coined, so finding the existing one has to be easier.
+//
 // Authenticated: it is an editing aid, and the counts describe unpublished
 // drafts as well as live articles.
-func GetPopularTags(conn *sql.DB) http.Handler {
+func GetTags(conn *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		limit := 0
 		if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
@@ -34,9 +39,11 @@ func GetPopularTags(conn *sql.DB) http.Handler {
 			limit = parsed
 		}
 
-		tags, err := db.PopularTags(r.Context(), conn, limit)
+		// A blank q is not an error, it is the unfiltered list: the editor
+		// sends the box's contents, and an empty box means "what is popular".
+		tags, err := db.SearchTags(r.Context(), conn, r.URL.Query().Get("q"), limit)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to fetch popular tags")
+			writeError(w, http.StatusInternalServerError, "failed to fetch tags")
 			return
 		}
 		writeJSON(w, http.StatusOK, tags)

--- a/server/internal/handlers/tags_integration_test.go
+++ b/server/internal/handlers/tags_integration_test.go
@@ -17,7 +17,7 @@ import (
 // way to know the ranking is right is to put articles in a real MariaDB and
 // read the endpoint back. Skips unless CMS_TEST_DSN is set.
 //
-//	CMS_TEST_DSN='root:pw@tcp(127.0.0.1:3306)/cms_test?parseTime=true&multiStatements=true' go test ./internal/handlers/ -run PopularTagsHTTP -v
+//	CMS_TEST_DSN='root:pw@tcp(127.0.0.1:3306)/cms_test?parseTime=true&multiStatements=true' go test ./internal/handlers/ -run TagsHTTP -v
 func seedTaggedArticles(t *testing.T, conn *sql.DB) {
 	t.Helper()
 	ctx := context.Background()
@@ -28,6 +28,9 @@ func seedTaggedArticles(t *testing.T, conn *sql.DB) {
 		archived any
 	}{
 		{"tagged-one", `["triangle","drexel","Title IX"]`, nil},
+		// A beat tag from years ago: used once, nowhere near the popular list,
+		// and exactly the kind of spelling nobody retypes correctly.
+		{"tagged-beat", `["Men's Lacrosse","lacrosse"]`, nil},
 		{"tagged-two", `["triangle","Drexel"]`, nil},
 		// A draft: unpublished, but its tags are still tags the desk uses.
 		{"tagged-draft", `["triangle"]`, nil},
@@ -49,12 +52,12 @@ func seedTaggedArticles(t *testing.T, conn *sql.DB) {
 	t.Cleanup(db.InvalidatePopularTags)
 }
 
-func getPopularTags(t *testing.T, conn *sql.DB, query string) []db.PopularTag {
+func getTags(t *testing.T, conn *sql.DB, query string) []db.PopularTag {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, "/v1/tags/popular"+query, nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/tags"+query, nil)
 	rec := httptest.NewRecorder()
 
-	GetPopularTags(conn).ServeHTTP(rec, req)
+	GetTags(conn).ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
 	}
@@ -65,11 +68,11 @@ func getPopularTags(t *testing.T, conn *sql.DB, query string) []db.PopularTag {
 	return payload
 }
 
-func TestPopularTagsHTTP_RanksTagsAcrossTheArchive(t *testing.T) {
+func TestTagsHTTP_RanksTagsAcrossTheArchive(t *testing.T) {
 	conn := articlePatchTestDB(t)
 	seedTaggedArticles(t, conn)
 
-	tags := getPopularTags(t, conn, "")
+	tags := getTags(t, conn, "")
 
 	// One entry for drexel, not two: the seed spells it both ways, and the
 	// suggestions fold case. The two spellings are equally common here, so the
@@ -77,10 +80,6 @@ func TestPopularTagsHTTP_RanksTagsAcrossTheArchive(t *testing.T) {
 	want := []db.PopularTag{
 		{Name: "triangle", Uses: 3},
 		{Name: "Drexel", Uses: 2},
-		{Name: "Title IX", Uses: 1},
-	}
-	if len(tags) != len(want) {
-		t.Fatalf("got %+v, want %+v", tags, want)
 	}
 	for i, expected := range want {
 		if tags[i] != expected {
@@ -89,24 +88,76 @@ func TestPopularTagsHTTP_RanksTagsAcrossTheArchive(t *testing.T) {
 	}
 }
 
-// Archived articles are excluded, so a retracted story cannot keep suggesting
-// its tags to the next person writing one.
-func TestPopularTagsHTTP_ExcludesArchivedArticles(t *testing.T) {
+// The point of the search: a tag used once years ago is unreachable from the
+// popular list, and retyping it from memory is how a near-duplicate gets
+// coined instead.
+func TestTagsHTTP_FindsATagOutsideThePopularList(t *testing.T) {
 	conn := articlePatchTestDB(t)
 	seedTaggedArticles(t, conn)
 
-	for _, tag := range getPopularTags(t, conn, "") {
+	found := getTags(t, conn, "?q=lacrosse")
+
+	names := make([]string, 0, len(found))
+	for _, tag := range found {
+		names = append(names, tag.Name)
+	}
+	// Exact match first, then the one that merely contains it -- even though
+	// both are used exactly as often here.
+	want := []string{"lacrosse", "Men's Lacrosse"}
+	if len(names) != len(want) {
+		t.Fatalf("got %v, want %v", names, want)
+	}
+	for i, expected := range want {
+		if names[i] != expected {
+			t.Errorf("position %d: got %q, want %q", i, names[i], expected)
+		}
+	}
+}
+
+// The editor sends the box's contents, so a query that matches nothing has to
+// answer with an empty list rather than falling back to the popular tags --
+// suggestions that ignore what was typed read as a broken search.
+func TestTagsHTTP_ReturnsNothingForAQueryThatMatchesNothing(t *testing.T) {
+	conn := articlePatchTestDB(t)
+	seedTaggedArticles(t, conn)
+
+	if found := getTags(t, conn, "?q=zzzznotatag"); len(found) != 0 {
+		t.Fatalf("got %+v, want no matches", found)
+	}
+}
+
+// An empty box means "what is popular", not "match everything against a blank
+// string", and the two happen to agree -- but only because a blank query short
+// circuits before matching.
+func TestTagsHTTP_TreatsABlankQueryAsThePopularList(t *testing.T) {
+	conn := articlePatchTestDB(t)
+	seedTaggedArticles(t, conn)
+
+	found := getTags(t, conn, "?q=%20%20")
+
+	if len(found) == 0 || found[0].Name != "triangle" {
+		t.Fatalf("got %+v, want the popular list led by triangle", found)
+	}
+}
+
+// Archived articles are excluded, so a retracted story cannot keep suggesting
+// its tags to the next person writing one.
+func TestTagsHTTP_ExcludesArchivedArticles(t *testing.T) {
+	conn := articlePatchTestDB(t)
+	seedTaggedArticles(t, conn)
+
+	for _, tag := range getTags(t, conn, "") {
 		if tag.Name == "retracted" {
 			t.Fatalf("archived article's tag reached the suggestions: %+v", tag)
 		}
 	}
 }
 
-func TestPopularTagsHTTP_HonoursTheLimit(t *testing.T) {
+func TestTagsHTTP_HonoursTheLimit(t *testing.T) {
 	conn := articlePatchTestDB(t)
 	seedTaggedArticles(t, conn)
 
-	tags := getPopularTags(t, conn, "?limit=2")
+	tags := getTags(t, conn, "?limit=2")
 
 	if len(tags) != 2 {
 		t.Fatalf("got %d tags, want 2: %+v", len(tags), tags)
@@ -116,13 +167,13 @@ func TestPopularTagsHTTP_HonoursTheLimit(t *testing.T) {
 	}
 }
 
-func TestPopularTagsHTTP_RejectsAnUnusableLimit(t *testing.T) {
+func TestTagsHTTP_RejectsAnUnusableLimit(t *testing.T) {
 	conn := articlePatchTestDB(t)
 
 	for _, limit := range []string{"0", "-3", "many"} {
-		req := httptest.NewRequest(http.MethodGet, "/v1/tags/popular?limit="+limit, nil)
+		req := httptest.NewRequest(http.MethodGet, "/v1/tags?limit="+limit, nil)
 		rec := httptest.NewRecorder()
-		GetPopularTags(conn).ServeHTTP(rec, req)
+		GetTags(conn).ServeHTTP(rec, req)
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("limit=%s: status = %d, want 400", limit, rec.Code)
 		}

--- a/server/internal/handlers/tags_integration_test.go
+++ b/server/internal/handlers/tags_integration_test.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	db "server/internal/database"
+)
+
+// The suggestions are aggregated out of the articles table itself, so the only
+// way to know the ranking is right is to put articles in a real MariaDB and
+// read the endpoint back. Skips unless CMS_TEST_DSN is set.
+//
+//	CMS_TEST_DSN='root:pw@tcp(127.0.0.1:3306)/cms_test?parseTime=true&multiStatements=true' go test ./internal/handlers/ -run PopularTagsHTTP -v
+func seedTaggedArticles(t *testing.T, conn *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+
+	rows := []struct {
+		slug     string
+		tags     string
+		archived any
+	}{
+		{"tagged-one", `["triangle","drexel","Title IX"]`, nil},
+		{"tagged-two", `["triangle","Drexel"]`, nil},
+		// A draft: unpublished, but its tags are still tags the desk uses.
+		{"tagged-draft", `["triangle"]`, nil},
+		// Archived, so its tags must not reach the suggestion list at all.
+		{"tagged-archived", `["retracted"]`, "2026-01-01 00:00:00"},
+		{"untagged", "", nil},
+	}
+	for _, row := range rows {
+		if _, err := conn.ExecContext(ctx,
+			"INSERT INTO articles (title, slug, `text`, authors, tags, archived_at, creation_date) VALUES (?, ?, ?, ?, ?, ?, UTC_TIMESTAMP())",
+			row.slug, row.slug, "Body", `["Rui Zhao"]`, row.tags, row.archived,
+		); err != nil {
+			t.Fatalf("seed %s: %v", row.slug, err)
+		}
+	}
+	// The ranking is cached for minutes at a time; a test that seeds rows has
+	// to clear it or it reads whatever an earlier test left behind.
+	db.InvalidatePopularTags()
+	t.Cleanup(db.InvalidatePopularTags)
+}
+
+func getPopularTags(t *testing.T, conn *sql.DB, query string) []db.PopularTag {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/tags/popular"+query, nil)
+	rec := httptest.NewRecorder()
+
+	GetPopularTags(conn).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var payload []db.PopularTag
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return payload
+}
+
+func TestPopularTagsHTTP_RanksTagsAcrossTheArchive(t *testing.T) {
+	conn := articlePatchTestDB(t)
+	seedTaggedArticles(t, conn)
+
+	tags := getPopularTags(t, conn, "")
+
+	// One entry for drexel, not two: the seed spells it both ways, and the
+	// suggestions fold case. The two spellings are equally common here, so the
+	// displayed one is the tie-break -- lexicographically first.
+	want := []db.PopularTag{
+		{Name: "triangle", Uses: 3},
+		{Name: "Drexel", Uses: 2},
+		{Name: "Title IX", Uses: 1},
+	}
+	if len(tags) != len(want) {
+		t.Fatalf("got %+v, want %+v", tags, want)
+	}
+	for i, expected := range want {
+		if tags[i] != expected {
+			t.Errorf("position %d: got %+v, want %+v", i, tags[i], expected)
+		}
+	}
+}
+
+// Archived articles are excluded, so a retracted story cannot keep suggesting
+// its tags to the next person writing one.
+func TestPopularTagsHTTP_ExcludesArchivedArticles(t *testing.T) {
+	conn := articlePatchTestDB(t)
+	seedTaggedArticles(t, conn)
+
+	for _, tag := range getPopularTags(t, conn, "") {
+		if tag.Name == "retracted" {
+			t.Fatalf("archived article's tag reached the suggestions: %+v", tag)
+		}
+	}
+}
+
+func TestPopularTagsHTTP_HonoursTheLimit(t *testing.T) {
+	conn := articlePatchTestDB(t)
+	seedTaggedArticles(t, conn)
+
+	tags := getPopularTags(t, conn, "?limit=2")
+
+	if len(tags) != 2 {
+		t.Fatalf("got %d tags, want 2: %+v", len(tags), tags)
+	}
+	if tags[0].Name != "triangle" {
+		t.Errorf("got %q first, want the most-used tag %q", tags[0].Name, "triangle")
+	}
+}
+
+func TestPopularTagsHTTP_RejectsAnUnusableLimit(t *testing.T) {
+	conn := articlePatchTestDB(t)
+
+	for _, limit := range []string{"0", "-3", "many"} {
+		req := httptest.NewRequest(http.MethodGet, "/v1/tags/popular?limit="+limit, nil)
+		rec := httptest.NewRecorder()
+		GetPopularTags(conn).ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("limit=%s: status = %d, want 400", limit, rec.Code)
+		}
+	}
+}

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -127,6 +127,10 @@ func Register(mux *http.ServeMux, conn *sql.DB, verifier *oidc.IDTokenVerifier, 
 	mux.Handle("GET /v1/polls/{id}", handlers.GetPollByID(conn))
 	mux.Handle("GET /v1/developing-stories", handlers.GetDevelopingStories(conn))
 	mux.Handle("GET /v1/taxonomy", handlers.GetTaxonomy(conn))
+	// Tag suggestions for the article editor. Aggregated from the articles
+	// themselves -- there is no tags table -- so it is a read-only editing aid,
+	// not part of the taxonomy CRUD above.
+	mux.Handle("GET /v1/tags/popular", authMW(handlers.GetPopularTags(conn)))
 	mux.Handle("GET /v1/taxonomy/{type}/{slug}", handlers.GetTaxonomyItem(conn))
 	// Running the poll is part of editorial work, not site administration, so
 	// authoring and moderating questions is open to any signed-in editor.

--- a/server/internal/routes/routes.go
+++ b/server/internal/routes/routes.go
@@ -127,10 +127,10 @@ func Register(mux *http.ServeMux, conn *sql.DB, verifier *oidc.IDTokenVerifier, 
 	mux.Handle("GET /v1/polls/{id}", handlers.GetPollByID(conn))
 	mux.Handle("GET /v1/developing-stories", handlers.GetDevelopingStories(conn))
 	mux.Handle("GET /v1/taxonomy", handlers.GetTaxonomy(conn))
-	// Tag suggestions for the article editor. Aggregated from the articles
-	// themselves -- there is no tags table -- so it is a read-only editing aid,
-	// not part of the taxonomy CRUD above.
-	mux.Handle("GET /v1/tags/popular", authMW(handlers.GetPopularTags(conn)))
+	// Tag suggestions and search for the article editor. Aggregated from the
+	// articles themselves -- there is no tags table -- so it is a read-only
+	// editing aid, not part of the taxonomy CRUD above.
+	mux.Handle("GET /v1/tags", authMW(handlers.GetTags(conn)))
 	mux.Handle("GET /v1/taxonomy/{type}/{slug}", handlers.GetTaxonomyItem(conn))
 	// Running the poll is part of editorial work, not site administration, so
 	// authoring and moderating questions is open to any signed-in editor.


### PR DESCRIPTION
Sanjana asked for this in Slack on Aug 5: in WordPress the tag field offered the tags she adds to nearly every article, and she'd click them instead of retyping. The CMS's SEO Tags box is a bare text field, so that shortcut was gone.

Two things now sit under the box. With it empty, the tags the desk uses most. Once you start typing, a search over **every** tag the archive has — 19,893 of them — because the tags nobody remembers the spelling of are exactly the ones that aren't popular. Retyping a tag from memory is how near-duplicates get coined, so finding the existing one has to be easier than retyping it.

### How the ranking is built

There is no tags table. `articles`.`tags` holds a JSON array per article, so both the popular list and the search come from aggregating that column.

The aggregation runs in Go rather than as a `JSON_TABLE` query. The column is not reliably JSON — `FormatTags` falls back to a comma-joined string when marshalling fails, and untagged articles store `""` — and `parseStringListField` already absorbs both spellings. Reusing it means the suggestion counts cannot disagree with what the article editor itself reads back.

Case is folded, because the archive carries `Drexel` and `drexel` as separate strings, and offering both as separate suggestions is exactly the duplicate-looking list this is meant to replace. The displayed spelling is the commonest one, with a deterministic tie-break so the row does not rename itself when the cache rebuilds.

The cache holds the whole ranking, not the top slice — ~20k entries against ~9k articles, a couple of megabytes, and far cheaper than a per-keystroke scan of the article table. Only the response is capped. Archived articles are excluded; drafts are not.

### Ordering

Matches are ranked by *how* they match before *how popular* they are: exact, then prefix, then a word starting with the query, then anything containing it. Somebody typing "lacrosse" means the tag "lacrosse", and ordering on uses alone buries it under a better-used "Women's Lacrosse".

Against the real archive, `q=lacrosse` returns: `Lacrosse` (70), `lacrosse dragons` (1), `Women's Lacrosse` (51), `Men's Lacrosse` (46), `Drexel Women's Lacrosse` (24), `Drexel Men's Lacrosse` (21).

### In the editor

The box is searched on a 200ms debounce, so a typed word is one request rather than six. The popular tags stay on screen as the instant fallback and are filtered client-side on the keystroke, so the row narrows immediately instead of sitting empty until the search returns; stale responses for a prefix already typed past are dropped. A query that matches nothing says "No existing tag matches. Press Enter to create it." — coining a new tag is fine, but an editor should know that is what they're doing.

### The trap worth knowing about

Clicking a suggestion blurs the tag input, and blur commits whatever is in it. Typing `drex` and clicking `drexel` added **both** tags. The button suppresses the blur via `onMouseDown` preventDefault; removing that line makes the covering test fail, which I checked.

### Tests

- 9 unit tests on the ranking and match rules
- 7 handler integration tests against a real MariaDB, skipped without `CMS_TEST_DSN`
- 7 component tests in `editArticleView.test.tsx`, covering the blur trap, the debounce collapsing to one request, and finding a tag that is in the archive but not in the popular list

Full server suite, frontend suite (19/19), and `tsc -b` are green. Search quality was also eyeballed against the live 9,371-article archive with a read-only probe.

### Two things for the reviewer

**Based on #206, not main.** This builds on the featured-article branch because the editor page changes sit next to each other. Merge #206 first and this retargets cleanly.

**The swagger regen swept in unrelated catch-up.** `server/docs` was already stale — `canonical_url`, `photo_alt`, `featured_image_alt` and others were missing — so `swag init` added lines that aren't this endpoint. All generated, no deletions, but say the word and I'll drop the docs from the branch.

**Not visually checked.** The authed editor page needs the stubbed-entry-point + Playwright route to screenshot, which I did not set up. Behavior is covered by component tests, but nobody has looked at the row yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)