### PR TITLE
Give every WordPress sub-category a home without a nav link

### DIFF
--- a/frontend/src/pages/sectionsView.tsx
+++ b/frontend/src/pages/sectionsView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { AlertTriangle, Columns3, Pencil, Plus, RefreshCw, Search, Trash2, X } from "lucide-react"
+import { AlertTriangle, Columns3, Eye, EyeOff, Pencil, Plus, RefreshCw, Search, Trash2, X } from "lucide-react"
 import { useApiFetch } from "../hooks/useApiFetch"
 
 type TaxonomyKind = "section" | "subsection"
@@ -12,6 +12,7 @@ type TaxonomyItem = {
   parent_slug?: string | null
   article_count: number
   category_aliases?: string[] | null
+  is_visible?: boolean
 }
 
 type SectionRow = {
@@ -31,6 +32,7 @@ type FormState = {
   // category name, so this is how a section whose slug differs from its
   // category ("entertainment" vs "Arts & Entertainment") finds its articles.
   categoryAliases: string
+  isVisible: boolean
 }
 
 type EditorState =
@@ -53,7 +55,13 @@ const emptyForm: FormState = {
   slug: "",
   parentSlug: "",
   categoryAliases: "",
+  isVisible: true,
 }
+
+// What hiding actually does, said in full, because two thirds of it is what it
+// does NOT do: a hidden item keeps its page and keeps feeding its section.
+const visibilityHint =
+  "Hidden items keep their own page and their articles still appear on the parent section, they just lose their link in the section's subsection list."
 
 // Article matching is exact, so a slug that is not the category name resolves
 // to nothing and the section page renders empty -- which reads as "no articles
@@ -94,6 +102,8 @@ export default function SectionsView() {
   const [deleteTarget, setDeleteTarget] = useState<TaxonomyItem | null>(null)
   const [form, setForm] = useState<FormState>(emptyForm)
   const [slugTouched, setSlugTouched] = useState(false)
+  const [togglingId, setTogglingId] = useState<number | null>(null)
+  const [showHidden, setShowHidden] = useState(true)
 
   const loadSections = useCallback(async () => {
     setIsLoading(true)
@@ -190,14 +200,24 @@ export default function SectionsView() {
 
   const filtered = useMemo(() => {
     const query = search.toLowerCase().trim()
-    if (!query) return rows
-    return rows.filter(({ item, parentTitle }) =>
+    // A hidden parent still has to show when its children are on screen, or the
+    // tree loses its root and the indented rows dangle.
+    const visibleRows = showHidden
+      ? rows
+      : rows.filter(({ item, childCount }) => item.is_visible !== false || childCount > 0)
+    if (!query) return visibleRows
+    return visibleRows.filter(({ item, parentTitle }) =>
       item.canonical_title.toLowerCase().includes(query)
       || item.slug.toLowerCase().includes(query)
       || typeLabel(item).toLowerCase().includes(query)
       || (parentTitle ?? "").toLowerCase().includes(query),
     )
-  }, [rows, search])
+  }, [rows, search, showHidden])
+
+  const hiddenCount = useMemo(
+    () => items.filter((item) => item.is_visible === false).length,
+    [items],
+  )
 
   const openCreate = (type: TaxonomyKind, parentSlug = "") => {
     const parentExists = parentSlug && parentSections.some((section) => section.slug === parentSlug)
@@ -218,6 +238,7 @@ export default function SectionsView() {
       slug: item.slug,
       parentSlug: item.parent_slug ?? "",
       categoryAliases: (item.category_aliases ?? []).join("\n"),
+      isVisible: item.is_visible !== false,
     })
     setSlugTouched(true)
     setError(null)
@@ -281,6 +302,7 @@ export default function SectionsView() {
         canonical_title: canonicalTitle,
         parent_slug: form.type === "subsection" ? parentSlug : null,
         category_aliases: categoryAliases,
+        is_visible: form.isVisible,
       }
 
       const response = editor.mode === "create"
@@ -289,15 +311,13 @@ export default function SectionsView() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         })
+        // The PUT is addressed by the item's CURRENT type and slug, while the
+        // body carries what it should become -- that is how a section is
+        // converted into a subsection.
         : await apiFetch(`/v1/taxonomy/${encodeURIComponent(editor.item.type)}/${encodeURIComponent(editor.item.slug)}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            slug,
-            canonical_title: canonicalTitle,
-            parent_slug: form.type === "subsection" ? parentSlug : null,
-            category_aliases: categoryAliases,
-          }),
+          body: JSON.stringify(body),
         })
 
       if (!response.ok) {
@@ -311,6 +331,42 @@ export default function SectionsView() {
       setError(err instanceof Error ? err.message : "Unable to save taxonomy item")
     } finally {
       setIsSaving(false)
+    }
+  }
+
+  // Visibility is the one field worth changing without opening the editor: it
+  // is how the desk curates the subsection strip, which is a lot of small
+  // yes/no decisions across 90-odd rows.
+  //
+  // category_aliases is deliberately absent from the body -- omitting it leaves
+  // the stored value alone, and a toggle must not be able to wipe the matching
+  // rules that keep a section's page full.
+  const toggleVisibility = async (item: TaxonomyItem) => {
+    const nextVisible = item.is_visible === false
+    setTogglingId(item.id)
+    setError(null)
+    try {
+      const response = await apiFetch(`/v1/taxonomy/${encodeURIComponent(item.type)}/${encodeURIComponent(item.slug)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: item.type,
+          slug: item.slug,
+          canonical_title: item.canonical_title,
+          parent_slug: item.parent_slug ?? null,
+          is_visible: nextVisible,
+        }),
+      })
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response))
+      }
+      setItems((current) => current.map((row) => (
+        row.id === item.id ? { ...row, is_visible: nextVisible } : row
+      )))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to change visibility")
+    } finally {
+      setTogglingId(null)
     }
   }
 
