### PR TITLE
Let caches hold the public reads for a minute

### DIFF
--- a/server/internal/handlers/cache_headers_integration_test.go
+++ b/server/internal/handlers/cache_headers_integration_test.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"server/internal/middleware"
+	"server/internal/models"
+)
+
+// The unit tests around setPublicReadCache prove the rule; these prove the
+// handlers actually call it. The distinction matters because the failure is
+// silent in both directions: a missing call just means no caching, and a call
+// on the wrong branch means a shared cache can serve an editor's drafts to a
+// reader.
+//
+//	CMS_TEST_DSN='user:pw@tcp(127.0.0.1:3306)/cms_test?parseTime=true&multiStatements=true' go test ./internal/handlers/ -run CacheHeaders -v
+func TestCacheHeadersPublicListingIsCacheable(t *testing.T) {
+	conn := articlePatchTestDB(t)
+	if _, err := conn.ExecContext(context.Background(),
+		"INSERT INTO articles (title, slug, `text`, categories, pub_date) VALUES (?, ?, ?, ?, UTC_TIMESTAMP())",
+		"Cacheable story", "cacheable-story", "Body", `["News"]`,
+	); err != nil {
+		t.Fatalf("seed article: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	GetArticles(conn).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/articles?limit=5", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Cache-Control"); got != publicReadCacheControl {
+		t.Errorf("Cache-Control = %q, want %q", got, publicReadCacheControl)
+	}
+}
+
+// The one that matters: the editor's copy of the same URL carries drafts and
+// soft-deleted rows, so it must never be marked public.
+func TestCacheHeadersEditorListingIsNotCacheable(t *testing.T) {
+	conn := articlePatchTestDB(t)
+	if _, err := conn.ExecContext(context.Background(),
+		"INSERT INTO articles (title, slug, `text`, categories, pub_date) VALUES (?, ?, ?, ?, NULL)",
+		"Unpublished draft", "unpublished-draft", "Body", `["News"]`,
+	); err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles?limit=5", nil)
+	req = req.WithContext(middleware.ContextWithUser(req.Context(), &models.User{ID: 1, Name: "Editor", Role: models.RoleEditor}))
+	rec := httptest.NewRecorder()
+	GetArticles(conn).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	// The draft has to actually be in the body, or this asserts nothing.
+	if !strings.Contains(rec.Body.String(), "unpublished-draft") {
+		t.Fatal("the editor listing did not include the draft; this test would pass vacuously")
+	}
+	if got := rec.Header().Get("Cache-Control"); strings.Contains(got, "public") {
+		t.Errorf("Cache-Control = %q on a response carrying an unpublished headline", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != uncacheableCacheControl {
+		t.Errorf("Cache-Control = %q, want %q", got, uncacheableCacheControl)
+	}
+}
+
+// A 404 must not be cached: a slug that is wrong for sixty seconds because a
+// reader hit it before the article published is a support ticket.
+func TestCacheHeadersNotFoundIsNotCacheable(t *testing.T) {
+	conn := articlePatchTestDB(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles/no-such-article", nil)
+	req.SetPathValue("slug", "no-such-article")
+	rec := httptest.NewRecorder()
+	GetArticle(conn).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "" {
+		t.Errorf("Cache-Control = %q on a 404, want none", got)
+	}
+}

--- a/server/internal/handlers/featured_article_integration_test.go
+++ b/server/internal/handlers/featured_article_integration_test.go
@@ -160,8 +160,8 @@ func TestFeaturedArticleHTTP_HomepageLeadsWithTheFeaturedArticle(t *testing.T) {
 		}
 		// Without a stated freshness bound, a featured-article change reaches
 		// readers whenever some intermediary's heuristic decides it should.
-		if got := rec.Header().Get("Cache-Control"); got != homepageCacheControl {
-			t.Errorf("homepage Cache-Control = %q, want %q", got, homepageCacheControl)
+		if got := rec.Header().Get("Cache-Control"); got != publicReadCacheControl {
+			t.Errorf("homepage Cache-Control = %q, want %q", got, publicReadCacheControl)
 		}
 		var body struct {
 			News []struct {

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -69,6 +69,52 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, models.ErrorResponse{Error: msg})
 }
 
+// publicReadCacheControl bounds how stale a public read may be.
+//
+// Without a Cache-Control header every intermediary picks its own heuristic,
+// and Scalene's fetch cache has no expiry to respect at all -- an edit could
+// take an unbounded time to appear on the site. 60s is short enough that an
+// editor who fixes a headline sees it on the next reload rather than wondering
+// whether the save worked, and long enough that a page is not re-rendered per
+// visitor. stale-while-revalidate keeps that bound cheap: a traffic spike is
+// still served from cache while one request refreshes it behind the scenes.
+const publicReadCacheControl = "public, max-age=60, stale-while-revalidate=300"
+
+// uncacheableCacheControl is what an editor's copy of a public read gets.
+const uncacheableCacheControl = "private, no-store"
+
+// setPublicReadCache marks a GET cacheable, and is the only correct way to do
+// it on a route behind OptionalAuth.
+//
+// Those routes answer two different audiences at one URL: anonymously they are
+// the published, non-archived view, and to a signed-in editor they also carry
+// drafts and soft-deleted rows. Marking an editor's copy `public` would let a
+// shared cache hand unpublished headlines to a reader, so a request that
+// carries credentials is marked uncacheable instead.
+//
+// Vary names what distinguishes the two, since auth arrives either as the
+// `sid` cookie or as a bearer token. It is added rather than set so the
+// compression middleware's own Vary: Accept-Encoding survives. Note that
+// Cloudflare honours Vary only for Accept-Encoding, so the Vary here protects
+// standards-compliant caches and Scalene's fetch cache; a CDN rule that caches
+// this API must bypass on cookie rather than rely on it.
+func setPublicReadCache(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Vary", "Cookie")
+	w.Header().Add("Vary", "Authorization")
+	if _, isEditor := middleware.UserFromContext(r.Context()); isEditor {
+		w.Header().Set("Cache-Control", uncacheableCacheControl)
+		return
+	}
+	w.Header().Set("Cache-Control", publicReadCacheControl)
+}
+
+// setAlwaysPublicCache is setPublicReadCache for the reads that have no
+// authenticated form at all -- no auth middleware is registered on them, so
+// every caller gets the same bytes and there is nothing to Vary on.
+func setAlwaysPublicCache(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", publicReadCacheControl)
+}
+
 func requireArticleWriteRole(w http.ResponseWriter, r *http.Request) bool {
 	user, ok := middleware.UserFromContext(r.Context())
 	if !ok || (user.Role != models.RoleAdmin && user.Role != models.RoleEditor) {
@@ -979,6 +1025,7 @@ func GetAuthorArticles(conn *sql.DB) http.HandlerFunc {
 			articles = articles[:limit]
 		}
 
+		setPublicReadCache(w, r)
 		writeJSON(w, http.StatusOK, models.AuthorArticlesResponse{
 			Author: models.AuthorArticlesAuthor{
 				ID:          author.ID,
@@ -1051,6 +1098,7 @@ func GetArticles(conn *sql.DB) http.HandlerFunc {
 			articles = articles[:limit]
 		}
 
+		setPublicReadCache(w, r)
 		writeJSON(w, http.StatusOK, models.ArticlesResponse{
 			Articles:   articleListItems(articles, excerptWords, categoryPreferenceSlugs(params)...),
 			Pagination: paginationResponse(page, limit, offset, hasMore, totalCount),
@@ -1120,6 +1168,7 @@ func GetSectionArticles(conn *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		setPublicReadCache(w, r)
 		writeJSON(w, http.StatusOK, models.SectionArticlesResponse{
 			Section: models.TaxonomySummary{
 				Slug:           params.Section,
@@ -1196,6 +1245,7 @@ func GetSubsectionArticles(conn *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		setPublicReadCache(w, r)
 		writeJSON(w, http.StatusOK, models.SubsectionArticlesResponse{
 			Section: models.TaxonomySummary{
 				Slug:           params.Section,
@@ -1711,6 +1761,7 @@ func GetArticle(conn *sql.DB) http.HandlerFunc {
 		resp.PublishedDate = a.PublishedAt
 		resp.ModifiedDate = a.ModifiedAt
 
+		setPublicReadCache(w, r)
 		writeJSON(w, http.StatusOK, resp)
 	}
 }
@@ -1764,6 +1815,9 @@ func GetArticleComments(conn *sql.DB) http.HandlerFunc {
 			})
 		}
 
+		// No auth middleware on this route: the thread is the approved comments
+		// and nothing else, whoever is asking.
+		setAlwaysPublicCache(w)
 		writeJSON(w, http.StatusOK, models.ArticleCommentsResponse{
 			ArticleSlug: slug,
 			Comments:    resp,
@@ -2633,12 +2687,6 @@ func RestoreArticle(conn *sql.DB) http.HandlerFunc {
 	}
 }
 
-// homepageCacheControl bounds how long a featured-article change can take to
-// reach readers. 60s is short enough that an editor swapping the lead sees it
-// on the next reload rather than wondering whether the save worked, and long
-// enough that the homepage is not re-rendered per visitor.
-const homepageCacheControl = "public, max-age=60, stale-while-revalidate=300"
-
 // leadWithFeaturedArticle moves the featured article to the front of the
 // homepage news block. It is a no-op when nothing is featured, so the default
 // homepage stays newest-first.
@@ -2819,13 +2867,11 @@ func GetHomepage(conn *sql.DB) http.HandlerFunc {
 		}
 
 		// The homepage carries the editor's live decisions -- the featured lead,
-		// the breaking-news banner, the carousel -- so it needs a short, stated
-		// freshness bound. Without a Cache-Control header every intermediary
-		// picks its own heuristic, and Scalene's fetch cache has no expiry to
-		// respect at all, so "featured" could take an unbounded time to appear.
-		// stale-while-revalidate keeps that bound cheap: a spike is still served
-		// from cache while one request refreshes it behind the scenes.
-		w.Header().Set("Cache-Control", homepageCacheControl)
+		// the breaking-news banner, the carousel -- so it needs the shortest
+		// freshness bound of anything here, which is why publicReadCacheControl
+		// is set to one that suits it. The rest of the public reads inherited
+		// the same bound rather than each picking one.
+		setAlwaysPublicCache(w)
 		writeJSON(w, http.StatusOK, sectionArticles)
 	}
 }

--- a/server/internal/handlers/handlers_test.go
+++ b/server/internal/handlers/handlers_test.go
@@ -608,3 +608,75 @@ func TestCategoryPreferenceSlugsPrefersTheSubsection(t *testing.T) {
 		t.Errorf("got %v, want nothing for a listing with no section", got)
 	}
 }
+
+// The OptionalAuth routes answer two audiences at one URL. An editor's copy
+// carries drafts and soft-deleted rows, so marking it `public` would let a
+// shared cache hand unpublished headlines to a reader.
+func TestSetPublicReadCache_AnonymousIsCacheable(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles", nil)
+	rec := httptest.NewRecorder()
+
+	setPublicReadCache(rec, req)
+
+	if got := rec.Header().Get("Cache-Control"); got != publicReadCacheControl {
+		t.Errorf("Cache-Control = %q, want %q", got, publicReadCacheControl)
+	}
+}
+
+func TestSetPublicReadCache_EditorIsNotCacheable(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles", nil)
+	req = req.WithContext(middleware.ContextWithUser(req.Context(), &models.User{ID: 1, Role: models.RoleAdmin}))
+	rec := httptest.NewRecorder()
+
+	setPublicReadCache(rec, req)
+
+	if got := rec.Header().Get("Cache-Control"); got != uncacheableCacheControl {
+		t.Fatalf("Cache-Control = %q, want %q -- an editor's drafts must never be publicly cached", got, uncacheableCacheControl)
+	}
+	if strings.Contains(rec.Header().Get("Cache-Control"), "public") {
+		t.Error("an editor's response must not be marked public")
+	}
+}
+
+// Auth arrives either as the `sid` cookie or as a bearer token, so both name
+// the difference between the two audiences.
+func TestSetPublicReadCache_VariesOnCredentials(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles", nil)
+	rec := httptest.NewRecorder()
+
+	setPublicReadCache(rec, req)
+
+	vary := rec.Header().Values("Vary")
+	for _, want := range []string{"Cookie", "Authorization"} {
+		found := false
+		for _, got := range vary {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Vary %v is missing %q", vary, want)
+		}
+	}
+}
+
+// Added, not set: the compression middleware puts Vary: Accept-Encoding on
+// every response, and overwriting it would let a cache serve a gzipped body to
+// a client that cannot read it.
+func TestSetPublicReadCache_KeepsExistingVary(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/articles", nil)
+	rec := httptest.NewRecorder()
+	rec.Header().Add("Vary", "Accept-Encoding")
+
+	setPublicReadCache(rec, req)
+
+	found := false
+	for _, got := range rec.Header().Values("Vary") {
+		if got == "Accept-Encoding" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Vary %v dropped Accept-Encoding", rec.Header().Values("Vary"))
+	}
+}

--- a/server/internal/handlers/public_site.go
+++ b/server/internal/handlers/public_site.go
@@ -83,6 +83,7 @@ func GetSitemapSlugs(conn *sql.DB) http.Handler {
 			return
 		}
 
+		setAlwaysPublicCache(w)
 		writeJSON(w, http.StatusOK, slugs)
 	})
 }

--- a/server/internal/handlers/seo.go
+++ b/server/internal/handlers/seo.go
@@ -23,6 +23,7 @@ func GetSEOSettings(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusInternalServerError, "failed to fetch SEO settings")
 			return
 		}
+		setAlwaysPublicCache(w)
 		writeJSON(w, http.StatusOK, settings)
 	})
 }

--- a/server/internal/handlers/settings.go
+++ b/server/internal/handlers/settings.go
@@ -27,6 +27,7 @@ func GetSiteSettings(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusInternalServerError, "failed to fetch site settings")
 			return
 		}
+		setAlwaysPublicCache(w)
 		writeJSON(w, http.StatusOK, models.SiteSettingsResponse{SiteTitle: siteTitle})
 	})
 }
@@ -77,6 +78,7 @@ func GetBreakingNews(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusInternalServerError, "failed to fetch breaking-news settings")
 			return
 		}
+		setAlwaysPublicCache(w)
 		writeJSON(w, http.StatusOK, settings)
 	})
 }
