### PR TITLE
Keep WordPress shortcodes out of derived excerpts

### DIFF
--- a/server/internal/database/http_models.go
+++ b/server/internal/database/http_models.go
@@ -601,11 +601,27 @@ var captionMarkupPattern = regexp.MustCompile(
 		`|<figcaption\b[^>]*>.*?</figcaption\s*>` +
 		`|<[a-z][a-z0-9]*\b[^>]*wp-caption-text[^>]*>.*?</[a-z][a-z0-9]*\s*>`)
 
+// WordPress shortcodes are markup too, but bracketed rather than angled, so
+// tag-stripping leaves them intact: a crossword post whose body is a single
+// [puzzleme ...] shortcode derived an excerpt that was the whole shortcode --
+// attributes, embed ids and all -- and the public site printed it under the
+// headline. Two shapes are removed, both narrow enough to leave editorial
+// brackets ("[sic]", "[Editor's note]") alone: the shortcodes this corpus
+// actually carries, named explicitly; and any bracketed token that carries
+// attributes, which is what makes it a shortcode rather than prose. Applied
+// before tag-stripping because attribute values hold HTML of their own (the
+// puzzleme attribution is a link), which would otherwise be torn out from
+// inside the brackets first.
+var shortcodePattern = regexp.MustCompile(
+	`(?is)\[/?(?:puzzleme|caption|gallery|embed|playlist|audio|video)\b[^\]]*\]` +
+		`|\[[a-z][a-z0-9_-]*\s+[^\]]*=[^\]]*\]`)
+
 // deriveExcerpt builds a plain-text excerpt from HTML article content by
-// dropping image captions, stripping tags, collapsing whitespace, and
-// truncating to a word limit.
+// dropping image captions and shortcodes, stripping tags, collapsing
+// whitespace, and truncating to a word limit.
 func deriveExcerpt(content string) string {
 	text := captionMarkupPattern.ReplaceAllString(content, " ")
+	text = shortcodePattern.ReplaceAllString(text, " ")
 	text = htmlTagPattern.ReplaceAllString(text, " ")
 	text = html.UnescapeString(text)
 	words := strings.Fields(text)

--- a/server/internal/database/http_models_test.go
+++ b/server/internal/database/http_models_test.go
@@ -213,3 +213,45 @@ func TestDeriveExcerpt_KeepsTextAroundAnInlineFigure(t *testing.T) {
 		t.Errorf("deriveExcerpt = %q, want both paragraphs and no caption", got)
 	}
 }
+
+// A crossword post is a single [puzzleme ...] shortcode, which stripping tags
+// leaves untouched: the derived excerpt was the shortcode source, embed ids and
+// all, printed under the headline on the public site.
+func TestDeriveExcerpt_DropsShortcodes(t *testing.T) {
+	puzzleme := `<p>[puzzleme basepath='https://puzzleme.amuselabs.com/pmm/' ` +
+		`set='4d204c915da55d641d981a020851d8b3990a78c1' id='dc2b9486' ` +
+		`attribution='Made by Coco Li using the online <a href="https://amuselabs.com/games/crossword/" ` +
+		`target="_blank">cross word generator</a> from Amuse Labs' type='crossword']</p>`
+
+	cases := map[string]struct{ content, want string }{
+		"puzzleme only":       {puzzleme, ""},
+		"puzzleme with prose": {puzzleme + `<p>Solve it below.</p>`, "Solve it below."},
+		"paired shortcode": {
+			`<p>[gallery ids="1,2"]</p><p>Look at these.</p>`,
+			"Look at these.",
+		},
+		"unknown shortcode with attributes": {
+			`[somewidget size='3']<p>The story begins here.</p>`,
+			"The story begins here.",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := deriveExcerpt(tc.content); got != tc.want {
+				t.Errorf("deriveExcerpt = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The shortcode rule keys on attributes, not on brackets, so editorial
+// interjections survive -- they are part of the sentence.
+func TestDeriveExcerpt_KeepsEditorialBrackets(t *testing.T) {
+	content := `<p>He said the vote was "unanimious" [sic] and [Editor's note: it was not].</p>`
+	want := `He said the vote was "unanimious" [sic] and [Editor's note: it was not].`
+
+	if got := deriveExcerpt(content); got != want {
+		t.Errorf("deriveExcerpt = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
A crossword post's whole body is a single `[puzzleme ...]` shortcode. `deriveExcerpt` strips HTML tags, which leaves brackets alone, so the derived excerpt was the shortcode source — basepath, embed ids, attribution markup and all — and the public site printed it under the headline on the Comics & Puzzles listing:

> "What's on Tea-V?" — `[puzzleme basepath='https://puzzleme.amuselabs.com/pmm/' set='4d204c…' id='dc2b9486' attribution='Made by Coco Li using the online <a href=…>cross word generator</a> from Amuse Labs' type='crossword']`

Shortcodes are now dropped before tags are stripped, since attribute values carry HTML of their own (the puzzleme attribution is a link) that would otherwise be torn out from inside the brackets first. Two shapes match, both narrow enough to leave editorial brackets like `[sic]` and `[Editor's note]` alone:

- the shortcodes this corpus carries, named explicitly (`puzzleme`, `caption`, `gallery`, `embed`, `playlist`, `audio`, `video`);
- any bracketed token carrying attributes, which is what makes it a shortcode rather than prose.

Scope: this governs excerpts derived from here on. Rows that already store a shortcode excerpt are cleared directly, and DrexelTriangle/Scalene#77 strips on render so nothing else in the corpus can leak the same way.

Tests: four `deriveExcerpt` cases for the shortcode shapes plus one asserting editorial brackets survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)