### PR TITLE
Serve a static maintenance page when the frontend is unreachable

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -329,6 +329,7 @@ two files over first (from a workstation, at the repo root):
 ```bash
 scp deploy/nginx/triangle-cms.conf \
     deploy/nginx/triangle-cms-active-upstreams.conf.example \
+    deploy/nginx/down.html \
     <user>@<delta>:/tmp/
 ```
 
@@ -343,6 +344,12 @@ sudo install -o triangle-runner -g triangle-runner -m 0644 \
   /tmp/triangle-cms-active-upstreams.conf.example \
   /etc/nginx/triangle-cms/active-upstreams.conf
 
+# Maintenance page. Root-owned and world-readable: Nginx reads it as the worker
+# user, and nothing at runtime should be able to rewrite what the site falls
+# back to.
+sudo install -d -o root -g root -m 0755 /var/www/triangle-cms-down
+sudo install -o root -g root -m 0644 /tmp/down.html /var/www/triangle-cms-down/down.html
+
 # The stock default site also matches `server_name _` and can win the vhost pick.
 sudo rm -f /etc/nginx/sites-enabled/default
 
@@ -352,6 +359,31 @@ sudo nginx -t && sudo systemctl reload nginx
 Nginx will not start without `active-upstreams.conf`, since the site `include`s
 it unconditionally. A passing `nginx -t` *before* the site is enabled only
 validates the stock config and proves nothing.
+
+### The maintenance page
+
+When Nginx cannot reach the active frontend slot -- connection refused, or a
+read timeout -- `location /` serves `/var/www/triangle-cms-down/down.html` as a
+**503**, via an internal rewrite. Things worth knowing before changing it:
+
+- It is a rewrite, not a redirect. Uptime checks follow redirects, so a 302 to a
+  down page would make every monitor report the site healthy for the whole
+  outage. Better Stack and UptimeRobot both see 503 on the requested URL, which
+  is what you want.
+- The page is `internal;`, so `/_down.html` is not fetchable on its own and
+  cannot be cached or indexed as a 200.
+- It sends `Cache-Control: no-store`. Do not remove this. Cloudflare caching the
+  down page would keep the site dark after the backend recovered.
+- It is entirely self-contained -- no external CSS, fonts, images, or scripts.
+  Anything that could serve those assets is down when this page renders. Keep it
+  that way when editing.
+- It covers `location /` only. `/v1/` is untouched, so API clients keep getting
+  real transport errors rather than an HTML body, and `/healthz` and
+  `/v1/health/db` still report the truth for monitoring.
+- `proxy_intercept_errors` stays off, so error responses the frontend generates
+  deliberately are passed through instead of being replaced by this page.
+
+Re-copy `down.html` whenever it changes; nothing in `deploy.sh` installs it.
 
 The site sets `client_max_body_size 91m` on `/v1/` to sit just above the
 backend's `MEDIA_MAX_UPLOAD_BYTES` (90 MiB default). Nginx's stock limit is 1m,