@@ -341,10 +397,21 @@ export default function SectionsView() {
         <div>
           <h1 className="text-2xl font-bold text-foreground">Sections</h1>
           <p className="text-sm text-muted-foreground mt-0.5">
-            {isLoading ? "Loading..." : `${parentSections.length} sections, ${items.filter((item) => item.type === "subsection").length} subsections`}
+            {isLoading
+              ? "Loading..."
+              : `${parentSections.length} sections, ${items.filter((item) => item.type === "subsection").length} subsections${hiddenCount > 0 ? `, ${hiddenCount} hidden` : ""}`}
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm font-medium hover:bg-muted/40 transition-colors"
+            type="button"
+            title={showHidden ? "Show only the items linked on section pages" : "Show every item, including hidden ones"}
+            onClick={() => setShowHidden((current) => !current)}
+          >
+            {showHidden ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            {showHidden ? "Hide hidden" : "Show hidden"}
+          </button>
           <button
             className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm font-medium hover:bg-muted/40 transition-colors"
             type="button"
@@ -398,21 +465,23 @@ export default function SectionsView() {
               <th className="text-left px-4 py-3 font-semibold text-muted-foreground">Type</th>
               <th className="text-left px-4 py-3 font-semibold text-muted-foreground">Slug</th>
               <th className="text-left px-4 py-3 font-semibold text-muted-foreground">Articles</th>
+              <th className="text-left px-4 py-3 font-semibold text-muted-foreground">Linked</th>
               <th className="text-right px-4 py-3 font-semibold text-muted-foreground">Actions</th>
             </tr>
           </thead>
           <tbody>
             {isLoading ? (
               <tr>
-                <td className="px-4 py-8 text-center text-muted-foreground" colSpan={5}>Loading sections...</td>
+                <td className="px-4 py-8 text-center text-muted-foreground" colSpan={6}>Loading sections...</td>
               </tr>
             ) : filtered.length === 0 ? (
               <tr>
-                <td className="px-4 py-8 text-center text-muted-foreground" colSpan={5}>No sections found.</td>
+                <td className="px-4 py-8 text-center text-muted-foreground" colSpan={6}>No sections found.</td>
               </tr>
             ) : (
               filtered.map(({ item, parentTitle, childCount, isChild, isLast }) => {
                 const articleCount = item.article_count ?? 0
+                const isVisible = item.is_visible !== false
                 const canDelete = articleCount === 0 && childCount === 0
                 const deleteTitle = articleCount > 0
                   ? "Cannot delete while articles use this item."
@@ -458,6 +527,22 @@ export default function SectionsView() {
                       </span>
                     </td>
                     <td className="px-4 py-3">
+                      <button
+                        className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium transition-colors disabled:opacity-50 ${
+                          isVisible
+                            ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-500 hover:bg-emerald-500/20"
+                            : "bg-muted text-muted-foreground hover:bg-muted/70"
+                        }`}
+                        type="button"
+                        disabled={togglingId === item.id}
+                        title={`${isVisible ? "Hide" : "Show"} ${item.canonical_title}. ${visibilityHint}`}
+                        onClick={() => void toggleVisibility(item)}
+                      >
+                        {isVisible ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />}
+                        {isVisible ? "Linked" : "Hidden"}
+                      </button>
+                    </td>
+                    <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-1">
                         <button
                           className="p-1.5 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
@@ -496,19 +581,24 @@ export default function SectionsView() {
               </button>
             </div>
             <div className="flex flex-col gap-4 px-5 py-4">
-              {editor.mode === "create" ? (
-                <label className="flex flex-col gap-1.5">
-                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Type</span>
-                  <select
-                    className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
-                    value={form.type}
-                    onChange={(event) => updateType(event.target.value as TaxonomyKind)}
-                  >
-                    <option value="section">Section</option>
-                    <option value="subsection">Subsection / Column</option>
-                  </select>
-                </label>
-              ) : null}
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Type</span>
+                <select
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                  value={form.type}
+                  onChange={(event) => updateType(event.target.value as TaxonomyKind)}
+                >
+                  <option value="section">Section</option>
+                  <option value="subsection">Subsection / Column</option>
+                </select>
+                {editor.mode === "edit" && form.type !== editor.item.type ? (
+                  <span className="text-xs text-amber-600 dark:text-amber-500">
+                    Changing the type moves this item&rsquo;s page between /sections and
+                    /subsections, so existing links to it will break. A section has to have
+                    no subsections of its own before it can become one.
+                  </span>
+                ) : null}
+              </label>
 
               <label className="flex flex-col gap-1.5">
                 <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Name</span>
@@ -563,6 +653,19 @@ export default function SectionsView() {
                   here whenever the name on the articles differs from the name above &mdash;
                   the Entertainment section holds articles filed under &ldquo;Arts &amp; Entertainment&rdquo;.
                   Leave empty when they match.
+                </span>
+              </label>
+
+              <label className="flex items-start gap-2.5">
+                <input
+                  className="mt-0.5 h-4 w-4 rounded border-border accent-primary"
+                  type="checkbox"
+                  checked={form.isVisible}
+                  onChange={(event) => setForm((current) => ({ ...current, isVisible: event.target.checked }))}
+                />
+                <span className="flex flex-col gap-0.5">
+                  <span className="text-sm text-foreground">Link this item on its section page</span>
+                  <span className="text-xs text-muted-foreground">{visibilityHint}</span>
                 </span>
               </label>
             </div>

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -5967,6 +5967,10 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "is_visible": {
+                    "description": "Pointer so an omitted field means \"visible\", which is what a client that\npredates visibility expects of anything it creates.",
+                    "type": "boolean"
+                },
                 "parent_slug": {
                     "type": "string"
                 },
@@ -5997,6 +6001,10 @@ const docTemplate = `{
                 "id": {
                     "type": "integer"
                 },
+                "is_visible": {
+                    "description": "IsVisible is whether the item earns a link in the subsection strip on its\nsection page. A hidden subsection is still browsable at its own URL and\nits articles still count towards its section; it simply has no nav entry.",
+                    "type": "boolean"
+                },
                 "parent_slug": {
                     "type": "string"
                 },
@@ -6021,10 +6029,18 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "is_visible": {
+                    "description": "Pointer so an omitted field leaves the stored visibility alone.",
+                    "type": "boolean"
+                },
                 "parent_slug": {
                     "type": "string"
                 },
                 "slug": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type converts a section to a subsection or back. Omitted leaves the kind\nalone, so a client that does not know about conversion cannot cause one.",
                     "type": "string"
                 }
             }

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -5964,6 +5964,10 @@
                         "type": "string"
                     }
                 },
+                "is_visible": {
+                    "description": "Pointer so an omitted field means \"visible\", which is what a client that\npredates visibility expects of anything it creates.",
+                    "type": "boolean"
+                },
                 "parent_slug": {
                     "type": "string"
                 },
@@ -5994,6 +5998,10 @@
                 "id": {
                     "type": "integer"
                 },
+                "is_visible": {
+                    "description": "IsVisible is whether the item earns a link in the subsection strip on its\nsection page. A hidden subsection is still browsable at its own URL and\nits articles still count towards its section; it simply has no nav entry.",
+                    "type": "boolean"
+                },
                 "parent_slug": {
                     "type": "string"
                 },
@@ -6018,10 +6026,18 @@
                         "type": "string"
                     }
                 },
+                "is_visible": {
+                    "description": "Pointer so an omitted field leaves the stored visibility alone.",
+                    "type": "boolean"
+                },
                 "parent_slug": {
                     "type": "string"
                 },
                 "slug": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type converts a section to a subsection or back. Omitted leaves the kind\nalone, so a client that does not know about conversion cannot cause one.",
                     "type": "string"
                 }
             }

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -1129,6 +1129,11 @@ definitions:
         items:
           type: string
         type: array
+      is_visible:
+        description: |-
+          Pointer so an omitted field means "visible", which is what a client that
+          predates visibility expects of anything it creates.
+        type: boolean
       parent_slug:
         type: string
       slug:
@@ -1153,6 +1158,12 @@ definitions:
         type: array
       id:
         type: integer
+      is_visible:
+        description: |-
+          IsVisible is whether the item earns a link in the subsection strip on its
+          section page. A hidden subsection is still browsable at its own URL and
+          its articles still count towards its section; it simply has no nav entry.
+        type: boolean
       parent_slug:
         type: string
       slug:
@@ -1171,9 +1182,17 @@ definitions:
         items:
           type: string
         type: array
+      is_visible:
+        description: Pointer so an omitted field leaves the stored visibility alone.
+        type: boolean
       parent_slug:
         type: string
       slug:
+        type: string
+      type:
+        description: |-
+          Type converts a section to a subsection or back. Omitted leaves the kind
+          alone, so a client that does not know about conversion cannot cause one.
         type: string
     type: object
   models.TaxonomySummary:

--- a/server/internal/database/schema/site_taxonomy.sql
+++ b/server/internal/database/schema/site_taxonomy.sql
@@ -10,6 +10,12 @@ CREATE TABLE IF NOT EXISTS site_taxonomy (
   -- "Arts & Entertainment". NULL means "never set" and is seeded with the
   -- known defaults; an empty array means an editor deliberately cleared it.
   category_aliases JSON NULL,
+  -- Whether the row earns a link in the subsection strip on its section page.
+  -- A hidden row is still a real subsection: its articles roll up to the
+  -- section and its own page still answers, it simply has no nav entry. That is
+  -- what the WordPress sub-categories need -- a home and a URL, not 48 more
+  -- links across seven section pages.
+  is_visible TINYINT(1) NOT NULL DEFAULT 1,
   UNIQUE KEY uq_site_taxonomy_kind_slug (kind, slug),
   KEY idx_site_taxonomy_kind (kind),
   KEY idx_site_taxonomy_parent_slug (parent_slug)

--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -30,10 +30,38 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 		return err
 	}
 
+	// Defaults to visible, so every row that predates the column keeps its link
+	// in the subsection strip. That is the freeze: the strip on each section
+	// page stays exactly what it is today, and everything seeded below arrives
+	// hidden.
+	if _, err = conn.ExecContext(ctx, `
+		ALTER TABLE site_taxonomy
+		ADD COLUMN IF NOT EXISTS is_visible TINYINT(1) NOT NULL DEFAULT 1
+	`); err != nil {
+		return err
+	}
+
 	if err = SeedDefaultCategoryAliases(ctx, conn); err != nil {
 		return err
 	}
-	return RefreshCategoryAliases(ctx, conn)
+	seeded, err := SeedLegacySubsections(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if err = RefreshCategoryAliases(ctx, conn); err != nil {
+		return err
+	}
+
+	if len(seeded) > 0 {
+		// After the refresh, because counting reads the alias cache the seed
+		// just added to. Not fatal: this runs before the article_categories
+		// index is built on a fresh database, and a wrong count is a number on
+		// a screen, recoverable by the next rebuild or by any edit to the row.
+		if err := RebuildTaxonomyArticleCountsFor(ctx, conn, seeded...); err != nil {
+			slog.Warn("failed to count articles for the newly seeded subsections; they will read 0 until the next rebuild", "error", err)
+		}
+	}
+	return nil
 }
 
 // defaultCategoryAliases are the categories a section has to answer to beyond
@@ -120,6 +148,223 @@ var defaultCategoryAliases = map[string][]string{
 	// Sponsored content, and the weakest of these calls: it is not news, but
 	// an advertiser paid for it to be visible and no section fits it better.
 	"news": {"Paid Post"},
+}
+
+// legacySubsection is a WordPress sub-category that never got a row of its own.
+type legacySubsection struct {
+	Slug   string
+	Title  string
+	Parent string
+}
+
+// legacySubsections are the WordPress categories that become real subsections,
+// hidden: they get a slug, a page, and a place in the tree, but no link in the
+// subsection strip on their section page.
+//
+// Two populations, both of which the taxonomy handled badly.
+//
+// The first is everything defaultCategoryAliases absorbs above. An alias makes a
+// section's page list the articles, which is most of what is needed, but it
+// leaves the category itself with no identity: "Men's Lacrosse" had no page, and
+// the category chip on those articles pointed at a URL nothing answered. A row
+// gives each one a page and makes the chip land somewhere.
+//
+// The second is the categories that matched nothing at all -- wrestling (103
+// published articles), Triangle Talks (73), Theater (28) and the rest. Those
+// articles appeared on no section page in the CMS or on the site. Filing each
+// under a section is what puts them back, since a section matches its own slug
+// or any of its children's.
+//
+// Every row carries its exact category title as an alias rather than trusting
+// the slug to derive it. Some do derive ("swimming-diving" expands to
+// "swimming & diving"), but "aint-that-something-with-brandon-liz" does not, and
+// a seed that silently half-works is the failure mode this whole file is about.
+//
+// The parent sections' aliases are deliberately left in place. They are what
+// keeps a section's page complete if one of these rows is ever deleted, and
+// duplicate match values cost nothing -- TaxonomyCountCondition de-duplicates.
+var legacySubsections = []legacySubsection{
+	// Sports. WordPress rolled a parent category over its children, so
+	// /category/sports/ listed these without anyone configuring it; flat
+	// matching here does not, which is what stranded them.
+	{"tennis", "Tennis", "sports"},
+	{"crew", "Crew", "sports"},
+	{"mens-lacrosse", "Men's Lacrosse", "sports"},
+	{"womens-lacrosse", "Women's Lacrosse", "sports"},
+	{"golf", "Golf", "sports"},
+	{"softball", "Softball", "sports"},
+	{"swimming-diving", "Swimming & Diving", "sports"},
+	{"running", "Running", "sports"},
+	{"athlete-of-the-week", "Athlete of the Week", "sports"},
+	{"wrestling", "Wrestling", "sports"},
+
+	// Entertainment. Style is the large one -- the beat plus its recurring
+	// features -- and sits here rather than under Opinion's Lifestyle because
+	// it is culture coverage, not opinion writing.
+	{"features", "Features", "entertainment"},
+	{"style", "Style", "entertainment"},
+	{"tv", "TV", "entertainment"},
+	{"theater", "Theater", "entertainment"},
+	{"beer-reviews", "Beer Reviews", "entertainment"},
+	{"wine-reviews", "Wine Reviews", "entertainment"},
+	{"restaurant-reviews", "Restaurant Reviews", "entertainment"},
+	{"last-call", "Last Call", "entertainment"},
+	{"exhibits", "Exhibits", "entertainment"},
+	{"reel2reel", "Reel2Reel", "entertainment"},
+	{"street-style", "Street Style", "entertainment"},
+	{"style-guide", "Style Guide", "entertainment"},
+	{"beauty-guide", "Beauty Guide", "entertainment"},
+	{"designer-profile", "Designer Profile", "entertainment"},
+	{"store-profile", "Store Profile", "entertainment"},
+	{"inside-her-bag", "Inside Her Bag", "entertainment"},
+	{"fashion-week", "Fashion Week", "entertainment"},
+	{"diy", "DIY", "entertainment"},
+
+	// Opinion's own voice: neither editorials nor letters are filed under it.
+	{"editorial", "Editorial", "opinion"},
+	{"letters-to-the-editor", "Letters to the Editor", "opinion"},
+	{"commentary", "Commentary", "opinion"},
+
+	// Columns is where recurring bylined series live, which is what the
+	// podcasts are -- "Mark and Jair Explain Sports" is a show, not a sports
+	// article, and a row keeps it out of Sports despite the name.
+	{"podcasts", "Podcasts", "columns"},
+	{"mark-and-jair-explain-sports", "Mark and Jair Explain Sports", "columns"},
+	{"aint-that-something-with-brandon-liz", "Ain't That Something With Brandon & Liz", "columns"},
+	{"you-me-buscemi", "You, Me, Buscemi", "columns"},
+	{"polkadot-tea-pot", "Polkadot Tea.Pot", "columns"},
+	{"wheres-mario", "Where's Mario", "columns"},
+	{"student-snapshot", "Student Snapshot", "columns"},
+	{"triangle-talks", "Triangle Talks", "columns"},
+	{"triangle-sports-talk", "Triangle Sports Talk", "columns"},
+	{"sadie-says", "Sadie Says", "columns"},
+	{"tech-tuesday", "Tech Tuesday", "columns"},
+	{"dear-granny-and-eloise", "Dear Granny and Eloise", "columns"},
+	{"movies-ive-seen", "Movies I've Seen", "columns"},
+	{"humans-of-drexel", "Humans of Drexel", "columns"},
+
+	{"word-search", "Word Search", "comics-puzzles"},
+
+	{"administration", "Administration", "news"},
+	{"sjn-grant", "SJN Grant", "news"},
+}
+
+// SeedLegacySubsections inserts legacySubsections as hidden subsections, once,
+// and returns the slugs it created.
+//
+// Once, and recorded in cms_settings, because these rows are editable: an editor
+// who deletes "Reel2Reel" or renames it must not find it back after the next
+// deploy. The flag is set even when nothing was inserted, since "already has
+// every row" and "already ran" want the same outcome.
+//
+// A row whose slug is taken is skipped rather than updated, for the same reason:
+// an existing row is somebody's, not ours. A row whose parent section is missing
+// is skipped too -- parent_slug has to reference a real section, and a
+// subsection orphaned under a name nothing answers is worse than one more
+// uncategorized category.
+//
+// An empty table is not "nothing to skip", it is "the sections have not been
+// imported yet", so it returns without recording the flag and tries again next
+// boot. Otherwise a server that starts before its seed import would burn the
+// one run it gets and skip all 48 rows.
+func SeedLegacySubsections(ctx context.Context, conn *sql.DB) ([]string, error) {
+	if conn == nil {
+		return nil, nil
+	}
+
+	// The run-once flag lives in cms_settings, so without that table there is no
+	// way to seed exactly once -- and seeding repeatedly would resurrect rows an
+	// editor deleted. Production creates it well before this runs; a database
+	// without it is a test fixture or a half-built schema, and skipping is the
+	// safe answer for both.
+	var settingsTableExists int
+	if err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'cms_settings'",
+	).Scan(&settingsTableExists); err != nil {
+		return nil, err
+	}
+	if settingsTableExists == 0 {
+		return nil, nil
+	}
+
+	var done string
+	switch err := conn.QueryRowContext(ctx,
+		"SELECT value_text FROM cms_settings WHERE key_name = 'legacy_subsections_seeded' LIMIT 1",
+	).Scan(&done); err {
+	case nil:
+		if strings.TrimSpace(done) == "1" {
+			return nil, nil
+		}
+	case sql.ErrNoRows:
+		// Not yet seeded.
+	default:
+		return nil, err
+	}
+
+	sections, err := existingSlugsByKind(ctx, conn, "section")
+	if err != nil {
+		return nil, err
+	}
+	if len(sections) == 0 {
+		return nil, nil
+	}
+	subsections, err := existingSlugsByKind(ctx, conn, "subsection")
+	if err != nil {
+		return nil, err
+	}
+
+	var nextID int64
+	if err := conn.QueryRowContext(ctx, "SELECT COALESCE(MAX(id), 0) FROM site_taxonomy").Scan(&nextID); err != nil {
+		return nil, err
+	}
+
+	inserted := make([]string, 0, len(legacySubsections))
+	for _, item := range legacySubsections {
+		if _, taken := subsections[item.Slug]; taken {
+			continue
+		}
+		if _, ok := sections[item.Parent]; !ok {
+			slog.Warn("skipping legacy subsection whose parent section is missing",
+				"slug", item.Slug, "parent_slug", item.Parent)
+			continue
+		}
+		aliases, err := MarshalCategoryJSON([]string{item.Title})
+		if err != nil {
+			return nil, err
+		}
+		nextID++
+		if _, err := conn.ExecContext(ctx, `
+			INSERT INTO site_taxonomy
+				(id, kind, slug, canonical_title, parent_slug, article_count, category_aliases, is_visible)
+			VALUES (?, 'subsection', ?, ?, ?, 0, ?, 0)
+		`, nextID, item.Slug, item.Title, item.Parent, aliases); err != nil {
+			return nil, err
+		}
+		inserted = append(inserted, item.Slug)
+	}
+
+	if len(inserted) > 0 {
+		slog.Info("seeded legacy WordPress sub-categories as hidden subsections", "count", len(inserted))
+	}
+	return inserted, writeSettingRaw(ctx, conn, "legacy_subsections_seeded", "1")
+}
+
+func existingSlugsByKind(ctx context.Context, conn *sql.DB, kind string) (map[string]struct{}, error) {
+	rows, err := conn.QueryContext(ctx, "SELECT slug FROM site_taxonomy WHERE kind = ?", kind)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	slugs := make(map[string]struct{})
+	for rows.Next() {
+		var slug string
+		if err := rows.Scan(&slug); err != nil {
+			return nil, err
+		}
+		slugs[strings.TrimSpace(slug)] = struct{}{}
+	}
+	return slugs, rows.Err()
 }
 
 func SeedDefaultCategoryAliases(ctx context.Context, conn *sql.DB) error {

--- a/server/internal/database/taxonomy_integration_test.go
+++ b/server/internal/database/taxonomy_integration_test.go
@@ -242,3 +242,99 @@ func TestRefreshLoadsCategoryTitlesAndPrefersARealPage(t *testing.T) {
 		t.Errorf("aliased-only category = %q, want %q", got, want)
 	}
 }
