### PR TITLE
Let a subsection hang under another subsection

### DIFF
--- a/frontend/src/pages/sectionsView.tsx
+++ b/frontend/src/pages/sectionsView.tsx
@@ -21,7 +21,17 @@ type SectionRow = {
   childCount: number
   isChild: boolean
   isLast: boolean
+  // How far from a section this row sits: 0 for a section, 1 for a subsection,
+  // 2 for a subsection of a subsection. The tree is three levels deep now (A&E
+  // > Food > Beer Reviews), so indentation cannot be a boolean any more.
+  depth: number
 }
+
+// How deep the tree may go, counting the section. Mirrors MaxTaxonomyDepth on
+// the server, which is the side that enforces it -- this copy only decides which
+// rows the parent picker offers, so that the editor does not present a choice
+// the save would reject.
+const MAX_DEPTH = 3
 
 type FormState = {
   type: TaxonomyKind
@@ -146,57 +156,126 @@ export default function SectionsView() {
       })
   }, [items])
 
-  const rows = useMemo(() => {
-    const children = items
-      .filter((item) => item.type === "subsection")
-      .sort((left, right) => left.canonical_title.localeCompare(right.canonical_title))
-
-    const childrenByParent = new Map<string, TaxonomyItem[]>()
-    for (const child of children) {
+  const childrenByParent = useMemo(() => {
+    const grouped = new Map<string, TaxonomyItem[]>()
+    for (const child of items.filter((item) => item.type === "subsection")) {
       const parentSlug = child.parent_slug ?? ""
-      if (!childrenByParent.has(parentSlug)) {
-        childrenByParent.set(parentSlug, [])
+      if (!grouped.has(parentSlug)) {
+        grouped.set(parentSlug, [])
       }
-      childrenByParent.get(parentSlug)?.push(child)
+      grouped.get(parentSlug)?.push(child)
     }
+    for (const group of grouped.values()) {
+      group.sort((left, right) => left.canonical_title.localeCompare(right.canonical_title))
+    }
+    return grouped
+  }, [items])
 
+  const rows = useMemo(() => {
     const nextRows: SectionRow[] = []
-    const renderedChildren = new Set<number>()
+    const rendered = new Set<number>()
 
-    for (const parent of parentSections) {
-      const parentChildren = childrenByParent.get(parent.slug) ?? []
+    // Recursive, because the tree is three levels: a section, its subsections,
+    // and theirs. The rendered set doubles as the cycle guard -- this walks
+    // server data, and a row that somehow parented an ancestor would otherwise
+    // loop forever and hang the screen rather than showing a broken tree.
+    const pushSubtree = (item: TaxonomyItem, parentTitle: string | null, depth: number, isLast: boolean) => {
+      if (rendered.has(item.id)) return
+      rendered.add(item.id)
+      const children = childrenByParent.get(item.slug) ?? []
       nextRows.push({
-        item: parent,
-        parentTitle: null,
-        childCount: parentChildren.length,
-        isChild: false,
-        isLast: false,
+        item,
+        parentTitle,
+        childCount: children.length,
+        isChild: depth > 0,
+        isLast,
+        depth,
       })
-      parentChildren.forEach((child, index) => {
-        renderedChildren.add(child.id)
-        nextRows.push({
-          item: child,
-          parentTitle: parent.canonical_title,
-          childCount: 0,
-          isChild: true,
-          isLast: index === parentChildren.length - 1,
-        })
+      children.forEach((child, index) => {
+        pushSubtree(child, item.canonical_title, depth + 1, index === children.length - 1)
       })
     }
 
-    for (const child of children) {
-      if (renderedChildren.has(child.id)) continue
+    for (const section of parentSections) {
+      pushSubtree(section, null, 0, false)
+    }
+
+    // Anything the walk did not reach hangs under a parent that no longer
+    // exists. Still listed, and named as orphaned, because an invisible row is
+    // one nobody can fix.
+    for (const item of items) {
+      if (item.type !== "subsection" || rendered.has(item.id)) continue
       nextRows.push({
-        item: child,
-        parentTitle: child.parent_slug ? `Unknown parent: ${child.parent_slug}` : "No parent",
-        childCount: 0,
+        item,
+        parentTitle: item.parent_slug ? `Unknown parent: ${item.parent_slug}` : "No parent",
+        childCount: (childrenByParent.get(item.slug) ?? []).length,
         isChild: true,
         isLast: true,
+        depth: 1,
       })
     }
 
     return nextRows
-  }, [items, parentSections])
+  }, [items, parentSections, childrenByParent])
+
+  // Depth of the chain ABOVE a slug, so the parent picker can drop anything that
+  // has no room left beneath it.
+  const depthOf = useCallback((slug: string) => {
+    const bySlug = new Map(items.map((item) => [item.slug, item]))
+    let depth = 1
+    let current = bySlug.get(slug)
+    const seen = new Set<string>()
+    while (current && current.type === "subsection" && current.parent_slug) {
+      if (seen.has(current.slug)) break
+      seen.add(current.slug)
+      depth += 1
+      current = bySlug.get(current.parent_slug)
+    }
+    return depth
+  }, [items])
+
+  // Everything a subsection may hang under: the sections, plus the subsections
+  // still shallow enough to take a child. Editing a row excludes itself and its
+  // own descendants, since neither can be its parent.
+  const parentChoices = useMemo(() => {
+    const editingSlug = editor?.mode === "edit" ? editor.item.slug : null
+
+    const forbidden = new Set<string>()
+    if (editingSlug) {
+      const queue = [editingSlug]
+      while (queue.length > 0) {
+        const slug = queue.shift() as string
+        if (forbidden.has(slug)) continue
+        forbidden.add(slug)
+        for (const child of childrenByParent.get(slug) ?? []) {
+          queue.push(child.slug)
+        }
+      }
+    }
+
+    // The moved row brings its own subtree along, so the room it needs is its
+    // own height, not one level.
+    const movedHeight = editingSlug
+      ? (() => {
+          const heightOf = (slug: string): number => {
+            const children = childrenByParent.get(slug) ?? []
+            return children.length === 0 ? 0 : 1 + Math.max(...children.map((child) => heightOf(child.slug)))
+          }
+          return heightOf(editingSlug)
+        })()
+      : 0
+
+    return items
+      .filter((item) => item.type === "section" || item.type === "subsection")
+      .filter((item) => !forbidden.has(item.slug))
+      .filter((item) => depthOf(item.slug) + 1 + movedHeight <= MAX_DEPTH)
+      .sort((left, right) => {
+        const leftDepth = depthOf(left.slug)
+        const rightDepth = depthOf(right.slug)
+        if (leftDepth !== rightDepth) return leftDepth - rightDepth
+        return left.canonical_title.localeCompare(right.canonical_title)
+      })
+  }, [items, childrenByParent, depthOf, editor])
 
   const filtered = useMemo(() => {
     const query = search.toLowerCase().trim()
@@ -220,7 +299,9 @@ export default function SectionsView() {
   )
 
   const openCreate = (type: TaxonomyKind, parentSlug = "") => {
-    const parentExists = parentSlug && parentSections.some((section) => section.slug === parentSlug)
+    // Any row that can still take a child, not just a section: "Add subsection"
+    // from Food has to preselect Food.
+    const parentExists = parentSlug && parentChoices.some((choice) => choice.slug === parentSlug)
     const nextParent = type === "subsection"
       ? (parentExists ? parentSlug : parentSections.some((section) => section.slug === "columns") ? "columns" : parentSections[0]?.slug ?? "")
       : ""
@@ -479,14 +560,14 @@ export default function SectionsView() {
                 <td className="px-4 py-8 text-center text-muted-foreground" colSpan={6}>No sections found.</td>
               </tr>
             ) : (
-              filtered.map(({ item, parentTitle, childCount, isChild, isLast }) => {
+              filtered.map(({ item, parentTitle, childCount, isChild, isLast, depth }) => {
                 const articleCount = item.article_count ?? 0
                 const isVisible = item.is_visible !== false
                 const canDelete = articleCount === 0 && childCount === 0
                 const deleteTitle = articleCount > 0
                   ? "Cannot delete while articles use this item."
                   : childCount > 0
-                    ? "Cannot delete while subsections use this section."
+                    ? "Cannot delete while subsections use this item."
                     : `Delete ${item.canonical_title}`
 
                 return (
@@ -494,6 +575,12 @@ export default function SectionsView() {
                     <td className="px-4 py-3 font-medium text-foreground">
                       {isChild ? (
                         <span className="flex items-start gap-1.5">
+                          {/* One blank rail per level above the elbow, so a
+                              grandchild reads as sitting under its subsection
+                              rather than beside it. */}
+                          {Array.from({ length: depth - 1 }, (_, level) => (
+                            <span key={level} className="w-4 shrink-0" aria-hidden="true" />
+                          ))}
                           <span className="flex flex-col items-center w-4 shrink-0 mt-0.5">
                             <span className="w-px h-2 bg-border" />
                             <span className="w-3 h-px bg-border" />
@@ -501,6 +588,7 @@ export default function SectionsView() {
                           </span>
                           <span>
                             <span className="text-muted-foreground">{item.canonical_title}</span>
+                            {childCount > 0 ? <span className="ml-2 text-xs text-muted-foreground">({childCount})</span> : null}
                             {parentTitle ? <span className="block text-xs text-muted-foreground/70">{parentTitle}</span> : null}
                           </span>
                         </span>
@@ -623,19 +711,27 @@ export default function SectionsView() {
 
               {form.type === "subsection" ? (
                 <label className="flex flex-col gap-1.5">
-                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Parent Section</span>
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Parent</span>
                   <select
                     className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
                     value={form.parentSlug}
                     onChange={(event) => setForm((current) => ({ ...current, parentSlug: event.target.value }))}
                   >
-                    <option value="">Choose a section</option>
-                    {parentSections.map((section) => (
-                      <option key={section.slug} value={section.slug}>
-                        {section.canonical_title}
+                    <option value="">Choose a parent</option>
+                    {parentChoices.map((choice) => (
+                      <option key={`${choice.type}-${choice.slug}`} value={choice.slug}>
+                        {/* Indented with figure spaces so a subsection reads as
+                            sitting under its section in a plain <select>, which
+                            cannot nest beyond one optgroup level. */}
+                        {"  ".repeat(depthOf(choice.slug) - 1)}{choice.canonical_title}
                       </option>
                     ))}
                   </select>
+                  <span className="text-xs text-muted-foreground">
+                    A subsection can sit under a section or under another subsection &mdash;
+                    Beer Reviews sits under Food, which sits under Arts &amp; Entertainment.
+                    Anything already {MAX_DEPTH} levels deep is left out, since nothing can hang below it.
+                  </span>
                 </label>
               ) : null}
 

--- a/server/internal/database/taxonomy.go
+++ b/server/internal/database/taxonomy.go
@@ -48,6 +48,14 @@ func EnsureTaxonomyTable(ctx context.Context, conn *sql.DB) error {
 	if err != nil {
 		return err
 	}
+	// After the legacy seeding, which is what creates the review subsections
+	// this moves. On a fresh database both run in the same boot, and the order
+	// is the difference between re-parenting three rows and finding none.
+	moved, err := SeedFoodSubsection(ctx, conn)
+	if err != nil {
+		return err
+	}
+	seeded = append(seeded, moved...)
 	if err = RefreshCategoryAliases(ctx, conn); err != nil {
 		return err
 	}
@@ -349,6 +357,143 @@ func SeedLegacySubsections(ctx context.Context, conn *sql.DB) ([]string, error) 
 	return inserted, writeSettingRaw(ctx, conn, "legacy_subsections_seeded", "1")
 }
 
+// foodSubsection is the A&E "Food" row and the review categories that move
+// under it, which is what the third level of nesting was added for.
+//
+// Beer Reviews, Wine Reviews, Restaurant Reviews and Cooking were already
+// subsections of Entertainment, sitting beside the movies-and-music coverage
+// rather than under a heading of their own. The desk wanted them kept as real
+// categories -- their pages and their chips stay where they are -- but gathered
+// under one Food entry in A&E's strip.
+//
+// Cooking differs from the other three in one way worth knowing: it is a
+// current, visible subsection rather than a legacy WordPress category, so moving
+// it takes its link OUT of A&E's strip and puts it in Food's. That is the
+// intent, not a side effect.
+var (
+	foodSubsectionSlug   = "food"
+	foodSubsectionTitle  = "Food"
+	foodSubsectionParent = "entertainment"
+	// No aliases: "food" already matches the category "Food" through
+	// CategoryMatchValues, and everything else Food should list arrives through
+	// its children. Inventing spellings here would be guessing at categories
+	// that may mean something else to the desk.
+	foodSubsectionAliases  = []string{"Food"}
+	foodSubsectionChildren = []string{"beer-reviews", "wine-reviews", "restaurant-reviews", "cooking"}
+)
+
+// SeedFoodSubsection creates Food under A&E and re-parents the review
+// categories beneath it, once.
+//
+// Once, and recorded in cms_settings, for the reason SeedLegacySubsections is:
+// these rows are editable. An editor who moves Restaurant Reviews back out, or
+// deletes Food, must not find the arrangement restored on the next deploy.
+//
+// It cannot ride on legacy_subsections_seeded -- that flag is already set in
+// production and those three rows already exist, so this needs its own.
+//
+// Food arrives VISIBLE, unlike the legacy seeding: it is a heading the desk
+// asked for in A&E's strip, not a URL being handed to an orphaned category. Its
+// children keep whatever visibility they already have; they are simply reparented.
+func SeedFoodSubsection(ctx context.Context, conn *sql.DB) ([]string, error) {
+	if conn == nil {
+		return nil, nil
+	}
+
+	var settingsTableExists int
+	if err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'cms_settings'",
+	).Scan(&settingsTableExists); err != nil {
+		return nil, err
+	}
+	if settingsTableExists == 0 {
+		return nil, nil
+	}
+
+	var done string
+	switch err := conn.QueryRowContext(ctx,
+		"SELECT value_text FROM cms_settings WHERE key_name = 'food_subsection_seeded' LIMIT 1",
+	).Scan(&done); err {
+	case nil:
+		if strings.TrimSpace(done) == "1" {
+			return nil, nil
+		}
+	case sql.ErrNoRows:
+		// Not yet seeded.
+	default:
+		return nil, err
+	}
+
+	sections, err := existingSlugsByKind(ctx, conn, "section")
+	if err != nil {
+		return nil, err
+	}
+	if len(sections) == 0 {
+		// The taxonomy has not been imported yet. Returning without recording
+		// the flag leaves the one run intact for a later boot; see
+		// SeedLegacySubsections.
+		return nil, nil
+	}
+	if _, ok := sections[foodSubsectionParent]; !ok {
+		slog.Warn("skipping the Food subsection seed: its parent section is missing",
+			"parent_slug", foodSubsectionParent)
+		return nil, writeSettingRaw(ctx, conn, "food_subsection_seeded", "1")
+	}
+
+	subsections, err := existingSlugsByKind(ctx, conn, "subsection")
+	if err != nil {
+		return nil, err
+	}
+
+	touched := make([]string, 0, len(foodSubsectionChildren)+1)
+	if _, taken := subsections[foodSubsectionSlug]; !taken {
+		aliases, err := MarshalCategoryJSON(foodSubsectionAliases)
+		if err != nil {
+			return nil, err
+		}
+		var nextID int64
+		if err := conn.QueryRowContext(ctx, "SELECT COALESCE(MAX(id), 0) + 1 FROM site_taxonomy").Scan(&nextID); err != nil {
+			return nil, err
+		}
+		if _, err := conn.ExecContext(ctx, `
+			INSERT INTO site_taxonomy
+				(id, kind, slug, canonical_title, parent_slug, article_count, category_aliases, is_visible)
+			VALUES (?, 'subsection', ?, ?, ?, 0, ?, 1)
+		`, nextID, foodSubsectionSlug, foodSubsectionTitle, foodSubsectionParent, aliases); err != nil {
+			return nil, err
+		}
+		touched = append(touched, foodSubsectionSlug)
+	}
+
+	for _, child := range foodSubsectionChildren {
+		if _, exists := subsections[child]; !exists {
+			continue
+		}
+		// Guarded on the CURRENT parent, so a row an editor has already moved
+		// somewhere deliberate is left where they put it.
+		result, err := conn.ExecContext(ctx, `
+			UPDATE site_taxonomy
+			SET parent_slug = ?
+			WHERE kind = 'subsection' AND slug = ? AND parent_slug = ?
+		`, foodSubsectionSlug, child, foodSubsectionParent)
+		if err != nil {
+			return nil, err
+		}
+		// RowsAffected is not trusted as proof here -- through MaxScale it can
+		// report 0 for a write that landed -- so the slug is reported as touched
+		// either way and the recount that follows settles the numbers.
+		if _, err := result.RowsAffected(); err != nil {
+			return nil, err
+		}
+		touched = append(touched, child)
+	}
+
+	if len(touched) > 0 {
+		slog.Info("seeded the Food subsection under A&E", "slugs", touched)
+	}
+	return touched, writeSettingRaw(ctx, conn, "food_subsection_seeded", "1")
+}
+
 func existingSlugsByKind(ctx context.Context, conn *sql.DB, kind string) (map[string]struct{}, error) {
 	rows, err := conn.QueryContext(ctx, "SELECT slug FROM site_taxonomy WHERE kind = ?", kind)
 	if err != nil {
@@ -629,14 +774,129 @@ func possessiveVariant(phrase string) string {
 	return strings.Join(words, " ")
 }
 
-// taxonomyMatchSlugs maps every section/subsection slug to the slugs whose
-// articles belong to it: a subsection matches only itself, a section matches
-// itself plus all of its children.
+// MaxTaxonomyDepth is how many levels the section tree may hold, counting the
+// section itself: section -> subsection -> subsection. A&E needed the third for
+// Food, which holds Beer Reviews, Wine Reviews and Restaurant Reviews.
 //
-// The children matter because a section can be a pure container. Nothing is
-// filed under the category "Special Editions" -- its articles live under
-// "Welcome Week" and "100 Year Anniversary" -- so matching the section slug
-// alone reports zero for a section that visibly has content.
+// Bounded because the walks below are recursive and the tree is editor-editable.
+// The bound is also what makes a cycle survivable rather than a hang, though
+// validateTaxonomyParent refuses to create one in the first place.
+const MaxTaxonomyDepth = 3
+
+// TaxonomyChildren returns the slugs filed directly under a slug.
+func TaxonomyChildren(ctx context.Context, conn *sql.DB, slug string) ([]string, error) {
+	if conn == nil || strings.TrimSpace(slug) == "" {
+		return nil, nil
+	}
+	rows, err := conn.QueryContext(ctx,
+		"SELECT slug FROM site_taxonomy WHERE kind = 'subsection' AND parent_slug = ?",
+		strings.TrimSpace(slug),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var children []string
+	for rows.Next() {
+		var child string
+		if err := rows.Scan(&child); err != nil {
+			return nil, err
+		}
+		if trimmed := strings.TrimSpace(child); trimmed != "" {
+			children = append(children, trimmed)
+		}
+	}
+	return children, rows.Err()
+}
+
+// TaxonomyDescendants returns a slug plus every slug below it, at any depth,
+// with the slug itself first. That set is what "articles filed under this" means
+// once the tree has three levels.
+func TaxonomyDescendants(ctx context.Context, conn *sql.DB, slug string) ([]string, error) {
+	trimmed := strings.TrimSpace(slug)
+	if conn == nil || trimmed == "" {
+		return nil, nil
+	}
+	rows, err := conn.QueryContext(ctx, `
+		SELECT slug, COALESCE(parent_slug, '')
+		FROM site_taxonomy
+		WHERE kind = 'subsection' AND parent_slug IS NOT NULL AND parent_slug <> ''
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	children := make(map[string][]string)
+	for rows.Next() {
+		var child, parent string
+		if err := rows.Scan(&child, &parent); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(child) == "" {
+			continue
+		}
+		children[strings.TrimSpace(parent)] = append(children[strings.TrimSpace(parent)], strings.TrimSpace(child))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return append([]string{trimmed}, descendantsOf(children, trimmed)...), nil
+}
+
+// TaxonomyAncestors returns a slug's parent chain, nearest first, stopping at
+// the root section.
+//
+// It stops after MaxTaxonomyDepth hops regardless: this walks editor-owned data
+// that a bad write could have made circular, and a traversal that cannot
+// terminate would take the request thread with it.
+func TaxonomyAncestors(ctx context.Context, conn *sql.DB, slug string) ([]string, error) {
+	if conn == nil {
+		return nil, nil
+	}
+	parents, err := taxonomyParentsBySlug(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	return ancestorChain(parents, slug), nil
+}
+
+// ancestorChain walks a parent map upward, nearest ancestor first. Bounded by
+// MaxTaxonomyDepth and by a seen set, so a cycle yields a truncated chain rather
+// than an infinite loop.
+func ancestorChain(parents map[string]string, slug string) []string {
+	var chain []string
+	seen := map[string]struct{}{}
+	current := strings.TrimSpace(slug)
+	for range MaxTaxonomyDepth {
+		parent := strings.TrimSpace(parents[current])
+		if parent == "" {
+			break
+		}
+		if _, looped := seen[parent]; looped {
+			break
+		}
+		seen[parent] = struct{}{}
+		chain = append(chain, parent)
+		current = parent
+	}
+	return chain
+}
+
+// taxonomyMatchSlugs maps every section/subsection slug to the slugs whose
+// articles belong to it: itself plus every descendant, to any depth.
+//
+// The descendants matter because a row can be a pure container. Nothing is filed
+// under the category "Special Editions" -- its articles live under "Welcome
+// Week" and "100 Year Anniversary" -- so matching the section slug alone reports
+// zero for a section that visibly has content.
+//
+// Transitive rather than one hop, because the tree is three levels now. Under
+// A&E, Beer Reviews hangs off Food rather than off the section, and a single hop
+// would have counted those articles for Food while dropping them from
+// Entertainment -- a section quietly shorter than the sum of its subsections,
+// which is the same silent-omission failure the alias seeding exists to fix.
 func taxonomyMatchSlugs(ctx context.Context, conn *sql.DB) (map[string][]string, error) {
 	rows, err := conn.QueryContext(ctx, `
 		SELECT slug, kind, COALESCE(parent_slug, '')
@@ -667,13 +927,30 @@ func taxonomyMatchSlugs(ctx context.Context, conn *sql.DB) (map[string][]string,
 		return nil, err
 	}
 
-	for parent, kids := range children {
-		if _, ok := matches[parent]; !ok {
-			continue
-		}
-		matches[parent] = append(matches[parent], kids...)
+	for slug := range matches {
+		matches[slug] = append(matches[slug], descendantsOf(children, slug)...)
 	}
 	return matches, nil
+}
+
+// descendantsOf collects every slug below one, breadth-first. The seen set is
+// what makes it safe on data it does not control: a cycle visits each member
+// once and stops.
+func descendantsOf(children map[string][]string, slug string) []string {
+	var found []string
+	seen := map[string]struct{}{slug: {}}
+	queue := append([]string(nil), children[slug]...)
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if _, visited := seen[current]; visited {
+			continue
+		}
+		seen[current] = struct{}{}
+		found = append(found, current)
+		queue = append(queue, children[current]...)
+	}
+	return found
 }
 
 // TaxonomyCountCondition builds the WHERE fragment matching articles in any of
@@ -870,10 +1147,16 @@ func RebuildTaxonomyArticleCounts(ctx context.Context, conn *sql.DB) error {
 //
 // A full rebuild runs one scan of the articles table per taxonomy row -- fine as
 // startup or maintenance work, far too slow to sit inside a save. The blast
-// radius of one edit is small: the row itself, plus its parent section, because
-// a section matches its own slug OR any of its children's. Nothing else moves.
+// radius of one edit is small: the row itself, plus every ancestor above it,
+// because a row matches its own slug OR any of its descendants'. Nothing else
+// moves.
 //
-// Callers pass the slugs they touched; parents are resolved here.
+// Every ancestor rather than just the parent: with three levels, editing Beer
+// Reviews moves the count of Food AND of Entertainment above it, and stopping at
+// the parent would leave the section showing a stale number that nothing short
+// of a full rebuild would correct.
+//
+// Callers pass the slugs they touched; ancestors are resolved here.
 func RebuildTaxonomyArticleCountsFor(ctx context.Context, conn *sql.DB, slugs ...string) error {
 	matchSlugs, err := taxonomyMatchSlugs(ctx, conn)
 	if err != nil {
@@ -885,15 +1168,15 @@ func RebuildTaxonomyArticleCountsFor(ctx context.Context, conn *sql.DB, slugs ..
 		return err
 	}
 
-	affected := make(map[string]struct{}, len(slugs)*2)
+	affected := make(map[string]struct{}, len(slugs)*MaxTaxonomyDepth)
 	for _, slug := range slugs {
 		normalized := strings.TrimSpace(slug)
 		if normalized == "" {
 			continue
 		}
 		affected[normalized] = struct{}{}
-		if parent := parents[normalized]; parent != "" {
-			affected[parent] = struct{}{}
+		for _, ancestor := range ancestorChain(parents, normalized) {
+			affected[ancestor] = struct{}{}
 		}
 	}
 	if len(affected) == 0 {

--- a/server/internal/database/taxonomy_integration_test.go
+++ b/server/internal/database/taxonomy_integration_test.go
@@ -338,3 +338,90 @@ func countRows(t *testing.T, conn *sql.DB, query string) int64 {
 	}
 	return count
 }
+
+// TestFoodSubsectionSeedMovesTheReviewCategories covers the migration that the
+// third level exists for: Food appears under A&E, and the three review
+// categories move from beside it to under it.
+//
+// The run-once half matters as much as the move. These rows are editable, so an
+// editor who pulls Restaurant Reviews back out to the section must not find it
+// under Food again after the next deploy.
+func TestFoodSubsectionSeedMovesTheReviewCategories(t *testing.T) {
+	conn := taxonomyTestDB(t)
+	ctx := context.Background()
+
+	if err := EnsureSettingsTable(ctx, conn); err != nil {
+		t.Fatalf("ensure settings table: %v", err)
+	}
+	for _, key := range []string{"legacy_subsections_seeded", "food_subsection_seeded"} {
+		if _, err := conn.ExecContext(ctx, "DELETE FROM cms_settings WHERE key_name = ?", key); err != nil {
+			t.Fatalf("clear %s: %v", key, err)
+		}
+	}
+
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("ensure taxonomy table: %v", err)
+	}
+	insertTaxonomyRow(t, conn, 1, "section", "entertainment", "Entertainment")
+	// Cooking is a current, visible subsection rather than a legacy WordPress
+	// category, so nothing else in this boot would create it. It is here for
+	// the same reason production has it: the seed has to move a live row, not
+	// just the ones it seeded a moment earlier.
+	insertTaxonomyRow(t, conn, 2, "subsection", "cooking", "Cooking")
+	if _, err := conn.ExecContext(ctx,
+		"UPDATE site_taxonomy SET parent_slug = 'entertainment', is_visible = 1 WHERE slug = 'cooking'",
+	); err != nil {
+		t.Fatalf("parent the cooking row: %v", err)
+	}
+
+	// One boot does both: the legacy seeding creates the review subsections,
+	// and the Food seed moves them. Order is what makes that work.
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+
+	parentOf := func(slug string) string {
+		t.Helper()
+		var parent sql.NullString
+		if err := conn.QueryRowContext(ctx,
+			"SELECT parent_slug FROM site_taxonomy WHERE slug = ?", slug,
+		).Scan(&parent); err != nil {
+			t.Fatalf("read parent of %s: %v", slug, err)
+		}
+		return parent.String
+	}
+
+	if got := parentOf("food"); got != "entertainment" {
+		t.Errorf("food parent = %q, want entertainment", got)
+	}
+	for _, child := range foodSubsectionChildren {
+		if got := parentOf(child); got != "food" {
+			t.Errorf("%s parent = %q, want food", child, got)
+		}
+	}
+
+	// Food is a heading the desk asked for, so unlike the legacy rows it
+	// arrives with a link.
+	var visible int
+	if err := conn.QueryRowContext(ctx,
+		"SELECT is_visible FROM site_taxonomy WHERE slug = 'food'",
+	).Scan(&visible); err != nil {
+		t.Fatalf("read food visibility: %v", err)
+	}
+	if visible != 1 {
+		t.Error("food seeded hidden, want visible -- it is the entry A&E's strip is meant to gain")
+	}
+
+	// An editor moves one back, and a restart leaves it where they put it.
+	if _, err := conn.ExecContext(ctx,
+		"UPDATE site_taxonomy SET parent_slug = 'entertainment' WHERE slug = 'wine-reviews'",
+	); err != nil {
+		t.Fatalf("move a row back: %v", err)
+	}
+	if err := EnsureTaxonomyTable(ctx, conn); err != nil {
+		t.Fatalf("third ensure: %v", err)
+	}
+	if got := parentOf("wine-reviews"); got != "entertainment" {
+		t.Errorf("wine-reviews parent = %q, want entertainment -- the seed re-ran over an editor's change", got)
+	}
+}

--- a/server/internal/database/taxonomy_test.go
+++ b/server/internal/database/taxonomy_test.go
@@ -499,3 +499,78 @@ func TestNoCategoryIsAliasedToTwoSections(t *testing.T) {
 		}
 	}
 }
+
+// The tree walks below are pure functions of a parent/child map, so they are
+// tested without a database. What they have to survive is not just the happy
+// three-level shape but the shapes a bad write could leave behind, since they
+// run on editor-owned rows.
+
+func TestDescendantsOfWalksEveryLevel(t *testing.T) {
+	// A&E > Food > the three review categories.
+	children := map[string][]string{
+		"entertainment": {"food", "movies"},
+		"food":          {"beer-reviews", "wine-reviews", "restaurant-reviews"},
+	}
+
+	got := descendantsOf(children, "entertainment")
+	for _, want := range []string{"food", "movies", "beer-reviews", "wine-reviews", "restaurant-reviews"} {
+		if !containsValue(got, want) {
+			t.Errorf("descendants = %v, want %q included -- a grandchild's articles roll up to the section", got, want)
+		}
+	}
+	if len(got) != 5 {
+		t.Errorf("descendants = %v, want exactly the five below A&E", got)
+	}
+
+	// A middle row sees only what is under IT, not its siblings.
+	if got := descendantsOf(children, "food"); len(got) != 3 || containsValue(got, "movies") {
+		t.Errorf("descendants of food = %v, want only its own three children", got)
+	}
+	if got := descendantsOf(children, "beer-reviews"); len(got) != 0 {
+		t.Errorf("descendants of a leaf = %v, want none", got)
+	}
+}
+
+func TestDescendantsOfTerminatesOnACycle(t *testing.T) {
+	// validateTaxonomyParent refuses to create this, but the walk runs on rows
+	// that a direct database edit could have made circular, and a rollup that
+	// hangs takes the request thread with it.
+	children := map[string][]string{
+		"food":         {"beer-reviews"},
+		"beer-reviews": {"food"},
+	}
+
+	got := descendantsOf(children, "food")
+	if len(got) != 1 || got[0] != "beer-reviews" {
+		t.Errorf("descendants = %v, want the cycle visited once", got)
+	}
+}
+
+func TestAncestorChainReturnsNearestFirst(t *testing.T) {
+	parents := map[string]string{
+		"beer-reviews": "food",
+		"food":         "entertainment",
+	}
+
+	got := ancestorChain(parents, "beer-reviews")
+	if len(got) != 2 || got[0] != "food" || got[1] != "entertainment" {
+		t.Fatalf("chain = %v, want [food entertainment]", got)
+	}
+	// The last entry is the root section, which is what
+	// rootSectionForSubsection reads to answer "which section is this under".
+	if got[len(got)-1] != "entertainment" {
+		t.Errorf("root = %q, want entertainment", got[len(got)-1])
+	}
+	if got := ancestorChain(parents, "entertainment"); len(got) != 0 {
+		t.Errorf("chain of a section = %v, want empty", got)
+	}
+}
+
+func TestAncestorChainStopsOnACycle(t *testing.T) {
+	parents := map[string]string{"food": "beer-reviews", "beer-reviews": "food"}
+
+	got := ancestorChain(parents, "food")
+	if len(got) > MaxTaxonomyDepth {
+		t.Fatalf("chain = %v, want the walk bounded rather than looping", got)
+	}
+}

--- a/server/internal/handlers/article_params.go
+++ b/server/internal/handlers/article_params.go
@@ -118,7 +118,7 @@ func normalizeAndValidateArticleParams(ctx context.Context, conn *sql.DB, params
 	}
 
 	if params.Subsection != "" {
-		parentSection, ok, err := parentSectionForSubsection(ctx, conn, params.Subsection)
+		parentSection, ok, err := rootSectionForSubsection(ctx, conn, params.Subsection)
 		if err != nil {
 			return ArticleParams{}, err
 		}
@@ -130,6 +130,17 @@ func normalizeAndValidateArticleParams(ctx context.Context, conn *sql.DB, params
 		} else if params.Section != parentSection {
 			return ArticleParams{}, fmt.Errorf("subsection_slug does not belong to section_slug")
 		}
+
+		// A subsection can be a container too now, so its page needs its own
+		// descendants for the same reason a section's does.
+		matchSlugs, err := db.TaxonomyDescendants(ctx, conn, params.Subsection)
+		if err != nil {
+			return ArticleParams{}, err
+		}
+		if len(matchSlugs) == 0 {
+			matchSlugs = []string{params.Subsection}
+		}
+		params.SubsectionMatchSlugs = matchSlugs
 	}
 
 	return params, nil
@@ -156,10 +167,14 @@ func taxonomySectionExists(ctx context.Context, conn *sql.DB, section string) (b
 	return err == nil, err
 }
 
-// sectionMatchSlugs returns the section plus every subsection filed under it,
-// which together define what "articles in this section" means. Falls back to
-// the section alone when there is no database handle, matching the behaviour of
-// the other taxonomy lookups here.
+// sectionMatchSlugs returns the section plus every subsection below it, at any
+// depth, which together define what "articles in this section" means. Falls back
+// to the section alone when there is no database handle, matching the behaviour
+// of the other taxonomy lookups here.
+//
+// Transitive because the tree is three levels: A&E holds Food, and Food holds
+// Beer Reviews. One hop would have listed Food's own articles under A&E while
+// dropping everything filed under the three review categories beneath it.
 func sectionMatchSlugs(ctx context.Context, conn *sql.DB, section string) ([]string, error) {
 	trimmed := strings.TrimSpace(section)
 	if trimmed == "" {
@@ -172,30 +187,17 @@ func sectionMatchSlugs(ctx context.Context, conn *sql.DB, section string) ([]str
 		}
 		return slugs, nil
 	}
-
-	rows, err := conn.QueryContext(ctx,
-		"SELECT slug FROM site_taxonomy WHERE kind = ? AND parent_slug = ?",
-		string(models.TaxonomyTypeSubsection), trimmed,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	slugs := []string{trimmed}
-	for rows.Next() {
-		var slug string
-		if err := rows.Scan(&slug); err != nil {
-			return nil, err
-		}
-		if strings.TrimSpace(slug) != "" {
-			slugs = append(slugs, slug)
-		}
-	}
-	return slugs, rows.Err()
+	return db.TaxonomyDescendants(ctx, conn, trimmed)
 }
 
-func parentSectionForSubsection(ctx context.Context, conn *sql.DB, subsection string) (string, bool, error) {
+// rootSectionForSubsection resolves the SECTION a subsection ultimately belongs
+// to, walking up however many levels sit between them.
+//
+// The root rather than the immediate parent, because this backs the check that
+// ?subsection_slug= agrees with ?section_slug=, and the caller names a section.
+// Returning "food" for beer-reviews would fail that check against the only
+// section a reader could have arrived from.
+func rootSectionForSubsection(ctx context.Context, conn *sql.DB, subsection string) (string, bool, error) {
 	if conn != nil {
 		var parent sql.NullString
 		err := conn.QueryRowContext(ctx,
@@ -208,7 +210,18 @@ func parentSectionForSubsection(ctx context.Context, conn *sql.DB, subsection st
 		if err != nil {
 			return "", false, err
 		}
-		return parent.String, parent.Valid && parent.String != "", nil
+		if !parent.Valid || strings.TrimSpace(parent.String) == "" {
+			return "", false, nil
+		}
+		ancestors, err := db.TaxonomyAncestors(ctx, conn, subsection)
+		if err != nil {
+			return "", false, err
+		}
+		if len(ancestors) == 0 {
+			return "", false, nil
+		}
+		// Nearest first, so the last entry is the top of the chain.
+		return ancestors[len(ancestors)-1], true, nil
 	}
 
 	for section, subsections := range allowedSubsectionsBySection {

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -213,8 +213,15 @@ func canonicalTitleForTaxonomy(ctx context.Context, conn *sql.DB, kind, slug str
 // of 30 links is not navigation. The desk decides which ones are worth a link
 // on the sections screen; everything else stays reachable by URL and by the
 // category chip on an article.
-func subsectionsForSection(ctx context.Context, conn *sql.DB, sectionSlug string) ([]models.TaxonomySummary, error) {
-	trimmedSection := strings.TrimSpace(sectionSlug)
+// visibleSubsectionsOf returns the link strip for a page: the DIRECT children of
+// a slug that the desk has left visible.
+//
+// Direct children only, at every level. On A&E that now means Food rather than
+// the three review categories folded underneath it -- which is the point of the
+// nesting, since the strip existed to stay short. Food's own page gets its own
+// strip from the same call.
+func visibleSubsectionsOf(ctx context.Context, conn *sql.DB, parentSlug string) ([]models.TaxonomySummary, error) {
+	trimmedSection := strings.TrimSpace(parentSlug)
 	if trimmedSection == "" {
 		return []models.TaxonomySummary{}, nil
 	}
@@ -484,7 +491,7 @@ func orderCategoriesForSection(categories []models.CategorySummary, preferSlugs 
 // also carries. Empty when the listing has no section context at all.
 func categoryPreferenceSlugs(params ArticleParams) []string {
 	if params.Subsection != "" {
-		return []string{params.Subsection}
+		return params.subsectionMatch()
 	}
 	return params.SectionMatchSlugs
 }
@@ -1171,7 +1178,7 @@ func GetSectionArticles(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		subsections, err := subsectionsForSection(r.Context(), conn, params.Section)
+		subsections, err := visibleSubsectionsOf(r.Context(), conn, params.Section)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
@@ -1253,6 +1260,11 @@ func GetSubsectionArticles(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+		children, err := visibleSubsectionsOf(r.Context(), conn, params.Subsection)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 
 		setPublicReadCache(w, r)
 		writeJSON(w, http.StatusOK, models.SubsectionArticlesResponse{
@@ -1266,8 +1278,9 @@ func GetSubsectionArticles(conn *sql.DB) http.HandlerFunc {
 				Name:           subsectionCanonicalTitle,
 				CanonicalTitle: subsectionCanonicalTitle,
 			},
-			Articles:   articleListItems(articles, excerptWords, categoryPreferenceSlugs(params)...),
-			Pagination: paginationResponse(page, limit, offset, hasMore, totalCount),
+			Subsections: children,
+			Articles:    articleListItems(articles, excerptWords, categoryPreferenceSlugs(params)...),
+			Pagination:  paginationResponse(page, limit, offset, hasMore, totalCount),
 		})
 	}
 }
@@ -1277,10 +1290,34 @@ type ArticleParams struct {
 	AuthorSearch string
 	Section      string
 	Subsection   string
-	// SectionMatchSlugs is the section plus its subsections, resolved during
-	// validation because the filter builder has no database handle. A section
-	// with no matching category of its own is still populated by its children.
+	// SectionMatchSlugs is the section plus every subsection below it, resolved
+	// during validation because the filter builder has no database handle. A
+	// section with no matching category of its own is still populated by its
+	// children.
 	SectionMatchSlugs []string
+	// SubsectionMatchSlugs is the same for a subsection that has children of its
+	// own. Food is a container in exactly the way a section can be: its articles
+	// are filed under Beer Reviews and Restaurant Reviews, so matching "food"
+	// alone renders its page empty. Holds just the subsection itself for a leaf.
+	SubsectionMatchSlugs []string
+}
+
+// subsectionMatch is the slug set a subsection listing filters on, falling back
+// to the subsection itself when nothing resolved it.
+//
+// The fallback is not cosmetic. An empty slug list makes
+// appendCategorySlugCondition add no condition at all, so a filter that failed
+// to resolve would not narrow the listing -- it would return every article on
+// the site under a subsection's name. Callers that build ArticleParams without
+// going through normalizeAndValidateArticleParams reach exactly that state.
+func (p ArticleParams) subsectionMatch() []string {
+	if len(p.SubsectionMatchSlugs) > 0 {
+		return p.SubsectionMatchSlugs
+	}
+	if strings.TrimSpace(p.Subsection) == "" {
+		return nil
+	}
+	return []string{p.Subsection}
 }
 
 func queryArticles(r *http.Request, conn *sql.DB, params ArticleParams, limit, offset int) (*sql.Rows, error) {
@@ -1426,7 +1463,7 @@ func articleQueryFilters(r *http.Request, params ArticleParams) ([]string, []any
 	// real category. That is how /special-editions/welcome-week served 0
 	// articles while 30 were filed under "Welcome Week".
 	if params.Subsection != "" {
-		appendCategorySlugCondition(&conditions, &args, params.Subsection)
+		appendCategorySlugCondition(&conditions, &args, params.subsectionMatch()...)
 	} else if params.Section != "" {
 		appendCategorySlugCondition(&conditions, &args, params.SectionMatchSlugs...)
 	}

--- a/server/internal/handlers/taxonomy.go
+++ b/server/internal/handlers/taxonomy.go
@@ -155,11 +155,14 @@ func taxonomyItemExists(ctx context.Context, conn *sql.DB, taxType, slug string)
 	return err == nil, err
 }
 
-func taxonomySectionHasChildren(ctx context.Context, conn *sql.DB, sectionSlug string) (bool, error) {
+// taxonomyHasChildren reports whether anything is filed under a slug. It asks
+// about parent_slug rather than about kind, so it answers for a subsection that
+// parents other subsections as well as for a section.
+func taxonomyHasChildren(ctx context.Context, conn *sql.DB, slug string) (bool, error) {
 	var exists int
 	err := conn.QueryRowContext(ctx,
 		"SELECT 1 FROM site_taxonomy WHERE kind = ? AND parent_slug = ? LIMIT 1",
-		string(models.TaxonomyTypeSubsection), sectionSlug,
+		string(models.TaxonomyTypeSubsection), slug,
 	).Scan(&exists)
 	if err == sql.ErrNoRows {
 		return false, nil
@@ -167,7 +170,21 @@ func taxonomySectionHasChildren(ctx context.Context, conn *sql.DB, sectionSlug s
 	return err == nil, err
 }
 
-func validateTaxonomyParent(ctx context.Context, conn *sql.DB, taxType string, parentSlug *string) (any, error) {
+// validateTaxonomyParent checks that a row's parent_slug names something that
+// can hold it, and returns the value to store (nil for a section).
+//
+// A subsection may hang under a section or under another subsection: A&E wanted
+// a Food subsection with Beer Reviews, Wine Reviews and Restaurant Reviews under
+// THAT rather than beside it. Both levels are kind='subsection' -- depth is a
+// property of the parent chain, not a third kind, which keeps every consumer
+// that switches on kind (the public site's slug router, the article filters, the
+// sections screen) working unchanged.
+//
+// db.MaxTaxonomyDepth caps the chain. The limit is not arbitrary: the rollup,
+// the recount and the root-section lookup all walk this chain, and an unbounded
+// tree turns each of them into a page whose cost the desk cannot see. Three
+// levels is what was asked for and one more than the site renders.
+func validateTaxonomyParent(ctx context.Context, conn *sql.DB, taxType, slug string, parentSlug *string) (any, error) {
 	if parentSlug == nil || strings.TrimSpace(*parentSlug) == "" {
 		if taxType == string(models.TaxonomyTypeSubsection) {
 			return nil, fmt.Errorf("parent_slug is required for subsections")
@@ -182,18 +199,67 @@ func validateTaxonomyParent(ctx context.Context, conn *sql.DB, taxType string, p
 	if taxType != string(models.TaxonomyTypeSubsection) {
 		return nil, fmt.Errorf("parent_slug is only allowed for subsections")
 	}
+	if parent == strings.TrimSpace(slug) {
+		return nil, fmt.Errorf("parent_slug cannot be the item itself")
+	}
 	if conn == nil {
 		return parent, nil
 	}
 
-	exists, err := taxonomyItemExists(ctx, conn, string(models.TaxonomyTypeSection), parent)
+	isSection, err := taxonomyItemExists(ctx, conn, string(models.TaxonomyTypeSection), parent)
 	if err != nil {
 		return nil, err
 	}
-	if !exists {
-		return nil, fmt.Errorf("parent_slug must reference an existing section")
+	if isSection {
+		return parent, nil
+	}
+
+	isSubsection, err := taxonomyItemExists(ctx, conn, string(models.TaxonomyTypeSubsection), parent)
+	if err != nil {
+		return nil, err
+	}
+	if !isSubsection {
+		return nil, fmt.Errorf("parent_slug must reference an existing section or subsection")
+	}
+
+	// The parent's own ancestors decide whether it has room for a child. This
+	// also catches a cycle: an ancestor walk that comes back to the row being
+	// saved is a loop, and a loop would hang every traversal that follows it.
+	ancestors, err := db.TaxonomyAncestors(ctx, conn, parent)
+	if err != nil {
+		return nil, err
+	}
+	for _, ancestor := range ancestors {
+		if ancestor == strings.TrimSpace(slug) {
+			return nil, fmt.Errorf("parent_slug would make the tree circular")
+		}
+	}
+	// depth counts the row being saved: the parent, its ancestors, and it.
+	if depth := len(ancestors) + 2; depth > db.MaxTaxonomyDepth {
+		return nil, fmt.Errorf("a subsection cannot nest more than %d levels deep", db.MaxTaxonomyDepth)
 	}
 	return parent, nil
+}
+
+// taxonomyChildDepth is how many levels hang BELOW a slug: 0 for a leaf. Saving
+// a row has to look down as well as up, since re-parenting a row that has
+// children of its own pushes those children down with it.
+func taxonomyChildDepth(ctx context.Context, conn *sql.DB, slug string) (int, error) {
+	children, err := db.TaxonomyChildren(ctx, conn, slug)
+	if err != nil {
+		return 0, err
+	}
+	deepest := 0
+	for _, child := range children {
+		depth, err := taxonomyChildDepth(ctx, conn, child)
+		if err != nil {
+			return 0, err
+		}
+		if depth+1 > deepest {
+			deepest = depth + 1
+		}
+	}
+	return deepest, nil
 }
 
 // @Summary List taxonomy items
@@ -320,7 +386,7 @@ func PostTaxonomy(conn *sql.DB) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "canonical_title is required")
 			return
 		}
-		parentSlug, err := validateTaxonomyParent(r.Context(), conn, taxType, body.ParentSlug)
+		parentSlug, err := validateTaxonomyParent(r.Context(), conn, taxType, slug, body.ParentSlug)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
@@ -428,19 +494,12 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 				return
 			}
 			if conn != nil {
-				// A subsection cannot parent another subsection, so a section
-				// with children has to be emptied before it can become one.
-				if taxType == string(models.TaxonomyTypeSection) {
-					hasChildren, err := taxonomySectionHasChildren(r.Context(), conn, slug)
-					if err != nil {
-						writeError(w, http.StatusInternalServerError, err.Error())
-						return
-					}
-					if hasChildren {
-						writeError(w, http.StatusBadRequest, "section cannot become a subsection while subsections use it")
-						return
-					}
-				}
+				// A section with children used to be blocked from becoming a
+				// subsection outright, because a subsection could not parent one.
+				// It can now, so the question is only whether the subtree still
+				// fits under the new parent -- checked below, once the parent is
+				// known, since that is what decides it.
+				//
 				// (kind, slug) is unique, so the conversion can collide with a
 				// row that already holds the destination. Say which, rather
 				// than surfacing a driver-level duplicate-key error as a 500.
@@ -456,10 +515,31 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			}
 		}
 
-		parentSlug, err := validateTaxonomyParent(r.Context(), conn, newType, body.ParentSlug)
+		parentSlug, err := validateTaxonomyParent(r.Context(), conn, newType, slug, body.ParentSlug)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
+		}
+		// validateTaxonomyParent only looks upward, which is the whole answer
+		// when creating a leaf. Moving an EXISTING row carries its own subtree
+		// with it, so the depth that matters is the chain above the new parent
+		// plus everything already hanging below this row.
+		if parent := parentSlugForRecount(parentSlug); parent != "" && conn != nil {
+			ancestors, err := db.TaxonomyAncestors(r.Context(), conn, parent)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			childDepth, err := taxonomyChildDepth(r.Context(), conn, slug)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if len(ancestors)+2+childDepth > db.MaxTaxonomyDepth {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf(
+					"moving this item and everything under it would nest more than %d levels deep", db.MaxTaxonomyDepth))
+				return
+			}
 		}
 		if newSlug != slug && conn != nil {
 			count, err := taxonomyItemArticleCount(r.Context(), conn, taxType, slug)
@@ -475,16 +555,17 @@ func PutTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 				writeError(w, http.StatusBadRequest, "slug cannot be changed while articles use this taxonomy item")
 				return
 			}
-			if taxType == string(models.TaxonomyTypeSection) {
-				hasChildren, err := taxonomySectionHasChildren(r.Context(), conn, slug)
-				if err != nil {
-					writeError(w, http.StatusInternalServerError, err.Error())
-					return
-				}
-				if hasChildren {
-					writeError(w, http.StatusBadRequest, "section slug cannot be changed while subsections use it")
-					return
-				}
+			// Children point at their parent by slug, so renaming any row that
+			// has them would orphan the lot. That is no longer a section-only
+			// hazard now that a subsection can hold children too.
+			hasChildren, err := taxonomyHasChildren(r.Context(), conn, slug)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if hasChildren {
+				writeError(w, http.StatusBadRequest, "slug cannot be changed while subsections use it")
+				return
 			}
 		}
 
@@ -585,16 +666,19 @@ func DeleteTaxonomyItem(conn *sql.DB) http.HandlerFunc {
 			// Children first: it is an indexed lookup on one small table, and
 			// it is the more specific reason to refuse, so it should not be
 			// preempted by a scan of every article.
-			if taxType == string(models.TaxonomyTypeSection) {
-				hasChildren, err := taxonomySectionHasChildren(r.Context(), conn, slug)
-				if err != nil {
-					writeError(w, http.StatusInternalServerError, err.Error())
-					return
-				}
-				if hasChildren {
-					writeError(w, http.StatusBadRequest, "section cannot be deleted while subsections use it")
-					return
-				}
+			//
+			// Asked of subsections too, not just sections: deleting Food while
+			// Beer Reviews hangs under it would strand three rows pointing at a
+			// parent that no longer exists, and their articles would stop
+			// rolling up to A&E without anything saying so.
+			hasChildren, err := taxonomyHasChildren(r.Context(), conn, slug)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if hasChildren {
+				writeError(w, http.StatusBadRequest, "this item cannot be deleted while subsections use it")
+				return
 			}
 			// Deletion is irreversible and editors can do it, so ask the
 			// articles table rather than a number that may predate the last

--- a/server/internal/handlers/taxonomy_integration_test.go
+++ b/server/internal/handlers/taxonomy_integration_test.go
@@ -536,7 +536,7 @@ func TestTaxonomyHTTPHiddenSubsectionKeepsEverythingButItsLink(t *testing.T) {
 	indexArticleCategories(t, conn)
 
 	// The strip: the visible one only.
-	subsections, err := subsectionsForSection(ctx, conn, "sports")
+	subsections, err := visibleSubsectionsOf(ctx, conn, "sports")
 	if err != nil {
 		t.Fatalf("subsections for section: %v", err)
 	}
@@ -554,7 +554,7 @@ func TestTaxonomyHTTPHiddenSubsectionKeepsEverythingButItsLink(t *testing.T) {
 	}
 
 	// Its own page still resolves.
-	parent, ok, err := parentSectionForSubsection(ctx, conn, "crew")
+	parent, ok, err := rootSectionForSubsection(ctx, conn, "crew")
 	if err != nil {
 		t.Fatalf("parent for subsection: %v", err)
 	}
@@ -633,8 +633,15 @@ func TestTaxonomyHTTPConvertsBetweenSectionAndSubsection(t *testing.T) {
 		}
 	}
 
-	// A section with children cannot become one: a subsection cannot parent a
-	// subsection.
+	// A section with children used to be refused outright, because a subsection
+	// could not parent one. Now the only question is whether the subtree still
+	// fits: esports > sports > squash is exactly the three levels allowed, so
+	// this conversion is refused only once it would need a fourth.
+	if code := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type": "subsection", "slug": "squash-doubles", "canonical_title": "Squash Doubles", "parent_slug": "squash",
+	}).Code; code != http.StatusCreated {
+		t.Fatalf("POST a grandchild = %d", code)
+	}
 	refused := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/sports", map[string]any{
 		"type":            "subsection",
 		"slug":            "sports",
@@ -642,7 +649,30 @@ func TestTaxonomyHTTPConvertsBetweenSectionAndSubsection(t *testing.T) {
 		"parent_slug":     "esports",
 	})
 	if refused.Code != http.StatusBadRequest {
-		t.Fatalf("converting a section with children = %d, want 400: %s", refused.Code, refused.Body.String())
+		t.Fatalf("converting a section two levels deep = %d, want 400: %s", refused.Code, refused.Body.String())
+	}
+
+	// Remove the bottom row and the same conversion fits, which is what proves
+	// the refusal was the depth rule and not a blanket ban on moving a parent.
+	if code := taxonomyRequest(t, DeleteTaxonomyItem(conn), http.MethodDelete, "/v1/taxonomy/subsection/squash-doubles", nil).Code; code != http.StatusNoContent {
+		t.Fatalf("DELETE the grandchild = %d", code)
+	}
+	if code := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/section/sports", map[string]any{
+		"type":            "subsection",
+		"slug":            "sports",
+		"canonical_title": "Sports",
+		"parent_slug":     "esports",
+	}).Code; code != http.StatusNoContent {
+		t.Fatalf("converting a section with one level under it = %d, want 204", code)
+	}
+	// Put it back, so the rest of the test runs against the shape it expects.
+	if code := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/subsection/sports", map[string]any{
+		"type":            "section",
+		"slug":            "sports",
+		"canonical_title": "Sports",
+		"parent_slug":     nil,
+	}).Code; code != http.StatusNoContent {
+		t.Fatalf("converting back to a section = %d", code)
 	}
 
 	// A childless one can.
@@ -672,4 +702,164 @@ func TestTaxonomyHTTPConvertsBetweenSectionAndSubsection(t *testing.T) {
 	if promoted.Type != "section" || promoted.ParentSlug != nil {
 		t.Fatalf("promoted item = %+v, want a parentless section", promoted)
 	}
+}
+
+// TestTaxonomyHTTPThreeLevelNesting is the arrangement A&E asked for, end to
+// end: Food under Arts & Entertainment, and the review categories under Food.
+//
+// The interesting assertion is the rollup. Beer Reviews is two hops from the
+// section now, and the one-hop rollup this replaced would have counted its
+// articles for Food while dropping them from A&E -- a section quietly shorter
+// than the sum of its parts, which is the failure mode nothing on the screen
+// would have shown.
+func TestTaxonomyHTTPThreeLevelNesting(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+	ctx := context.Background()
+
+	create := func(kind, slug, title string, parent any) {
+		t.Helper()
+		recorder := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+			"type":            kind,
+			"slug":            slug,
+			"canonical_title": title,
+			"parent_slug":     parent,
+		})
+		if recorder.Code != http.StatusCreated {
+			t.Fatalf("POST %s = %d: %s", slug, recorder.Code, recorder.Body.String())
+		}
+	}
+
+	create("section", "entertainment", "Arts & Entertainment", nil)
+	create("subsection", "food", "Food", "entertainment")
+	create("subsection", "beer-reviews", "Beer Reviews", "food")
+
+	// A fourth level is refused, and by the depth rule rather than by accident:
+	// the parent exists and is otherwise valid.
+	tooDeep := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+		"type":            "subsection",
+		"slug":            "ipa-reviews",
+		"canonical_title": "IPA Reviews",
+		"parent_slug":     "beer-reviews",
+	})
+	if tooDeep.Code != http.StatusBadRequest {
+		t.Errorf("POST a fourth level = %d, want 400: %s", tooDeep.Code, tooDeep.Body.String())
+	}
+
+	// One article, filed under the grandchild's category only.
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO articles (id, categories, pub_date) VALUES (1, '["Beer Reviews"]', UTC_TIMESTAMP())`,
+	); err != nil {
+		t.Fatalf("insert article: %v", err)
+	}
+	indexArticleCategories(t, conn)
+	if err := db.RebuildTaxonomyArticleCounts(ctx, conn); err != nil {
+		t.Fatalf("rebuild counts: %v", err)
+	}
+
+	items := getTaxonomyItems(t, conn)
+	for _, want := range []struct {
+		slug   string
+		count  int64
+		reason string
+	}{
+		{"beer-reviews", 1, "the article's own category"},
+		{"food", 1, "its child's article rolls up"},
+		{"entertainment", 1, "a grandchild's article still reaches the section"},
+	} {
+		if got := findItem(t, items, want.slug).ArticleCount; got != want.count {
+			t.Errorf("%s count = %d, want %d -- %s", want.slug, got, want.count, want.reason)
+		}
+	}
+
+	// The middle row is a container: its page has to list what is under it, or
+	// /food renders empty while its three categories have articles.
+	params, err := normalizeAndValidateArticleParams(ctx, conn, ArticleParams{Subsection: "food"})
+	if err != nil {
+		t.Fatalf("validate subsection params: %v", err)
+	}
+	if !containsSlug(params.SubsectionMatchSlugs, "beer-reviews") {
+		t.Errorf("match slugs = %v, want the child included", params.SubsectionMatchSlugs)
+	}
+	// And it resolves to the SECTION above it, not to its immediate parent,
+	// since that is what ?section_slug= is checked against.
+	if params.Section != "entertainment" {
+		t.Errorf("section = %q, want entertainment", params.Section)
+	}
+
+	deep, err := normalizeAndValidateArticleParams(ctx, conn, ArticleParams{Subsection: "beer-reviews"})
+	if err != nil {
+		t.Fatalf("validate grandchild params: %v", err)
+	}
+	if deep.Section != "entertainment" {
+		t.Errorf("grandchild section = %q, want entertainment -- the root, not %q", deep.Section, "food")
+	}
+
+	// The strip shows direct children only, at both levels. That is the point
+	// of the nesting: A&E links Food, and Food links the reviews.
+	sectionStrip, err := visibleSubsectionsOf(ctx, conn, "entertainment")
+	if err != nil {
+		t.Fatalf("section strip: %v", err)
+	}
+	if len(sectionStrip) != 1 || sectionStrip[0].Slug != "food" {
+		t.Errorf("section strip = %v, want only Food", sectionStrip)
+	}
+	foodStrip, err := visibleSubsectionsOf(ctx, conn, "food")
+	if err != nil {
+		t.Fatalf("food strip: %v", err)
+	}
+	if len(foodStrip) != 1 || foodStrip[0].Slug != "beer-reviews" {
+		t.Errorf("food strip = %v, want Beer Reviews", foodStrip)
+	}
+
+	// Food holds a child, so deleting it would strand Beer Reviews under a
+	// parent that no longer exists. That guard used to apply to sections only.
+	deleted := taxonomyRequest(t, DeleteTaxonomyItem(conn), http.MethodDelete, "/v1/taxonomy/subsection/food", nil)
+	if deleted.Code != http.StatusBadRequest {
+		t.Errorf("DELETE a subsection with children = %d, want 400: %s", deleted.Code, deleted.Body.String())
+	}
+}
+
+// TestTaxonomyHTTPRejectsCircularParent covers the other way a walk could fail
+// to terminate: making an ancestor into a descendant.
+func TestTaxonomyHTTPRejectsCircularParent(t *testing.T) {
+	conn := taxonomyHTTPTestDB(t)
+
+	for _, item := range []struct {
+		kind, slug, title string
+		parent            any
+	}{
+		{"section", "entertainment", "Arts & Entertainment", nil},
+		{"subsection", "food", "Food", "entertainment"},
+	} {
+		recorder := taxonomyRequest(t, PostTaxonomy(conn), http.MethodPost, "/v1/taxonomy", map[string]any{
+			"type":            item.kind,
+			"slug":            item.slug,
+			"canonical_title": item.title,
+			"parent_slug":     item.parent,
+		})
+		if recorder.Code != http.StatusCreated {
+			t.Fatalf("POST %s = %d: %s", item.slug, recorder.Code, recorder.Body.String())
+		}
+	}
+
+	// Food's parent is a section, so this asks a row to hang under its own
+	// descendant only once entertainment is a subsection -- test the direct
+	// case instead: a row cannot parent itself.
+	itself := taxonomyRequest(t, PutTaxonomyItem(conn), http.MethodPut, "/v1/taxonomy/subsection/food", map[string]any{
+		"slug":            "food",
+		"canonical_title": "Food",
+		"parent_slug":     "food",
+	})
+	if itself.Code != http.StatusBadRequest {
+		t.Errorf("PUT self-parent = %d, want 400: %s", itself.Code, itself.Body.String())
+	}
+}
+
+func containsSlug(slugs []string, want string) bool {
+	for _, slug := range slugs {
+		if slug == want {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/handlers/taxonomy_test.go
+++ b/server/internal/handlers/taxonomy_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestValidateTaxonomyParent_RequiresParentForSubsection(t *testing.T) {
-	if _, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSubsection), nil); err == nil {
+	if _, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSubsection), "politics", nil); err == nil {
 		t.Fatal("expected missing parent_slug to be rejected")
 	}
 }
@@ -16,7 +16,7 @@ func TestValidateTaxonomyParent_RequiresParentForSubsection(t *testing.T) {
 func TestValidateTaxonomyParent_RejectsParentForSection(t *testing.T) {
 	parent := "news"
 
-	if _, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSection), &parent); err == nil {
+	if _, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSection), "opinion", &parent); err == nil {
 		t.Fatal("expected section parent_slug to be rejected")
 	}
 }
@@ -24,7 +24,7 @@ func TestValidateTaxonomyParent_RejectsParentForSection(t *testing.T) {
 func TestValidateTaxonomyParent_NormalizesSubsectionParent(t *testing.T) {
 	parent := "columns"
 
-	got, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSubsection), &parent)
+	got, err := validateTaxonomyParent(context.Background(), nil, string(models.TaxonomyTypeSubsection), "the-green-angle", &parent)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/server/internal/models/api_responses.go
+++ b/server/internal/models/api_responses.go
@@ -91,10 +91,14 @@ type SectionArticlesResponse struct {
 }
 
 type SubsectionArticlesResponse struct {
-	Section    TaxonomySummary   `json:"section"`
-	Subsection TaxonomySummary   `json:"subsection"`
-	Articles   []ArticleListItem `json:"articles"`
-	Pagination Pagination        `json:"pagination"`
+	Section    TaxonomySummary `json:"section"`
+	Subsection TaxonomySummary `json:"subsection"`
+	// Subsections are this subsection's OWN visible children, so a middle row
+	// like Food gets the same link strip a section page has. Empty for a leaf,
+	// which is most of them.
+	Subsections []TaxonomySummary `json:"subsections"`
+	Articles    []ArticleListItem `json:"articles"`
+	Pagination  Pagination        `json:"pagination"`
 }
 
 type SEOResponse struct {


### PR DESCRIPTION
A&E asked for a Food subsection holding Beer Reviews, Wine Reviews, Restaurant Reviews and Cooking. That is a third level the taxonomy did not have: `parent_slug` had to name a section, and the rollup was a single non-recursive hop.

## The shape

Depth is a property of the parent chain, not a new kind. Both levels stay `kind='subsection'`, so everything that switches on kind — the public site's slug router, the article filters, the sections screen — keeps working unchanged. `MaxTaxonomyDepth` caps the chain at three, because the walks are recursive over rows editors can edit.

## What actually mattered

**The rollup is now transitive.** This is the load-bearing change. One hop would have counted Beer Reviews for Food while dropping it from A&E, leaving a section quietly shorter than the sum of its subsections — the same silent-omission failure the alias seeding exists to fix. Recounts walk every ancestor for the same reason, and a subsection resolves to its **root** section rather than its parent, since that is what `?section_slug=` is checked against.

**A subsection can be a container.** `/food` matches its descendants; matching `food` alone would render it empty, as its articles are filed under the four categories beneath it. `/v1/subsections/<slug>/articles` also returns `subsections` now, so a middle row gets the link strip a section page has.

**The guards widened.** Delete and slug-change only asked about sections. Deleting Food would have stranded four rows pointing at a parent that no longer exists.

One behaviour change worth reviewing: converting a section that has children into a subsection used to be refused outright, on the premise that a subsection could not parent one. It is now allowed when the resulting subtree still fits in three levels. The existing test asserting the old rule was updated to assert the depth rule instead.

## Migration

`SeedFoodSubsection` creates Food and moves the four rows, once, under its own flag — `legacy_subsections_seeded` is already set in production. The move is guarded on the current parent, so a row an editor pulls back out stays where they put it.

Cooking is the one visible change to a section page readers use today: unlike the three review categories it is a live, visible subsection, so moving it takes its link out of A&E's strip and puts it in Food's. That is the intent.

## Testing

Tree-walk unit tests including cycle termination, plus DB-backed tests for the three-level rollup, the fourth-level rejection, and the seed's idempotence against an editor's change. Full Go suite green against MariaDB; frontend 19/19.

Needs DrexelTriangle/Scalene#94 for the public side, which links a subsection's own children in the nav strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