--- a/deploy/nginx/down.html
+++ b/deploy/nginx/down.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>The Triangle — temporarily unavailable</title>
+<!--
+  Served by Nginx when the frontend upstream is unreachable. It is served from
+  the host filesystem, so it MUST be entirely self-contained: no stylesheet, no
+  font, no image, no script from anywhere else. Every upstream that could serve
+  such an asset is, by definition, down when this page renders.
+
+  Keep it small enough to fit in a single response. Do not add a meta refresh --
+  a page that reloads itself turns one outage into a thundering herd against a
+  backend that is already struggling to come back up.
+-->
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff;
+    --fg: #16161a;
+    --muted: #5c5c66;
+    --rule: #e2e2e8;
+    --accent: #0a3161;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #101014;
+      --fg: #f2f2f5;
+      --muted: #a0a0ad;
+      --rule: #2a2a33;
+      --accent: #7fa8dd;
+    }
+  }
+  html { background: var(--bg); }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1.5rem;
+    background: var(--bg);
+    color: var(--fg);
+    font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+          Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 32rem; }
+  .mark {
+    font: 600 0.75rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  h1 {
+    margin: 1.25rem 0 0;
+    font-size: clamp(1.5rem, 4vw, 2rem);
+    font-weight: 600;
+    letter-spacing: -0.015em;
+  }
+  p { margin: 1rem 0 0; color: var(--muted); }
+  hr { margin: 2rem 0 0; border: 0; border-top: 1px solid var(--rule); }
+  .status { margin-top: 1.25rem; font-size: 0.9375rem; }
+  a { color: var(--accent); text-underline-offset: 2px; }
+  a:hover { text-decoration: none; }
+</style>
+</head>
+<body>
+<main>
+  <div class="mark">The Triangle</div>
+  <h1>We&rsquo;re temporarily unavailable.</h1>
+  <p>
+    The site is down for maintenance or is having trouble reaching its backend.
+    Nothing is lost &mdash; please try again in a few minutes.
+  </p>
+  <hr>
+  <p class="status">
+    Live updates: <a href="https://status.thetriangle.org/">status.thetriangle.org</a>
+  </p>
+</main>
+</body>
+</html>

--- a/deploy/nginx/triangle-cms.conf
+++ b/deploy/nginx/triangle-cms.conf
@@ -90,7 +90,47 @@ server {
     # Never serve dotfiles (keep ACME http-01 working if it is ever added here).
     location ~ /\.(?!well-known) { deny all; }
 
+    # Static maintenance page, served when the frontend upstream cannot be
+    # reached. `internal` means it is reachable ONLY via the error_page rewrite
+    # below -- never as its own URL. That matters: a publicly fetchable
+    # /_down.html is a 200 that Cloudflare will happily cache and that search
+    # engines will index, and it gives uptime checks a URL that reports "up"
+    # while the site is down.
+    location = /_down.html {
+        internal;
+        alias /var/www/triangle-cms-down/down.html;
+
+        # The whole point of this page is that it is transient. Without
+        # no-store, Cloudflare can pin "the site is down" at the edge and keep
+        # serving it after the backend is healthy again -- the same failure mode
+        # that the /wp-content/ 404 caching note above describes, except here it
+        # takes down every page at once.
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        add_header Retry-After 60 always;
+        add_header X-Robots-Tag "noindex" always;
+    }
+
     location / {
         proxy_pass $triangle_cms_frontend;
+
+        # Fires when Nginx itself cannot complete the proxy: connection refused
+        # (no container listening on the active slot's port), or a read timeout.
+        #
+        # `proxy_intercept_errors` is deliberately left OFF. Turning it on would
+        # also swallow error responses the frontend generates on purpose and
+        # replace them with this page, which hides real application behaviour.
+        # "Failure" here means the upstream is unreachable, not that it answered
+        # with something we dislike.
+        #
+        # =503 normalises 502/504 into the one status that actually means "try
+        # again shortly" and pairs with the Retry-After above. The original code
+        # is not lost -- it stays in error.log, which is where you diagnose from
+        # anyway.
+        #
+        # This is an internal rewrite, NOT an HTTP redirect. A 302 to a down
+        # page would be actively harmful: uptime checks follow redirects, land
+        # on a 200, and report the site as healthy through the entire outage.
+        # The client must see 503 on the URL it asked for.
+        error_page 502 503 504 =503 /_down.html;
     }
 }


### PR DESCRIPTION
When Nginx cannot complete the proxy to the active frontend slot — connection refused because no container is listening, or a read timeout — it fell through to the stock Nginx error page. That page says nothing useful, carries no cache directives, and looks like a broken server rather than a site that is coming back.

`location /` now falls back to an internal rewrite to a self-contained maintenance page.

## Three choices that are load-bearing

**It is a rewrite, not a redirect.** Uptime checks follow redirects, so a 302 to a down page would land every monitor on a 200 and report the site healthy for the whole outage. The client sees 503 on the URL it actually asked for.

**The page sends `Cache-Control: no-store`.** Cloudflare pinning it at the edge would keep the site dark after the backend recovered — the same trap as the `/wp-content/` 404 caching this file already documents, except it takes out every page at once instead of one image.

**`proxy_intercept_errors` stays off**, so this only catches an unreachable upstream. Turning it on would also replace error responses the frontend returns on purpose, hiding real application behaviour.

502 and 504 are normalised to 503 to pair with `Retry-After`; the original code is still in `error.log`, which is where it gets diagnosed anyway.

## Verified behaviour

Tested against a dead upstream in a container, not just `nginx -t`:

| Request | Result |
| --- | --- |
| `GET /` (upstream dead) | `503` + maintenance page, `Cache-Control: no-store`, `Retry-After: 60`, `X-Robots-Tag: noindex` |
| `GET /_down.html` | `404` — `internal;`, so it cannot be cached or indexed as a 200 |
| `GET /healthz` | `200` — Nginx liveness unaffected |
| `GET /v1/health/db` | `502`, stock error — API never receives an HTML body |

## Deployment note

Nothing in `deploy.sh` installs the HTML. It is copied during bootstrap next to the site config, as documented in `deploy/README.md`. Worth folding into the deploy script later so it cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)