+
+// TestLegacySubsectionSeedRunsOnceAndStaysHidden covers the three properties
+// the WordPress sub-category seed has to have.
+//
+// Hidden, because 48 more links across seven section pages is not navigation.
+// Once, because these rows are editable and a deploy must not undo an editor's
+// deletion. And skipping a row whose slug is taken, because an existing row is
+// somebody's, not the seed's.
+func TestLegacySubsectionSeedRunsOnceAndStaysHidden(t *testing.T) {
+	conn := taxonomyTestDB(t)
+	ctx := context.Background()
+
+	if err := EnsureSettingsTable(ctx, conn); err != nil {
+		t.Fatalf("ensure settings table: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		"DELETE FROM cms_settings WHERE key_name = 'legacy_subsections_seeded'",
+	); err != nil {
+		t.Fatalf("clear the seed flag: %v", err)
+	}
+
+	// An empty taxonomy means the sections have not been imported yet, not that
+	// there is nothing to do. Seeding here would burn the one run and file 48
+	// rows under parents that do not exist.
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("ensure taxonomy table: %v", err)
+	}
+	if count := countRows(t, conn, "SELECT COUNT(*) FROM site_taxonomy"); count != 0 {
+		t.Fatalf("seeded %d rows into an empty taxonomy, want none until the sections exist", count)
+	}
+
+	insertTaxonomyRow(t, conn, 1, "section", "sports", "Sports")
+	insertTaxonomyRow(t, conn, 2, "section", "entertainment", "Entertainment")
+	// An existing row the seed also knows about, deliberately visible, to prove
+	// the seed leaves it alone rather than hiding or rewriting it.
+	insertTaxonomyRow(t, conn, 3, "subsection", "tennis", "Tennis")
+	if _, err := conn.ExecContext(ctx,
+		"UPDATE site_taxonomy SET parent_slug = 'sports' WHERE slug = 'tennis'",
+	); err != nil {
+		t.Fatalf("parent the existing row: %v", err)
+	}
+
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+
+	// Everything under the two sections that exist, and nothing under the ones
+	// that do not.
+	seeded := countRows(t, conn, "SELECT COUNT(*) FROM site_taxonomy WHERE kind = 'subsection'")
+	var want int
+	for _, item := range legacySubsections {
+		if (item.Parent == "sports" || item.Parent == "entertainment") && item.Slug != "tennis" {
+			want++
+		}
+	}
+	if seeded != int64(want+1) { // +1 for the pre-existing tennis row
+		t.Fatalf("seeded %d subsections, want %d", seeded, want+1)
+	}
+	if visible := countRows(t, conn,
+		"SELECT COUNT(*) FROM site_taxonomy WHERE kind = 'subsection' AND is_visible = 1",
+	); visible != 1 {
+		t.Errorf("%d visible subsections, want only the pre-existing one -- the seed must arrive hidden", visible)
+	}
+
+	// Each seeded row carries its exact category title, so matching does not
+	// depend on the slug happening to derive it.
+	if got := CategoryMatchValues("street-style"); !containsValue(got, "street style") {
+		t.Errorf("values = %v, want the seeded category title", got)
+	}
+	// A slug that does not derive its own category is exactly why the seed
+	// writes the title as an alias -- but only for rows it actually created,
+	// and this one's parent section is absent here.
+	if got := CategoryMatchValues("aint-that-something-with-brandon-liz"); containsValue(got, "ain't that something with brandon & liz") {
+		t.Errorf("values = %v, want no alias -- that row was skipped for a missing parent", got)
+	}
+
+	// The run-once guard: a deleted row stays deleted across a restart.
+	if _, err := conn.ExecContext(ctx, "DELETE FROM site_taxonomy WHERE slug = 'crew'"); err != nil {
+		t.Fatalf("delete a seeded row: %v", err)
+	}
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("third ensure: %v", err)
+	}
+	if count := countRows(t, conn, "SELECT COUNT(*) FROM site_taxonomy WHERE slug = 'crew'"); count != 0 {
+		t.Error("a deleted seed row came back on the next start")
+	}
+}
+
+func countRows(t *testing.T, conn *sql.DB, query string) int64 {
+	t.Helper()
+	var count int64
+	if err := conn.QueryRowContext(context.Background(), query).Scan(&count); err != nil {
+		t.Fatalf("count (%s): %v", query, err)
+	}
+	return count
+}

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -204,6 +204,15 @@ func canonicalTitleForTaxonomy(ctx context.Context, conn *sql.DB, kind, slug str
 	return title, nil
 }
 