@@ -131,6 +133,7 @@ func GetHomepageCarousel(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusInternalServerError, "failed to fetch homepage carousel settings")
 			return
 		}
+		setAlwaysPublicCache(w)
 		writeJSON(w, http.StatusOK, models.HomepageCarouselSettingsResponse{Slides: slides})
 	})
 }
@@ -181,6 +184,7 @@ func GetFooterSettings(conn *sql.DB) http.Handler {
 			writeError(w, http.StatusInternalServerError, "failed to fetch footer settings")
 			return
 		}
+		setAlwaysPublicCache(w)
 		writeJSON(w, http.StatusOK, settings)
 	})
 }


### PR DESCRIPTION
Follow-up to #212. Only `/v1/homepage` stated a freshness bound, so
everything else was left to whatever heuristic an intermediary picked —
and Scalene's fetch cache has no expiry to respect at all, which is why
the homepage got a header in the first place.

`public, max-age=60, stale-while-revalidate=300` (the bound the homepage
already used) now covers:

- `/v1/articles` and `/v1/articles/{slug}`
- `/v1/sections/{slug}/articles`, `/v1/subsections/{slug}/articles`
- `/v1/authors/{slug}/articles`
- `/v1/articles/{slug}/comments`
- `/v1/sitemap/slugs`
- `/v1/settings/{site,footer,seo,breaking-news,homepage-carousel}`

