### PR TITLE
Answer 404 for section slugs that don't exist

### DIFF
--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -3227,6 +3227,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -3742,6 +3748,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -3224,6 +3224,12 @@
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -3739,6 +3745,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -3281,6 +3281,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -3607,6 +3611,10 @@ paths:
             $ref: '#/definitions/models.SubsectionArticlesResponse'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Not Found
           schema:
             $ref: '#/definitions/models.ErrorResponse'
         "500":

--- a/server/internal/handlers/article_params.go
+++ b/server/internal/handlers/article_params.go
@@ -3,12 +3,34 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	db "server/internal/database"
 	"server/internal/models"
 )
+
+// A slug that is well formed but absent from site_taxonomy is a missing
+// resource, not a malformed request. Handlers that read the slug from the
+// request path answer 404 for these; the query-string forms on
+// GET /v1/articles keep answering 400, since there the slug is a filter the
+// caller chose rather than the resource being addressed.
+var (
+	errSectionNotFound    = errors.New("invalid section_slug")
+	errSubsectionNotFound = errors.New("invalid subsection_slug")
+)
+
+// articleParamsStatus picks the status code for a validation failure.
+// pathParamErr is the sentinel whose slug arrived in the request path, so only
+// that one degrades to 404.
+func articleParamsStatus(err, pathParamErr error) int {
+	if errors.Is(err, pathParamErr) {
+		return http.StatusNotFound
+	}
+	return http.StatusBadRequest
+}
 
 var allowedSubsectionsBySection = map[string]map[string]struct{}{
 	"news": {
@@ -83,7 +105,7 @@ func normalizeAndValidateArticleParams(ctx context.Context, conn *sql.DB, params
 			return ArticleParams{}, err
 		}
 		if !ok {
-			return ArticleParams{}, fmt.Errorf("invalid section_slug")
+			return ArticleParams{}, errSectionNotFound
 		}
 	}
 
@@ -101,7 +123,7 @@ func normalizeAndValidateArticleParams(ctx context.Context, conn *sql.DB, params
 			return ArticleParams{}, err
 		}
 		if !ok {
-			return ArticleParams{}, fmt.Errorf("invalid subsection_slug")
+			return ArticleParams{}, errSubsectionNotFound
 		}
 		if params.Section == "" {
 			params.Section = parentSection

--- a/server/internal/handlers/article_params_test.go
+++ b/server/internal/handlers/article_params_test.go
@@ -2,6 +2,9 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -24,10 +27,116 @@ func TestNormalizeSectionSlug(t *testing.T) {
 }
 
 func TestNormalizeAndValidateArticleParams_RejectsUnknownSectionSlug(t *testing.T) {
-	if _, err := normalizeAndValidateArticleParams(context.Background(), nil, ArticleParams{
+	_, err := normalizeAndValidateArticleParams(context.Background(), nil, ArticleParams{
 		Section: "candp",
-	}); err == nil {
+	})
+	if err == nil {
 		t.Fatal("expected error for unknown section_slug")
+	}
+	if !errors.Is(err, errSectionNotFound) {
+		t.Fatalf("err = %v, want errSectionNotFound", err)
+	}
+}
+
+func TestNormalizeAndValidateArticleParams_RejectsUnknownSubsectionSlug(t *testing.T) {
+	_, err := normalizeAndValidateArticleParams(context.Background(), nil, ArticleParams{
+		Subsection: "not-a-subsection",
+	})
+	if !errors.Is(err, errSubsectionNotFound) {
+		t.Fatalf("err = %v, want errSubsectionNotFound", err)
+	}
+}
+
+// A subsection that exists but sits under a different parent is a genuinely
+// contradictory request, so it must stay a 400 rather than becoming a 404.
+func TestArticleParamsStatus_MismatchedParentStaysBadRequest(t *testing.T) {
+	_, err := normalizeAndValidateArticleParams(context.Background(), nil, ArticleParams{
+		Section:    "sports",
+		Subsection: "the-love-triangle",
+	})
+	if err == nil {
+		t.Fatal("expected error for subsection outside the named section")
+	}
+	if got := articleParamsStatus(err, errSubsectionNotFound); got != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", got, http.StatusBadRequest)
+	}
+}
+
+func TestArticleParamsStatus_OnlyPathParamDegradesToNotFound(t *testing.T) {
+	cases := []struct {
+		name         string
+		err          error
+		pathParamErr error
+		want         int
+	}{
+		{name: "section in path", err: errSectionNotFound, pathParamErr: errSectionNotFound, want: http.StatusNotFound},
+		{name: "subsection in path", err: errSubsectionNotFound, pathParamErr: errSubsectionNotFound, want: http.StatusNotFound},
+		{name: "subsection is a query filter", err: errSubsectionNotFound, pathParamErr: errSectionNotFound, want: http.StatusBadRequest},
+		{name: "section is a query filter", err: errSectionNotFound, pathParamErr: errSubsectionNotFound, want: http.StatusBadRequest},
+		{name: "malformed author_slug", err: errors.New("invalid author_slug"), pathParamErr: errSectionNotFound, want: http.StatusBadRequest},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := articleParamsStatus(tc.err, tc.pathParamErr); got != tc.want {
+				t.Fatalf("status = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// The handlers validate against the static taxonomy fallback when there is no
+// database handle, so an unknown slug is answered before anything is queried.
+func TestSectionArticlesHandlers_UnknownPathSlugReturnsNotFound(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		target  string
+		pathKey string
+		slug    string
+	}{
+		{
+			name:    "section",
+			handler: GetSectionArticles(nil),
+			target:  "/v1/sections/sw.js/articles",
+			pathKey: "section_slug",
+			slug:    "sw.js",
+		},
+		{
+			name:    "subsection",
+			handler: GetSubsectionArticles(nil),
+			target:  "/v1/subsections/sw.js/articles",
+			pathKey: "subsection_slug",
+			slug:    "sw.js",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+			req.SetPathValue(tc.pathKey, tc.slug)
+			rec := httptest.NewRecorder()
+
+			tc.handler(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusNotFound, rec.Body.String())
+			}
+		})
+	}
+}
+
+// The section_slug/subsection_slug query filters are caller-chosen filters
+// rather than the addressed resource, so they keep answering 400.
+func TestGetSectionArticles_UnknownSubsectionFilterStaysBadRequest(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/sections/sports/articles?subsection_slug=not-a-subsection", nil)
+	req.SetPathValue("section_slug", "sports")
+	rec := httptest.NewRecorder()
+
+	GetSectionArticles(nil)(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
 }
 

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -1068,6 +1068,7 @@ func GetArticles(conn *sql.DB) http.HandlerFunc {
 // @Param excerpt_words query int false "Max words in excerpt" default(50)
 // @Success 200 {object} models.SectionArticlesResponse
 // @Failure 400 {object} models.ErrorResponse
+// @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /v1/sections/{section_slug}/articles [get]
 func GetSectionArticles(conn *sql.DB) http.HandlerFunc {
@@ -1078,7 +1079,7 @@ func GetSectionArticles(conn *sql.DB) http.HandlerFunc {
 			Subsection: r.URL.Query().Get("subsection_slug"),
 		})
 		if err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
+			writeError(w, articleParamsStatus(err, errSectionNotFound), err.Error())
 			return
 		}
 		page, limit, offset := listParams(r, 20)
@@ -1143,6 +1144,7 @@ func GetSectionArticles(conn *sql.DB) http.HandlerFunc {
 // @Param excerpt_words query int false "Max words in excerpt" default(50)
 // @Success 200 {object} models.SubsectionArticlesResponse
 // @Failure 400 {object} models.ErrorResponse
+// @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /v1/subsections/{subsection_slug}/articles [get]
 func GetSubsectionArticles(conn *sql.DB) http.HandlerFunc {
@@ -1153,7 +1155,7 @@ func GetSubsectionArticles(conn *sql.DB) http.HandlerFunc {
 			Subsection: r.PathValue("subsection_slug"),
 		})
 		if err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
+			writeError(w, articleParamsStatus(err, errSubsectionNotFound), err.Error())
 			return
 		}
 		page, limit, offset := listParams(r, 20)


### PR DESCRIPTION
The production error-rate panel has been sitting near 5% and is useless as an alerting signal, because the largest single contributor is not an error. Over 6h on Delta today: **720** `400 GET /v1/sections/{section_slug}/articles` and **326** `400 GET /v1/subsections/{subsection_slug}/articles`, roughly a thousand a day.

The slug is a *path* parameter on both routes, so a value that isn't in `site_taxonomy` is a missing resource, not a malformed request. It now returns 404.

### Why it isn't a one-line status change

`normalizeAndValidateArticleParams` is shared with `GET /v1/articles`, where `section_slug` and `subsection_slug` are query filters the caller chose rather than the resource being addressed — 400 is correct there. So the validator returns two sentinels, `errSectionNotFound` and `errSubsectionNotFound`, and each handler passes the one whose slug came from *its* path:

```go
writeError(w, articleParamsStatus(err, errSectionNotFound), err.Error())
```

`GET /v1/sections/sports/articles?subsection_slug=bogus` therefore still answers 400. So does `subsection_slug does not belong to section_slug`, which is a genuinely contradictory request.

The error message strings are unchanged, so response bodies are byte-identical and only the status code moves. That matters for the public site: `getSectionArticles` does `if (!res.ok) return;`, treating 400 and 404 the same, so this ships independently of anything on Scalene.

### Where the volume actually comes from

Two client-side causes, both tracked on the Scalene board rather than fixed here:

- The Astro catch-all resolves a section page by trying `/sections/` first and falling back to `/subsections/`, so every subsection page burns one failing request by design. Confirmed for `politics`, `music`, `gaming`, `cooking`, `world`.
- `/sw.js` 404s in production, falls through to the same catch-all, and gets looked up as a section — 126 of these in 90 minutes. The service worker isn't registering at all, which is a real bug independent of the metrics.

Three slugs 400 on *both* endpoints, meaning they're genuinely absent from `site_taxonomy`: `podcasts`, `sjn-grant`, `tri-this-sweet-treat`. Those need separate triage; this change makes them 404 instead of masking them as bad requests.

### Deliberately out of scope

`GET /v1/articles/{slug}` returns 400 for values like `index.xml`. That slug really is syntactically invalid, and `isValidCanonicalSlug` has 25+ call sites that are mostly write endpoints where 400 is plainly right — not worth widening this diff for ~5 events per 6h.

### Testing

`go test ./...` and `go vet ./...` clean. No existing test asserted 400 on these routes, so nothing needed loosening. Added coverage for both sentinels, the full status-mapping table, handler-level 404s, and the query-filter-stays-400 case. Swagger regenerated — additive `404` on these two routes only.

The taxonomy lookup can't be exercised locally (DB1's grants are host-scoped), so the handler tests run against the no-database fallback, which reaches the same sentinel. Real confirmation is the error-rate panel after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)