+// subsectionsForSection is the subsection strip on a section page: the links a
+// reader gets offered, not every subsection that exists.
+//
+// Hidden rows are left out on purpose. Most of the WordPress sub-categories are
+// subsections in every structural sense -- their articles roll up to the
+// section, and /v1/subsections/{slug}/articles answers for them -- but a strip
+// of 30 links is not navigation. The desk decides which ones are worth a link
+// on the sections screen; everything else stays reachable by URL and by the
+// category chip on an article.
 func subsectionsForSection(ctx context.Context, conn *sql.DB, sectionSlug string) ([]models.TaxonomySummary, error) {
 	trimmedSection := strings.TrimSpace(sectionSlug)
 	if trimmedSection == "" {
@@ -212,7 +221,7 @@ func subsectionsForSection(ctx context.Context, conn *sql.DB, sectionSlug string
 
 	rows, err := conn.QueryContext(
 		ctx,
-		"SELECT slug, canonical_title FROM site_taxonomy WHERE kind = 'subsection' AND parent_slug = ? ORDER BY id ASC",
+		"SELECT slug, canonical_title FROM site_taxonomy WHERE kind = 'subsection' AND parent_slug = ? AND is_visible = 1 ORDER BY id ASC",
 		trimmedSection,
 	)
 	if err != nil {

--- a/server/internal/handlers/taxonomy.go
+++ b/server/internal/handlers/taxonomy.go
@@ -27,13 +27,13 @@ func isValidTaxonomyType(taxType string) bool {
 // taxonomySelectColumns is the column list every taxonomy read shares, kept in
 // one place so a new column cannot be added to some queries and missed by
 // others -- scanTaxonomyRow depends on this exact order.
-const taxonomySelectColumns = "id, kind, slug, canonical_title, parent_slug, article_count, category_aliases"
+const taxonomySelectColumns = "id, kind, slug, canonical_title, parent_slug, article_count, category_aliases, is_visible"
 
 func scanTaxonomyRow(row interface{ Scan(...any) error }) (models.TaxonomyItem, error) {
 	var item models.TaxonomyItem
 	var parentSlug sql.NullString
 	var aliases sql.NullString
-	if err := row.Scan(&item.ID, &item.Type, &item.Slug, &item.CanonicalTitle, &parentSlug, &item.ArticleCount, &aliases); err != nil {
+	if err := row.Scan(&item.ID, &item.Type, &item.Slug, &item.CanonicalTitle, &parentSlug, &item.ArticleCount, &aliases, &item.IsVisible); err != nil {
 		return models.TaxonomyItem{}, err
 	}
 	if parentSlug.Valid && parentSlug.String != "" {
@@ -338,9 +338,14 @@ func PostTaxonomy(conn *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		isVisible := true
+		if body.IsVisible != nil {
+			isVisible = *body.IsVisible
+		}
+
 		_, err = db.Insert(r.Context(), conn, "site_taxonomy",
-			[]string{"id", "kind", "slug", "canonical_title", "parent_slug", "article_count", "category_aliases"},
-			nextID, taxType, slug, title, parentSlug, 0, aliases,
+			[]string{"id", "kind", "slug", "canonical_title", "parent_slug", "article_count", "category_aliases", "is_visible"},
+			nextID, taxType, slug, title, parentSlug, 0, aliases, isVisible,
 		)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -403,7 +408,55 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			}
 		}
 
-		parentSlug, err := validateTaxonomyParent(r.Context(), conn, taxType, body.ParentSlug)
+		// An omitted type leaves the kind alone, so a client that predates
+		// conversion cannot cause one by echoing back a row it did not change.
+		newType := taxType
+		if strings.TrimSpace(body.Type) != "" {
+			newType = strings.TrimSpace(body.Type)
+			if !isValidTaxonomyType(newType) {
+				writeError(w, http.StatusBadRequest, "type must be one of: section, subsection, tag")
+				return
+			}
+		}
+		if newType != taxType {
+			// Tags are a different vocabulary, not a level of the section tree:
+			// they have no parent, no page of their own, and nothing that a
+			// section's rules would mean anything for. Only the two levels of
+			// the tree convert into each other.
+			if taxType == string(models.TaxonomyTypeTag) || newType == string(models.TaxonomyTypeTag) {
+				writeError(w, http.StatusBadRequest, "only sections and subsections can be converted into each other")
+				return
+			}
+			if conn != nil {
+				// A subsection cannot parent another subsection, so a section
+				// with children has to be emptied before it can become one.
+				if taxType == string(models.TaxonomyTypeSection) {
+					hasChildren, err := taxonomySectionHasChildren(r.Context(), conn, slug)
+					if err != nil {
+						writeError(w, http.StatusInternalServerError, err.Error())
+						return
+					}
+					if hasChildren {
+						writeError(w, http.StatusBadRequest, "section cannot become a subsection while subsections use it")
+						return
+					}
+				}
+				// (kind, slug) is unique, so the conversion can collide with a
+				// row that already holds the destination. Say which, rather
+				// than surfacing a driver-level duplicate-key error as a 500.
+				taken, err := taxonomyItemExists(r.Context(), conn, newType, newSlug)
+				if err != nil {
+					writeError(w, http.StatusInternalServerError, err.Error())
+					return
+				}
+				if taken {
+					writeError(w, http.StatusBadRequest, fmt.Sprintf("a %s with the slug %q already exists", newType, newSlug))
+					return
+				}
+			}
+		}
+
+		parentSlug, err := validateTaxonomyParent(r.Context(), conn, newType, body.ParentSlug)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
@@ -438,8 +491,12 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 		// Omitting category_aliases leaves the stored value alone; sending []
 		// clears it. Without that distinction, every edit made from a client
 		// that does not know about aliases would silently wipe them.
-		columns := []string{"slug", "canonical_title", "parent_slug"}
-		values := []any{newSlug, title, parentSlug}
+		columns := []string{"kind", "slug", "canonical_title", "parent_slug"}
+		values := []any{newType, newSlug, title, parentSlug}
+		if body.IsVisible != nil {
+			columns = append(columns, "is_visible")
+			values = append(values, *body.IsVisible)
+		}
 		if body.CategoryAliases != nil {
 			aliases, err := normalizeCategoryAliases(*body.CategoryAliases)
 			if err != nil {

--- a/server/internal/handlers/taxonomy_integration_test.go
+++ b/server/internal/handlers/taxonomy_integration_test.go
@@ -506,3 +506,170 @@ func indexArticleCategories(t *testing.T, conn *sql.DB) {
 		t.Fatalf("rebuild article categories: %v", err)
 	}
 }
+
+// TestTaxonomyHTTPHiddenSubsectionKeepsEverythingButItsLink is the whole
+// contract of visibility, in one test, because the interesting half is what
+// hiding does NOT do.
+//
+// A hidden subsection loses its entry in the section's subsection strip. It
+// keeps its row, its articles, its own listing, and its contribution to the
+// parent section's page -- which is what makes it usable for the WordPress
+// sub-categories: 48 more categories with homes, and not 48 more nav links.
+func TestTaxonomyHTTPHiddenSubsectionKeepsEverythingButItsLink(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+	ctx := context.Background()
+
+	for _, body := range []map[string]any{
+		{"type": "section", "slug": "sports", "canonical_title": "Sports"},
+		{"type": "subsection", "slug": "squash", "canonical_title": "Squash", "parent_slug": "sports"},
+		{"type": "subsection", "slug": "crew", "canonical_title": "Crew", "parent_slug": "sports", "is_visible": false},
+	} {
+		if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", body).Code; code != http.StatusCreated {
+			t.Fatalf("POST %v = %d", body, code)
+		}
+	}
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO articles (id, categories, pub_date) VALUES (1, '["Crew"]', UTC_TIMESTAMP())`,
+	); err != nil {
+		t.Fatalf("insert article: %v", err)
+	}
+	indexArticleCategories(t, conn)
+
+	// The strip: the visible one only.
+	subsections, err := subsectionsForSection(ctx, conn, "sports")
+	if err != nil {
+		t.Fatalf("subsections for section: %v", err)
+	}
+	if len(subsections) != 1 || subsections[0].Slug != "squash" {
+		t.Fatalf("strip = %v, want only the visible subsection", subsections)
+	}
+
+	// The tree: both, or the section page loses the hidden one's articles.
+	matched, err := sectionMatchSlugs(ctx, conn, "sports")
+	if err != nil {
+		t.Fatalf("section match slugs: %v", err)
+	}
+	if len(matched) != 3 {
+		t.Errorf("section matches %v, want the hidden subsection included", matched)
+	}
+
+	// Its own page still resolves.
+	parent, ok, err := parentSectionForSubsection(ctx, conn, "crew")
+	if err != nil {
+		t.Fatalf("parent for subsection: %v", err)
+	}
+	if !ok || parent != "sports" {
+		t.Errorf("parent of the hidden subsection = %q/%v, want sports -- its page must still answer", parent, ok)
+	}
+
+	// And its article still counts, for it and for the section above it.
+	if err := db.RebuildTaxonomyArticleCounts(ctx, conn); err != nil {
+		t.Fatalf("rebuild counts: %v", err)
+	}
+	items := getTaxonomyItems(t, conn)
+	if got := findItem(t, items, "crew").ArticleCount; got != 1 {
+		t.Errorf("hidden subsection count = %d, want 1", got)
+	}
+	if got := findItem(t, items, "sports").ArticleCount; got != 1 {
+		t.Errorf("section count = %d, want 1 -- a hidden child still feeds its section", got)
+	}
+}
+
+// TestTaxonomyHTTPVisibilityRoundTrips covers the sections screen's toggle: the
+// default is visible, an explicit false sticks, and an omitted field leaves the
+// stored value alone the way category_aliases does.
+func TestTaxonomyHTTPVisibilityRoundTrips(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+
+	if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":            "section",
+		"slug":            "food",
+		"canonical_title": "Food",
+	}).Code; code != http.StatusCreated {
+		t.Fatalf("POST = %d", code)
+	}
+	if !findItem(t, getTaxonomyItems(t, conn), "food").IsVisible {
+		t.Fatal("a created item defaults to hidden, want visible")
+	}
+
+	if code := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/food", map[string]any{
+		"slug":            "food",
+		"canonical_title": "Food",
+		"parent_slug":     nil,
+		"is_visible":      false,
+	}).Code; code != http.StatusNoContent {
+		t.Fatalf("PUT hiding = %d", code)
+	}
+	if findItem(t, getTaxonomyItems(t, conn), "food").IsVisible {
+		t.Fatal("item still visible after being hidden")
+	}
+
+	// A rename that says nothing about visibility must not unhide it.
+	if code := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/food", map[string]any{
+		"slug":            "food",
+		"canonical_title": "Food & Drink",
+		"parent_slug":     nil,
+	}).Code; code != http.StatusNoContent {
+		t.Fatalf("PUT rename = %d", code)
+	}
+	if findItem(t, getTaxonomyItems(t, conn), "food").IsVisible {
+		t.Error("an unrelated edit unhid the item")
+	}
+}
+
+// TestTaxonomyHTTPConvertsBetweenSectionAndSubsection covers the conversion the
+// sections screen offers, in both directions, plus the guard that keeps it from
+// leaving a subsection parented to something that is no longer a section.
+func TestTaxonomyHTTPConvertsBetweenSectionAndSubsection(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+
+	for _, body := range []map[string]any{
+		{"type": "section", "slug": "sports", "canonical_title": "Sports"},
+		{"type": "section", "slug": "esports", "canonical_title": "Esports"},
+		{"type": "subsection", "slug": "squash", "canonical_title": "Squash", "parent_slug": "sports"},
+	} {
+		if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", body).Code; code != http.StatusCreated {
+			t.Fatalf("POST %v = %d", body, code)
+		}
+	}
+
+	// A section with children cannot become one: a subsection cannot parent a
+	// subsection.
+	refused := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/sports", map[string]any{
+		"type":            "subsection",
+		"slug":            "sports",
+		"canonical_title": "Sports",
+		"parent_slug":     "esports",
+	})
+	if refused.Code != http.StatusBadRequest {
+		t.Fatalf("converting a section with children = %d, want 400: %s", refused.Code, refused.Body.String())
+	}
+
+	// A childless one can.
+	if code := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/esports", map[string]any{
+		"type":            "subsection",
+		"slug":            "esports",
+		"canonical_title": "Esports",
+		"parent_slug":     "sports",
+	}).Code; code != http.StatusNoContent {
+		t.Fatalf("section -> subsection = %d", code)
+	}
+	converted := findItem(t, getTaxonomyItems(t, conn), "esports")
+	if converted.Type != "subsection" || converted.ParentSlug == nil || *converted.ParentSlug != "sports" {
+		t.Fatalf("converted item = %+v, want a subsection of sports", converted)
+	}
+
+	// And back, addressed by what it is now.
+	if code := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/subsection/squash", map[string]any{
+		"type":            "section",
+		"slug":            "squash",
+		"canonical_title": "Squash",
+		"parent_slug":     nil,
+	}).Code; code != http.StatusNoContent {
+		t.Fatalf("subsection -> section = %d", code)
+	}
+	promoted := findItem(t, getTaxonomyItems(t, conn), "squash")
+	if promoted.Type != "section" || promoted.ParentSlug != nil {
+		t.Fatalf("promoted item = %+v, want a parentless section", promoted)
+	}
+}

--- a/server/internal/models/types.go
+++ b/server/internal/models/types.go
@@ -288,6 +288,10 @@ type TaxonomyItem struct {
 	// section is filed under "Arts & Entertainment"). Article matching is
 	// exact, so a slug that is not the category string needs one of these.
 	CategoryAliases []string `json:"category_aliases"`
+	// IsVisible is whether the item earns a link in the subsection strip on its
+	// section page. A hidden subsection is still browsable at its own URL and
+	// its articles still count towards its section; it simply has no nav entry.
+	IsVisible bool `json:"is_visible"`
 }
 
 type TaxonomyInput struct {
@@ -296,12 +300,20 @@ type TaxonomyInput struct {
 	CanonicalTitle  string   `json:"canonical_title"`
 	ParentSlug      *string  `json:"parent_slug,omitempty"`
 	CategoryAliases []string `json:"category_aliases,omitempty"`
+	// Pointer so an omitted field means "visible", which is what a client that
+	// predates visibility expects of anything it creates.
+	IsVisible *bool `json:"is_visible,omitempty"`
 }
 
 type TaxonomyPut struct {
+	// Type converts a section to a subsection or back. Omitted leaves the kind
+	// alone, so a client that does not know about conversion cannot cause one.
+	Type           string  `json:"type,omitempty"`
 	Slug           string  `json:"slug,omitempty"`
 	CanonicalTitle string  `json:"canonical_title"`
 	ParentSlug     *string `json:"parent_slug,omitempty"`
+	// Pointer so an omitted field leaves the stored visibility alone.
+	IsVisible *bool `json:"is_visible,omitempty"`
 	// Pointer so an omitted field leaves the stored aliases alone, while an
 	// explicit [] clears them.
 	CategoryAliases *[]string `json:"category_aliases,omitempty"`


### PR DESCRIPTION
## What

Freezes the subsection strip as it looks today, then files the WordPress sub-categories the import left behind as **hidden** subsections: a slug, a page and a place in the tree, but no link in the strip. Editors get full control of the row, including visibility and section ↔ subsection conversion.

## Why

The taxonomy had two ways to hold a category and neither fit these. A subsection row gave a category a page *and* a nav link; an alias gave it neither, only a way to reach its section's page. So a category either joined the navigation or stayed anonymous — and 48 stayed anonymous, including 13 that matched nothing at all:

| category | published articles | appeared on |
|---|---|---|
| `wrestling` | 103 | nothing |
| `triangle talks` | 73 | nothing |
| `theater` | 28 | nothing |
| `sadie says`, `tech tuesday`, `wine reviews`, `administration`, `sjn grant`, … | ~90 combined | nothing |

The other ~35 (`tennis`, `crew`, `men's lacrosse`, `style`, `tv`, `beer reviews`, `editorial`, `letters to the editor`, `podcasts`, `word search`, …) reached a section only through a `category_aliases` entry, so the category itself had no identity or page.

## How

- **`site_taxonomy.is_visible`**, added by a runtime `ALTER`, defaulting to `1`. That's the freeze: all 44 existing subsections keep their links unchanged, and everything seeded arrives hidden.
- **Only `subsectionsForSection` filters on it.** `sectionMatchSlugs`, `taxonomyMatchSlugs` and `parentSectionForSubsection` are untouched, so a hidden subsection's articles still roll up to its section, its own `/v1/subsections/<slug>/articles` still answers, and its counts still work.
- **The seed runs once**, flagged in `cms_settings`, because these rows are editable and a deploy must not undo an editor's deletion. It skips a slug already taken, and defers entirely against an empty taxonomy rather than burning its one run before the sections are imported. Each row carries its exact category title as an alias rather than trusting the slug to derive it.
- **`PUT /v1/taxonomy/{type}/{slug}`** now accepts `type` and `is_visible`, both omit-safe so a client that doesn't send them changes nothing. Conversion refuses to demote a section that still has children, and answers a `(kind, slug)` collision with a 400 instead of a driver-level 500. The slug guard is unchanged — renaming a slug that articles use still breaks live URLs.
- **Sections screen**: a Linked/Hidden column with a one-click toggle (which omits `category_aliases`, so it can't wipe matching rules), a show/hide filter, a Type select in edit mode with a URL-breakage warning, and a visibility checkbox in the editor.

## Testing

`go build`; full `go test` including the DB-backed integration suites against a real MariaDB 11.8, with new tests for the seed's run-once / hidden / skip-taken properties, the visibility round-trip, and conversion in both directions; `tsc`; eslint; `npm run build`; swagger regenerated; Playwright screenshots of the sections screen and its editor.

## Note for whoever deploys this

On the first boot the seed runs and recounts the rows it created, so the counts on the sections screen jump for Sports, Entertainment, Opinion, Columns and News. That's the previously stranded articles arriving, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)