## The part worth reviewing

Five of those sit behind `OptionalAuth` and answer **two audiences at one
URL** — anonymously the published view, and to a signed-in editor the same
URL also carries drafts and soft-deleted rows. Marking an editor's copy
`public` would let a shared cache serve unpublished headlines to readers.

So the header depends on the caller: anonymous gets the public bound, a
request carrying credentials gets `private, no-store`. `Vary: Cookie,
Authorization` names the difference, added rather than set so the
compression middleware's `Vary: Accept-Encoding` survives.

**Cloudflare caveat, recorded on the helper:** CF honours `Vary` only for
`Accept-Encoding`. The `Vary` here protects standards-compliant caches and
Scalene's fetch cache — a CDN rule that caches this API needs to bypass on
cookie rather than rely on it.

## Deliberately excluded

- `/v1/articles/random` — caching it defeats the endpoint.
- `/v1/search` — query-string cardinality makes the hit rate poor.
- Everything behind `RequireAuth` — no public form to cache.

## Verification

- Response **bodies byte-identical to main** across all eleven endpoints
  against the real corpus. This is headers and nothing else.
- 404s and 500s carry no `Cache-Control`: the header is set immediately
  before the successful write, not at handler entry. A slug that 404s for
  sixty seconds because a reader beat the publish is a support ticket.
- Integration tests assert the editor branch through the real handler, and
  fail loudly if the draft isn't in the body so they can't pass vacuously.
- `go vet` clean, full suite including MariaDB integration tests passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
